### PR TITLE
Improvements over first merge

### DIFF
--- a/examples/hand_pose_estimation/backend_keypoints.py
+++ b/examples/hand_pose_estimation/backend_keypoints.py
@@ -532,7 +532,6 @@ def crop_image_from_coordinates(image, crop_center, crop_size, scale=1.0):
         Image_cropped: Numpy array of shape (crop_size, crop-size).
     """
     image = np.squeeze(image, 0)
-    print(image.shape)
     height, width, channels = image.shape
     scale = np.reshape(scale, [-1])
     crop_location = crop_center.astype(np.float)
@@ -855,7 +854,7 @@ def apply_child_transformations(keypoints3D, bone_index, parent_index,
     rotation_angle_x, rotation_angle_y = transformation_parameters[1:3]
     rotated_keypoints = transformation_parameters[3]
     transformation_parameters = np.stack([length_from_origin, rotation_angle_x,
-                                rotation_angle_y])
+                                          rotation_angle_y])
     return rotated_keypoints, transformation_parameters
 
 
@@ -1101,10 +1100,12 @@ def transform_cropped_keypoints(cropped_keypoints, centers, scale, crop_size):
     # Returns
         keypoints: Tensor (batch x num_keypoints x 3): Transformed coordinates.
     """
+    cropped_keypoints[:, [0, 1]] = cropped_keypoints[:, [1, 0]]
     keypoints = np.copy(cropped_keypoints)
     keypoints = keypoints - (crop_size // 2)
     keypoints = keypoints / scale
     keypoints = keypoints + centers
+    keypoints[:, [0, 1]] = keypoints[:, [1, 0]]
     return keypoints
 
 

--- a/examples/hand_pose_estimation/backend_keypoints.py
+++ b/examples/hand_pose_estimation/backend_keypoints.py
@@ -474,6 +474,8 @@ def get_bounding_box_features(X, Y, binary_class_mask):
     bounding_box = get_bounding_box(X_masked, Y_masked)
     center = get_crop_center(bounding_box)
     crop_size = get_crop_size(bounding_box)
+    bounding_box = [bounding_box[1],bounding_box[0],bounding_box[3],
+                    bounding_box[2]]
     return bounding_box, center, crop_size
 
 

--- a/examples/hand_pose_estimation/pipelines.py
+++ b/examples/hand_pose_estimation/pipelines.py
@@ -271,7 +271,7 @@ class DetectHandKeypoints(Processor):
         self.draw_keypoint = pr.DrawKeypoints2D(num_keypoints, normalized=True,
                                                 radius=4)
         self.denormalize = pr.DenormalizeImage()
-        self.wrap = pr.WrapOutput(['image', 'keypoints2D'])
+        self.wrap = pr.WrapOutput(['image', 'keypoints2D', 'keypoints3D'])
         self.expand_dims = pr.ExpandDims(axis=0)
 
     def call(self, image, hand_side=np.array([[1.0, 0.0]])):
@@ -291,10 +291,10 @@ class DetectHandKeypoints(Processor):
         viewpoints = self.predict_keypoints_angles(score_maps)
         canonical_keypoints = self.merge_dictionaries([rotation_parameters,
                                                        viewpoints])
-        relative_keypoints = self.postprocess_keypoints(canonical_keypoints)
-        tranformed_keypoints_2D = self.transform_keypoints(
-            keypoints_2D, center, crop_size_best, 256)
-        image = self.draw_keypoint(np.squeeze(image), tranformed_keypoints_2D)
+        keypoints3D = self.postprocess_keypoints(canonical_keypoints)
+        keypoints2D = self.transform_keypoints(keypoints_2D, center,
+                                               crop_size_best, 256)
+        image = self.draw_keypoint(np.squeeze(image), keypoints2D)
         image = self.denormalize(image)
-        output = self.wrap(image.astype('uint8'), keypoints_2D)
+        output = self.wrap(image.astype('uint8'), keypoints2D, keypoints3D)
         return output

--- a/examples/hand_pose_estimation/pipelines.py
+++ b/examples/hand_pose_estimation/pipelines.py
@@ -273,7 +273,7 @@ class DetectHandKeypoints(Processor):
         self.denormalize = pr.DenormalizeImage()
         self.wrap = pr.WrapOutput(['image', 'keypoints2D', 'keypoints3D'])
         self.expand_dims = pr.ExpandDims(axis=0)
-        self.draw_boxes = pr.DrawBoxes2D(class_names=['hand'])
+        self.draw_boxes = pr.DrawBoxes2D(['hand'], [[0, 1, 0]])
 
     def call(self, input_image, hand_side=np.array([[1.0, 0.0]])):
         image = self.preprocess_image(input_image)
@@ -282,7 +282,7 @@ class DetectHandKeypoints(Processor):
             output = self.wrap(input_image.astype('uint8'), None, None)
             return output
         hand_crop, segmentation_map, center, box, crop_size_best = hand_features
-        box = Box2D(box, score=100, class_name='hand')
+        box = Box2D(box, score=1.0, class_name='hand')
         image = self.draw_boxes(np.squeeze(image), [box])
         hand_crop = self.expand_dims(hand_crop)
         score_maps = self.predict_keypoints2D(hand_crop)

--- a/examples/hand_pose_estimation/test_pipeline.py
+++ b/examples/hand_pose_estimation/test_pipeline.py
@@ -12,8 +12,8 @@ HandViewPointNet = ViewPointNet()
 pipeline = DetectHandKeypoints(HandSegNet, HandPoseNet, HandPosePriorNet,
                                HandViewPointNet)
 
-img = load_image('./sample.jpg')
-detection = pipeline(img)
+image = load_image('./sample.jpg')
+detection = pipeline(image)
 
 show_image(detection['image'].astype('uint8'))
 write_image('./detection.jpg', detection['image'].astype('uint8'))


### PR DESCRIPTION

- Changes made to:
1. check if a hand is present in the image or not.
    This check can be used to correct the error occurred when hand is not present. When hand is not present no inference is 
    performed but the input image is showed.

2. Plot keypoints on the original image instead of cropped image.
    The previous commit plotted keypoints on the cropped image. The changes done performs inverse translation of keypoints  
    and plot them on the original image. 