### PR TITLE
Extend setup.py (e.g., by long description)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,17 @@ from setuptools import setup
 from setuptools import find_packages
 import paz
 
-setup(name='pypaz',
-      version=paz.__version__,
-      description='Perception for Autonomous Systems',
-      author='Octavio Arriaga',
-      author_email='octavio.arriaga@dfki.de',
-      license='MIT',
-      install_requires=['opencv-python', 'tensorflow', 'numpy'],
-      packages=find_packages())
+
+if __name__ == "__main__":
+    with open("README.md", "r") as f:
+        long_description = f.read()
+    setup(name='pypaz',
+          version=paz.__version__,
+          description='Perception for Autonomous Systems',
+          long_description=long_description,
+          author='Octavio Arriaga',
+          author_email='octavio.arriaga@dfki.de',
+          url='https://github.com/oarriaga/paz/',
+          license='MIT',
+          install_requires=['opencv-python', 'tensorflow', 'numpy'],
+          packages=find_packages())


### PR DESCRIPTION
The PyPI package description is empty at the moment: https://pypi.org/project/pypaz/

Adding these additional information should improve it:

* long description
* URL to GitHub