### PR TITLE
Port DINOv3 Foundation Model to Keras 3

### DIFF
--- a/paz/models/foundation/dinov3/dinov3_test.py
+++ b/paz/models/foundation/dinov3/dinov3_test.py
@@ -1,0 +1,295 @@
+import os
+import sys
+import logging
+import torch
+import numpy as np
+import pytest
+
+# --- Configuration for Keras Backend and Environment ---
+
+os.environ["KERAS_BACKEND"] = "jax"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", ".."))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import torch
+import keras
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.models.vision_transformer import (
+    vit_small,
+    vit_base,
+    vit_large,
+)
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.models.torch_vision_transformer_for_testing import (
+    PT_vit_small,
+    PT_vit_base,
+    PT_vit_large,
+)
+
+# ==============================================================================
+# Global Configuration
+# ==============================================================================
+
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+PT_MODELS_WEIGHTS_DIR_PATH = (
+    r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3/"
+)
+KERAS_MODELS_WEIGHTS_DIR_PATH = (
+    r"weights_dinov3"
+)
+
+PT_MODEL_WEIGHTS_PATHS = {
+    "dinov3_vits16": r"dinov3_vits16_pretrain_lvd1689m-08c60483.pth",
+    "dinov3_vitb16": r"dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth",
+    "dinov3_vitl16": r"dinov3_vitl16_pretrain_lvd1689m-8aa4cbdd.pth",
+}
+KERAS_MODEL_WEIGHTS_PATHS = {
+    "dinov3_vits16": r"dinov3_vits16_ported.keras",
+    "dinov3_vitb16": r"dinov3_vitb16_ported.keras",
+    "dinov3_vitl16": r"dinov3_vitl16_ported.keras",
+}
+
+model_kwargs = {
+    "img_size": 224,
+    "patch_size": 16,
+    "ffn_layer": "mlp",
+    "untie_cls_and_patch_norms": False,
+    "norm_layer": "layernorm",
+    "layerscale_init": 1e-6,
+    "n_storage_tokens": 4,
+    "pos_embed_rope_dtype": "float32",
+}
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+MODEL_CONFIGS = [
+    # (PyTorch Constructor, Keras Constructor, Weight Key)
+    (PT_vit_small, vit_small, "dinov3_vits16"),
+    (PT_vit_base, vit_base, "dinov3_vitb16"),
+    (PT_vit_large, vit_large, "dinov3_vitl16"),
+]
+
+
+def get_PT_model(pt_constructor, pt_weight_path_key, model_kwargs):
+    """Instantiates a PyTorch model and loads its pre-trained weights."""
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    pt_weight_path = os.path.join(
+        PT_MODELS_WEIGHTS_DIR_PATH, PT_MODEL_WEIGHTS_PATHS[pt_weight_path_key]
+    )
+    if not os.path.isfile(pt_weight_path):
+        pytest.skip(f"PyTorch weight file not found: {pt_weight_path}")
+
+    pt_model = pt_constructor(**model_kwargs)
+    state_dict = torch.load(pt_weight_path, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+    pt_model.eval()
+    print(f"PyTorch model '{pt_weight_path_key}' loaded from {pt_weight_path}")
+    return pt_model
+
+
+def get_keras_model(keras_constructor, keras_weight_path_key, model_kwargs):
+    """Instantiates a Keras model, builds it, and loads its ported weights."""
+    keras_weight_path = os.path.join(
+        KERAS_MODELS_WEIGHTS_DIR_PATH,
+        KERAS_MODEL_WEIGHTS_PATHS[keras_weight_path_key],
+    )
+    if not os.path.isfile(keras_weight_path):
+        pytest.skip(f"Keras weight file not found: {keras_weight_path}")
+
+    keras_model = keras_constructor(**model_kwargs)
+
+    # Build the model by passing a dummy input
+    dummy_input = np.random.randn(
+        1, model_kwargs["img_size"], model_kwargs["img_size"], 3
+    ).astype("float32")
+    keras_model(dummy_input, training=False)
+
+    # Load the pre-ported weights
+    keras_model.load_weights(keras_weight_path)
+    print(f"Keras model '{keras_weight_path_key}' loaded from {keras_weight_path}")
+    return keras_model
+
+
+# ==============================================================================
+# Test Suite for Final Output
+# ==============================================================================
+
+@pytest.mark.parametrize("pt_constructor, keras_constructor, weight_key", MODEL_CONFIGS)
+def test_final_output_equivalence(pt_constructor, keras_constructor, weight_key):
+    print(f"\n--- Testing Final Output Equivalence: {weight_key} ---")
+    pt_model = get_PT_model(pt_constructor, weight_key, model_kwargs)
+    keras_model = get_keras_model(keras_constructor, weight_key, model_kwargs)
+
+    # --- Create Identical Inputs ---
+    np.random.seed(42)  # Use a fixed seed for reproducibility
+    dummy_input_np = np.random.randn(1, 224, 224, 3).astype("float32")
+    keras_input = keras.ops.convert_to_tensor(dummy_input_np)
+    pt_input = torch.from_numpy(dummy_input_np.transpose(0, 3, 1, 2))
+    print("Generated identical inputs.")
+
+    # --- Get Model Outputs ---
+    print("Performing inference...")
+    keras_output = keras_model(keras_input, training=False)
+    with torch.no_grad():
+        pt_output = pt_model(pt_input, is_training=False)
+
+    # --- Compare Outputs ---
+    print("Comparing outputs...")
+    keras_output_np = keras.ops.convert_to_numpy(keras_output)
+    pt_output_np = pt_output.detach().cpu().numpy()
+
+    try:
+        np.testing.assert_allclose(
+            keras_output_np,
+            pt_output_np,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="Final model outputs do not match after loading weights",
+        )
+    except AssertionError as e:
+        print("\n❌ Outputs do not match!")
+        print(
+            f"Max absolute difference: {np.max(np.abs(keras_output_np - pt_output_np))}"
+        )
+        print(
+            f"Mean absolute difference: {np.mean(np.abs(keras_output_np - pt_output_np))}"
+        )
+        raise e
+    print(f"✅ Success! Final outputs for {weight_key} match.")
+
+
+# ==============================================================================
+# Test Suite for Deep-Dive Block Equivalence
+# ==============================================================================
+
+
+@pytest.mark.parametrize("pt_constructor, keras_constructor, weight_key", MODEL_CONFIGS)
+def test_deep_dive_block_equivalence(pt_constructor, keras_constructor, weight_key):
+    print(f"\n--- Testing Deep-Dive Block Equivalence: {weight_key} ---")
+    pt_model = get_PT_model(pt_constructor, weight_key, model_kwargs)
+    keras_model = get_keras_model(keras_constructor, weight_key, model_kwargs)
+
+    any_failure = False
+
+    def _compare_and_correct(keras_tensor, torch_tensor, layer_name, block_idx):
+        nonlocal any_failure
+        torch_np = torch_tensor.detach().cpu().numpy()
+        keras_np = keras.ops.convert_to_numpy(keras_tensor)
+        try:
+            mean_diff = np.mean(np.abs(keras_np - torch_np))
+            print(
+                f"    Comparing Block {block_idx} - {layer_name}: Mean abs diff = {mean_diff}"
+            )
+            if np.isnan(keras_np).any():
+                raise AssertionError("Keras output contains NaN values.")
+            if mean_diff > 1e-4:
+                raise AssertionError(
+                    f"Mean absolute difference {mean_diff} exceeds tolerance of 1e-4."
+                )
+            print(f"    ✅ Block {block_idx} - {layer_name}: Output matches.")
+            return keras_tensor
+        except AssertionError as e:
+            print(
+                f"    ❌ FAILURE at Block {block_idx} - {layer_name}: Output mismatch."
+            )
+            print(f"       {e}")
+            any_failure = True
+            print(f"       Correcting Keras tensor to continue analysis...")
+            return keras.ops.convert_to_tensor(torch_np)
+
+    for i in range(len(keras_model.blocks)):
+        print(f"\n--- Analyzing Block {i} ---")
+
+        # 1. Create a new, unique input for this block to isolate errors
+        np.random.seed(i)
+        image_np = np.random.randn(
+            1, model_kwargs["img_size"], model_kwargs["img_size"], 3
+        ).astype("float32")
+        keras_input = keras.ops.convert_to_tensor(image_np)
+        pt_input = torch.from_numpy(image_np.transpose(0, 3, 1, 2))
+
+        # 2. Get initial tokens
+        keras_tokens, (H_k, W_k) = keras_model.prepare_tokens_with_masks(keras_input)
+        pt_tokens, (H_pt, W_pt) = pt_model.prepare_tokens_with_masks(pt_input)
+
+        # 3. Get RoPE embeddings
+        rope_keras = keras_model.rope_embed(H=H_k, W=W_k, training=False)
+        rope_torch = pt_model.rope_embed(H=H_pt, W=W_pt)
+
+        # 4. Get the corresponding block from each model
+        keras_block = keras_model.blocks[i]
+        pt_block = pt_model.blocks[i]
+
+        # --- Deep Dive into the Block ---
+        keras_norm1_out = keras_block.norm1(keras_tokens)
+        pt_norm1_out = pt_block.norm1(pt_tokens)
+        keras_norm1_out = _compare_and_correct(
+            keras_norm1_out, pt_norm1_out, "Norm1", i
+        )
+
+        keras_attn_out = keras_block.attn(
+            keras_norm1_out, rope=rope_keras, training=False
+        )
+        pt_attn_out = pt_block.attn(pt_norm1_out, rope=rope_torch)
+        keras_attn_out = _compare_and_correct(
+            keras_attn_out, pt_attn_out, "Attention", i
+        )
+
+        keras_ls1_out = keras_block.ls1(keras_attn_out, training=False)
+        pt_ls1_out = pt_block.ls1(pt_attn_out)
+        keras_ls1_out = _compare_and_correct(
+            keras_ls1_out, pt_ls1_out, "LayerScale1", i
+        )
+
+        keras_res1_out = keras_tokens + keras_ls1_out
+        pt_res1_out = pt_tokens + pt_ls1_out
+        keras_res1_out = _compare_and_correct(
+            keras_res1_out, pt_res1_out, "Residual1", i
+        )
+
+        keras_norm2_out = keras_block.norm2(keras_res1_out)
+        pt_norm2_out = pt_block.norm2(pt_res1_out)
+        keras_norm2_out = _compare_and_correct(
+            keras_norm2_out, pt_norm2_out, "Norm2", i
+        )
+
+        keras_mlp_out = keras_block.mlp(keras_norm2_out, training=False)
+        pt_mlp_out = pt_block.mlp(pt_norm2_out)
+        keras_mlp_out = _compare_and_correct(keras_mlp_out, pt_mlp_out, "MLP", i)
+
+        keras_ls2_out = keras_block.ls2(keras_mlp_out, training=False)
+        pt_ls2_out = pt_block.ls2(pt_mlp_out)
+        keras_ls2_out = _compare_and_correct(
+            keras_ls2_out, pt_ls2_out, "LayerScale2", i
+        )
+
+        keras_final_out = keras_res1_out + keras_ls2_out
+        pt_final_out = pt_res1_out + pt_ls2_out
+        _compare_and_correct(keras_final_out, pt_final_out, "Final Block Output", i)
+
+    print(f"\n--- Deep-Dive Analysis for {weight_key} Complete ---")
+    assert (
+        not any_failure
+    ), f"One or more internal layers for {weight_key} had an output mismatch. See logs for details."
+
+
+# ==============================================================================
+# Run Tests
+# ==============================================================================
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/__init__.py
+++ b/paz/models/foundation/dinov3/layers/__init__.py
@@ -1,0 +1,14 @@
+from paz.models.foundation.dinov3.layers.attention import (
+    CausalSelfAttention,
+    SelfAttention,
+)
+from paz.models.foundation.dinov3.layers.layer_scale import LayerScale
+from paz.models.foundation.dinov3.layers.patch_embed import PatchEmbed
+from paz.models.foundation.dinov3.layers.rope_position_encoding import (
+    RopePositionEmbedding,
+)
+
+from .ffn_layers import Mlp, SwiGLUFFN, ListForwardMixin
+
+from .block import CausalSelfAttentionBlock, SelfAttentionBlock
+from .rms_norm import RMSNorm

--- a/paz/models/foundation/dinov3/layers/attention.py
+++ b/paz/models/foundation/dinov3/layers/attention.py
@@ -1,0 +1,173 @@
+import keras
+from keras import ops
+from keras.layers import Dense, Dropout
+from paz.models.foundation.dinov3.utils.utils import cat_keep_shapes, uncat_with_shapes
+
+
+def rope_rotate_half(x):
+    """Rotates half the hidden dimensions."""
+    x1, x2 = keras.ops.split(x, 2, axis=-1)
+    return keras.ops.concatenate([-x2, x1], axis=-1)
+
+
+def rope_apply(x, sin, cos):
+    """Applies rotary position embedding."""
+    return (x * cos) + (rope_rotate_half(x) * sin)
+
+
+class SelfAttention(keras.Layer):
+    """Keras implementation of DINOv3's SelfAttention layer."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.dim = dim
+        self.num_heads = num_heads
+        self.attn_drop = attn_drop
+        if self.dim % self.num_heads != 0:
+            raise ValueError(
+                f"dim ({dim}) must be divisible by num_heads ({num_heads})."
+            )
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = Dense(dim * 3, use_bias=qkv_bias, name="qkv")
+        self.attn_drop_layer = Dropout(attn_drop)
+        self.proj = Dense(dim, use_bias=proj_bias, name="proj")
+        self.proj_drop_layer = Dropout(proj_drop)
+
+    def apply_rope(self, q, k, rope):
+        sin, cos = rope
+
+        prefix = ops.shape(q)[-2] - ops.shape(sin)[-2]
+        if prefix < 0:
+            raise ValueError("Input sequence is shorter than the RoPE sequence.")
+
+        q_prefix, q_main = q[:, :, :prefix, :], q[:, :, prefix:, :]
+        k_prefix, k_main = k[:, :, :prefix, :], k[:, :, prefix:, :]
+
+        q_rotated = rope_apply(q_main, sin, cos)
+        k_rotated = rope_apply(k_main, sin, cos)
+
+        q = ops.concatenate((q_prefix, q_rotated), axis=-2)
+        k = ops.concatenate((k_prefix, k_rotated), axis=-2)
+
+        return q, k
+
+    def compute_attention(self, qkv, rope=None, training=None):
+        B, N, _ = ops.shape(qkv)
+        qkv_r = ops.reshape(qkv, (B, N, 3, self.num_heads, self.head_dim))
+        q, k, v = ops.unstack(qkv_r, axis=2)
+        q = ops.transpose(q, axes=[0, 2, 1, 3])
+        k = ops.transpose(k, axes=[0, 2, 1, 3])
+        v = ops.transpose(v, axes=[0, 2, 1, 3])
+
+        if rope is not None:
+            q, k = self.apply_rope(q, k, rope)
+
+        attn = ops.matmul(q, ops.transpose(k, axes=[0, 1, 3, 2]))
+        attn = attn * self.scale
+        attn = ops.softmax(attn, axis=-1)
+        attn = self.attn_drop_layer(attn, training=training)
+
+        x = ops.matmul(attn, v)
+        x = ops.transpose(x, axes=[0, 2, 1, 3])
+
+        return ops.reshape(x, (B, N, self.dim))
+
+    def forward_tensor(self, x, rope=None, training=None):
+        """Processes a single tensor input."""
+        qkv = self.qkv(x)
+        attn_v = self.compute_attention(qkv=qkv, rope=rope, training=training)
+        x = self.proj(attn_v)
+        return self.proj_drop_layer(x, training=training)
+
+    def forward_list(self, x_list, rope_list=None, training=None):
+        """Processes a list of tensors."""
+        x_flat, shapes, num_tokens = cat_keep_shapes(x_list)
+        qkv_flat = self.qkv(x_flat)
+        qkv_list = uncat_with_shapes(qkv_flat, shapes, num_tokens)
+
+        if rope_list is None:
+            rope_list = [None] * len(qkv_list)
+
+        att_out = [
+            self.compute_attention(qkv, rope=rope, training=training)
+            for qkv, rope in zip(qkv_list, rope_list)
+        ]
+
+        x_flat_out, shapes_out, num_tokens_out = cat_keep_shapes(att_out)
+        x_flat_out = self.proj(x_flat_out)
+        x_flat_out = self.proj_drop_layer(x_flat_out, training=training)
+
+        return uncat_with_shapes(x_flat_out, shapes_out, num_tokens_out)
+
+    def call(self, x, rope=None, training=None):
+        """Handles both a single tensor and a list of tensors."""
+        if isinstance(x, list):
+            return self.forward_list(x, rope_list=rope, training=training)
+        else:
+            return self.forward_tensor(x, rope=rope, training=training)
+
+
+class CausalSelfAttention(keras.Layer):
+    """Keras implementation of DINOv3's CausalSelfAttention layer."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.dim = dim
+        self.num_heads = num_heads
+        self.attn_drop = attn_drop
+        if dim % num_heads != 0:
+            raise ValueError(
+                f"dim ({dim}) must be divisible by num_heads ({num_heads})."
+            )
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = Dense(dim * 3, use_bias=qkv_bias, name="qkv")
+        self.attn_drop_layer = Dropout(attn_drop)
+        self.proj = Dense(dim, use_bias=proj_bias, name="proj")
+        self.proj_drop_layer = Dropout(proj_drop)
+
+    def call(self, x, is_causal=True, training=None):
+        B, N, C = ops.shape(x)
+        qkv = self.qkv(x)
+        qkv_r = ops.reshape(qkv, (B, N, 3, self.num_heads, self.head_dim))
+        q, k, v = ops.unstack(qkv_r, axis=2)
+        q = ops.transpose(q, axes=[0, 2, 1, 3])
+        k = ops.transpose(k, axes=[0, 2, 1, 3])
+        v = ops.transpose(v, axes=[0, 2, 1, 3])
+
+        attn = ops.matmul(q, ops.transpose(k, axes=[0, 1, 3, 2]))
+        attn = attn * self.scale
+
+        if is_causal:
+            seq_len = ops.shape(q)[2]
+            mask = ops.triu(ops.ones((seq_len, seq_len)), k=1)
+            attn += mask * -1e9
+
+        attn = ops.softmax(attn, axis=-1)
+
+        attn = self.attn_drop_layer(attn, training=training)
+        x = ops.matmul(attn, v)
+
+        x = ops.transpose(x, axes=[0, 2, 1, 3])
+        x = ops.reshape(x, (B, N, C))
+        x = self.proj(x)
+        return self.proj_drop_layer(x, training=training)

--- a/paz/models/foundation/dinov3/layers/attention_test.py
+++ b/paz/models/foundation/dinov3/layers/attention_test.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 import torch
 import numpy as np
-from typing import Tuple
 
 os.environ["KERAS_BACKEND"] = "jax"
 script_path = os.path.abspath(__file__)
@@ -13,13 +12,6 @@ os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
-
-
-from torch import nn, Tensor
-from typing import List
-import torch.nn.functional as F
-import math
-
 
 # ==============================================================================
 # Keras Layer Implementation

--- a/paz/models/foundation/dinov3/layers/attention_test.py
+++ b/paz/models/foundation/dinov3/layers/attention_test.py
@@ -1,0 +1,335 @@
+import os
+import sys
+import pytest
+import torch
+import numpy as np
+from typing import Tuple
+
+os.environ["KERAS_BACKEND"] = "jax"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+from torch import nn, Tensor
+from typing import List
+import torch.nn.functional as F
+import math
+
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.attention import (
+    SelfAttention,
+    CausalSelfAttention,
+)
+
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import (
+    PT_SelfAttention,
+    PT_CausalSelfAttention,
+)
+
+# ==============================================================================
+# Utility Functions
+# ==============================================================================
+
+
+def port_weights(torch_model, keras_model):
+    """Copies weights from a PyTorch model to its Keras equivalent."""
+    keras_model.qkv.kernel.assign(torch_model.qkv.weight.T.detach().numpy())
+    if torch_model.qkv.bias is not None:
+        keras_model.qkv.bias.assign(torch_model.qkv.bias.detach().numpy())
+
+    keras_model.proj.kernel.assign(torch_model.proj.weight.T.detach().numpy())
+    if torch_model.proj.bias is not None:
+        keras_model.proj.bias.assign(torch_model.proj.bias.detach().numpy())
+
+
+# ==============================================================================
+# PyTest Fixtures and Test Cases
+# ==============================================================================
+
+
+@pytest.fixture(scope="module")
+def params():
+    """Provides common parameters for the tests."""
+    torch.manual_seed(0)
+    np.random.seed(0)
+    return {"DIM": 128, "NUM_HEADS": 4, "BATCH": 2, "SEQ_LEN": 64}
+
+
+@pytest.fixture(scope="module")
+def inputs(params):
+    """Provides random input tensors for Torch and Keras."""
+    p = params
+    x_torch = torch.rand(p["BATCH"], p["SEQ_LEN"], p["DIM"])
+    rope_torch = (
+        torch.rand(1, p["NUM_HEADS"], p["SEQ_LEN"], p["DIM"] // p["NUM_HEADS"]),
+        torch.rand(1, p["NUM_HEADS"], p["SEQ_LEN"], p["DIM"] // p["NUM_HEADS"]),
+    )
+    x_keras = x_torch.numpy()
+    rope_keras = (rope_torch[0].numpy(), rope_torch[1].numpy())
+    return x_torch, x_keras, rope_torch, rope_keras
+
+
+@pytest.fixture(scope="module")
+def self_attention_models(params):
+    """Provides initialized and weight-ported SelfAttention models."""
+    p = params
+    torch_attn = PT_SelfAttention(
+        p["DIM"], p["NUM_HEADS"], qkv_bias=True, proj_bias=True
+    )
+    keras_attn = SelfAttention(p["DIM"], p["NUM_HEADS"], qkv_bias=True, proj_bias=True)
+    torch_attn.eval()
+
+    # Build layer and port weights
+    _ = keras_attn(np.zeros((p["BATCH"], p["SEQ_LEN"], p["DIM"]), dtype="float32"))
+    port_weights(torch_attn, keras_attn)
+    return torch_attn, keras_attn
+
+
+@pytest.fixture(scope="module")
+def causal_self_attention_models(params):
+    """Provides initialized and weight-ported CausalSelfAttention models."""
+    p = params
+    torch_causal_attn = PT_CausalSelfAttention(
+        p["DIM"], p["NUM_HEADS"], qkv_bias=True, proj_bias=True
+    )
+    keras_causal_attn = CausalSelfAttention(
+        p["DIM"], p["NUM_HEADS"], qkv_bias=True, proj_bias=True
+    )
+    torch_causal_attn.eval()
+
+    # Build layer and port weights
+    _ = keras_causal_attn(
+        np.zeros((p["BATCH"], p["SEQ_LEN"], p["DIM"]), dtype="float32")
+    )
+    port_weights(torch_causal_attn, keras_causal_attn)
+    return torch_causal_attn, keras_causal_attn
+
+
+# --- Test Cases ---
+def test_self_attention_call(self_attention_models, inputs):
+    """Tests the `call` method of SelfAttention with RoPE."""
+    torch_attn, keras_attn = self_attention_models
+    x_torch, x_keras, rope_torch, rope_keras = inputs
+
+    torch_out = torch_attn(x_torch, rope=rope_torch).detach().numpy()
+    keras_out = np.array(keras_attn(x_keras, rope=rope_keras, training=False))
+
+    np.testing.assert_allclose(
+        torch_out, keras_out, atol=1e-5, err_msg="`call` method outputs differ."
+    )
+
+
+def test_self_attention_forward_list(self_attention_models, inputs):
+    """Tests the `forward_list` method of SelfAttention."""
+    torch_attn, keras_attn = self_attention_models
+    x_torch, x_keras, rope_torch, rope_keras = inputs
+
+    torch_out_list = torch_attn.forward_list(
+        x_list=[x_torch, x_torch], rope_list=[rope_torch, rope_torch]
+    )
+    keras_out_list = keras_attn.forward_list(
+        [x_keras, x_keras], rope_list=[rope_keras, rope_keras], training=False
+    )
+
+    np.testing.assert_allclose(
+        torch_out_list[0].detach().numpy(),
+        np.array(keras_out_list[0]),
+        atol=1e-5,
+        err_msg="`forward_list` method outputs differ.",
+    )
+
+
+def test_causal_self_attention_call(causal_self_attention_models, inputs):
+    """Tests the `call` method of CausalSelfAttention."""
+    torch_causal_attn, keras_causal_attn = causal_self_attention_models
+    x_torch, x_keras, _, _ = inputs
+
+    torch_out = torch_causal_attn(x_torch).detach().numpy()
+    keras_out = np.array(keras_causal_attn(x_keras, training=False))
+
+    np.testing.assert_allclose(
+        torch_out, keras_out, atol=1e-5, err_msg="Causal `call` method outputs differ."
+    )
+
+
+def test_self_attention_without_rope(self_attention_models, inputs):
+    """Tests the SelfAttention layer without applying RoPE."""
+    torch_attn, keras_attn = self_attention_models
+    x_torch, x_keras, _, _ = inputs
+
+    torch_out = torch_attn(x_torch, rope=None).detach().numpy()
+    keras_out = np.array(keras_attn(x_keras, rope=None, training=False))
+
+    np.testing.assert_allclose(
+        torch_out, keras_out, atol=1e-5, err_msg="`call` method without RoPE failed."
+    )
+
+
+def test_causal_attention_as_standard_attention(causal_self_attention_models, inputs):
+    """Tests CausalSelfAttention with `is_causal=False` to ensure it matches standard attention."""
+    torch_causal_attn, keras_causal_attn = causal_self_attention_models
+    x_torch, x_keras, _, _ = inputs
+
+    torch_out = torch_causal_attn(x_torch, is_causal=False).detach().numpy()
+    keras_out = np.array(keras_causal_attn(x_keras, is_causal=False, training=False))
+
+    np.testing.assert_allclose(
+        torch_out,
+        keras_out,
+        atol=1e-5,
+        err_msg="Causal layer with `is_causal=False` failed.",
+    )
+
+
+def test_dropout_activation(params, inputs):
+    """Tests that dropout layers are active during training and inactive during evaluation."""
+    p = params
+    _, x_keras, _, _ = inputs
+    keras_attn_dropout = SelfAttention(
+        p["DIM"], p["NUM_HEADS"], attn_drop=0.5, proj_drop=0.5
+    )
+    _ = keras_attn_dropout(x_keras)
+
+    out_train = keras_attn_dropout(x_keras, training=True)
+    out_eval = keras_attn_dropout(x_keras, training=False)
+
+    assert not np.allclose(
+        out_train, out_eval
+    ), "Dropout layers seem inactive during training."
+
+
+def test_forward_list_varied_shapes(self_attention_models, params, inputs):
+    """Tests `forward_list` with a list of tensors having different sequence lengths."""
+    torch_attn, keras_attn = self_attention_models
+    p = params
+    x_torch, x_keras, rope_torch, rope_keras = inputs
+
+    x_torch_short = torch.rand(p["BATCH"], p["SEQ_LEN"] // 2, p["DIM"])
+    x_keras_short = x_torch_short.numpy()
+    rope_torch_short = (
+        torch.rand(1, p["NUM_HEADS"], p["SEQ_LEN"] // 2, p["DIM"] // p["NUM_HEADS"]),
+        torch.rand(1, p["NUM_HEADS"], p["SEQ_LEN"] // 2, p["DIM"] // p["NUM_HEADS"]),
+    )
+    rope_keras_short = (rope_torch_short[0].numpy(), rope_torch_short[1].numpy())
+
+    torch_list_varied = torch_attn.forward_list(
+        x_list=[x_torch, x_torch_short], rope_list=[rope_torch, rope_torch_short]
+    )
+    keras_list_varied = keras_attn.forward_list(
+        [x_keras, x_keras_short],
+        rope_list=[rope_keras, rope_keras_short],
+        training=False,
+    )
+
+    np.testing.assert_allclose(
+        torch_list_varied[0].detach().numpy(), keras_list_varied[0], atol=1e-5
+    )
+    np.testing.assert_allclose(
+        torch_list_varied[1].detach().numpy(), keras_list_varied[1], atol=1e-5
+    )
+
+
+def test_initialization_no_biases(params, inputs):
+    """Tests model initialization and execution with biases set to False."""
+    p = params
+    x_torch, x_keras, rope_torch, rope_keras = inputs
+    torch_attn_no_bias = PT_SelfAttention(
+        p["DIM"], p["NUM_HEADS"], qkv_bias=False, proj_bias=False
+    )
+    keras_attn_no_bias = SelfAttention(
+        p["DIM"], p["NUM_HEADS"], qkv_bias=False, proj_bias=False
+    )
+    torch_attn_no_bias.eval()
+
+    _ = keras_attn_no_bias(x_keras)
+    port_weights(torch_attn_no_bias, keras_attn_no_bias)
+
+    torch_out = torch_attn_no_bias(x_torch, rope=rope_torch).detach().numpy()
+    keras_out = np.array(keras_attn_no_bias(x_keras, rope=rope_keras, training=False))
+
+    np.testing.assert_allclose(
+        torch_out, keras_out, atol=1e-5, err_msg="Model with no biases failed."
+    )
+
+
+def test_value_error_on_invalid_heads(params):
+    """Tests that a ValueError is raised if `dim` is not divisible by `num_heads`."""
+    with pytest.raises(ValueError, match="must be divisible by"):
+        SelfAttention(dim=params["DIM"], num_heads=7)
+
+
+# --- DINOv3 Pre-trained Weights Test ---
+
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+dinov3_files_exist = os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)
+
+
+@pytest.mark.skipif(
+    not dinov3_files_exist, reason="DINOv3 local model/weight files not found."
+)
+def test_dinov3_pretrained_weights_match():
+    """
+    Tests the Keras SelfAttention layer by loading weights from a pre-trained
+    DINOv3 PyTorch model and verifying the outputs match.
+    """
+    # 1. Load the pre-trained DINOv3 model from local source
+    dinov3_model_local = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model_local.eval()
+
+    # 2. Extract the first attention layer and its parameters
+    torch_pretrained_attn = dinov3_model_local.blocks[0].attn
+    PRETRAINED_DIM = dinov3_model_local.embed_dim
+    PRETRAINED_NUM_HEADS = torch_pretrained_attn.num_heads
+    QKV_BIAS = torch_pretrained_attn.qkv.bias is not None
+    PROJ_BIAS = torch_pretrained_attn.proj.bias is not None
+
+    # 3. Initialize Keras SelfAttention with matching parameters
+    keras_attn_pretrained = SelfAttention(
+        dim=PRETRAINED_DIM,
+        num_heads=PRETRAINED_NUM_HEADS,
+        qkv_bias=QKV_BIAS,
+        proj_bias=PROJ_BIAS,
+    )
+
+    # 4. Prepare a dummy input tensor
+    BATCH_SIZE = 2
+    NUM_TOKENS = 201
+    x_torch_pretrained = torch.rand(BATCH_SIZE, NUM_TOKENS, PRETRAINED_DIM)
+    x_keras_pretrained = x_torch_pretrained.numpy()
+
+    # 5. Build Keras layer and port weights
+    _ = keras_attn_pretrained(np.zeros_like(x_keras_pretrained, dtype="float32"))
+    port_weights(torch_pretrained_attn, keras_attn_pretrained)
+
+    # 6. Run forward pass on both layers and compare outputs
+    torch_out_pretrained = torch_pretrained_attn(x_torch_pretrained).detach().numpy()
+    keras_out_pretrained = np.array(
+        keras_attn_pretrained(x_keras_pretrained, rope=None, training=False)
+    )
+
+    np.testing.assert_allclose(
+        torch_out_pretrained,
+        keras_out_pretrained,
+        atol=1e-5,
+        err_msg="Keras output with DINOv3 weights does not match PyTorch output.",
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/block.py
+++ b/paz/models/foundation/dinov3/layers/block.py
@@ -1,0 +1,231 @@
+import keras
+from keras import layers, ops
+from typing import Callable, Optional
+
+from paz.models.foundation.dinov3.layers.attention import (
+    SelfAttention,
+    CausalSelfAttention,
+)
+from paz.models.foundation.dinov3.layers.ffn_layers import Mlp
+from paz.models.foundation.dinov3.layers.layer_scale import LayerScale
+
+
+class StochasticDepth(layers.Layer):
+    def __init__(self, drop_rate, **kwargs):
+        super().__init__(**kwargs)
+        self.drop_rate = drop_rate
+
+    def call(self, x, training=None):
+        if self.drop_rate == 0.0 or not training:
+            return x
+
+        keep_prob = 1.0 - self.drop_rate
+        shape = (ops.shape(x)[0],) + (1,) * (len(ops.shape(x)) - 1)
+
+        random_tensor = keras.random.uniform(shape, 0, 1, dtype=x.dtype)
+        keep_mask = random_tensor >= self.drop_rate
+
+        return (x / keep_prob) * ops.cast(keep_mask, x.dtype)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"drop_rate": self.drop_rate})
+        return config
+
+
+class _Identity(layers.Layer):
+    def call(self, x):
+        return x
+
+
+class SelfAttentionBlock(layers.Layer):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        mlp_ratio=4.0,
+        qkv_bias=True,
+        proj_bias=True,
+        ffn_bias=True,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        init_values=None,
+        act_layer="gelu",
+        norm_layer=layers.LayerNormalization,
+        attn_class=SelfAttention,
+        ffn_layer=Mlp,
+        **kwargs,
+    ):
+        kwargs.pop("mask_k_bias", None)
+        super().__init__(**kwargs)
+        self.dim = dim
+        self.num_heads = num_heads
+        self.mlp_ratio = mlp_ratio
+        self.qkv_bias = qkv_bias
+        self.drop = drop
+        self.attn_drop = attn_drop
+        self.drop_path_rate = drop_path
+        self.init_values = init_values
+        self.act_layer = act_layer
+        self.norm_layer = norm_layer
+        self.attn_class = attn_class
+        self.ffn_layer = ffn_layer
+
+        self.norm1 = norm_layer(epsilon=1e-6, name="norm1")
+        self.attn = attn_class(
+            dim=dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            proj_bias=proj_bias,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+            name="attn",
+        )
+        self.ls1 = (
+            LayerScale(dimension=dim, init_values=init_values, name="ls1")
+            if init_values is not None
+            else _Identity(name="ls1")
+        )
+        self.drop_path1 = StochasticDepth(drop_path) if drop_path > 0.0 else _Identity()
+
+        self.norm2 = norm_layer(epsilon=1e-6, name="norm2")
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = ffn_layer(
+            hidden_features=mlp_hidden_dim,
+            out_features=dim,
+            act_layer=act_layer,
+            drop=drop,
+            bias=ffn_bias,
+            name="mlp",
+        )
+        self.ls2 = (
+            LayerScale(dimension=dim, init_values=init_values, name="ls2")
+            if init_values is not None
+            else _Identity(name="ls2")
+        )
+        self.drop_path2 = StochasticDepth(drop_path) if drop_path > 0.0 else _Identity()
+
+    def _forward_tensor(self, x, rope=None, training=None):
+        """Handles a single tensor input."""
+        x_norm1 = self.norm1(x)
+        attn_out = self.attn(x_norm1, rope=rope, training=training)
+        x = x + self.drop_path1(self.ls1(attn_out), training=training)
+        x_norm2 = self.norm2(x)
+        mlp_out = self.mlp(x_norm2, training=training)
+        x = x + self.drop_path2(self.ls2(mlp_out), training=training)
+        return x
+
+    def _forward_list(self, x_list, rope_list=None, training=None):
+        """Handles a list of tensors, as required by the main model."""
+        if rope_list is None:
+            rope_list = [None] * len(x_list)
+        x_norm1_list = [self.norm1(x) for x in x_list]
+        attn_out_list = self.attn(x_norm1_list, rope=rope_list, training=training)
+        x_res1_list = [
+            x + self.drop_path1(self.ls1(attn_out), training=training)
+            for x, attn_out in zip(x_list, attn_out_list)
+        ]
+        x_norm2_list = [self.norm2(x) for x in x_res1_list]
+        mlp_out_list = self.mlp(x_norm2_list, training=training)
+        x_res2_list = [
+            x + self.drop_path2(self.ls2(mlp_out), training=training)
+            for x, mlp_out in zip(x_res1_list, mlp_out_list)
+        ]
+        return x_res2_list
+
+    def call(self, x, rope=None, training=None):
+        """
+        Handles both a single tensor and a list of tensors.
+        """
+        if isinstance(x, list):
+            return self._forward_list(x, rope_list=rope, training=training)
+        else:
+            return self._forward_tensor(x, rope=rope, training=training)
+
+
+class CausalSelfAttentionBlock(layers.Layer):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        init_values: Optional[float] = None,
+        is_causal: bool = True,
+        act_layer: str = "gelu",
+        norm_layer: Callable = layers.LayerNormalization,
+        drop: float = 0.0,
+        qkv_bias: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.dim = dim
+        self.num_heads = num_heads
+        self.mlp_ratio = mlp_ratio
+        self.init_values = init_values
+        self.is_causal = is_causal
+        self.act_layer = act_layer
+        self.norm_layer = norm_layer
+        self.drop = drop
+        self.qkv_bias = qkv_bias
+
+        self.attention_norm = self.norm_layer(epsilon=1e-6, name="attention_norm")
+        self.ffn_norm = self.norm_layer(epsilon=1e-6, name="ffn_norm")
+
+        self.ls1 = (
+            LayerScale(dimension=dim, init_values=init_values, name="ls1")
+            if init_values is not None
+            else _Identity(name="ls1")
+        )
+        self.ls2 = (
+            LayerScale(dimension=dim, init_values=init_values, name="ls2")
+            if init_values is not None
+            else _Identity(name="ls2")
+        )
+
+        self.attention = CausalSelfAttention(
+            dim=dim,
+            num_heads=num_heads,
+            qkv_bias=self.qkv_bias,
+            attn_drop=self.drop,
+            proj_drop=self.drop,
+            name="attention",
+        )
+
+        mlp_hidden_dim = int(dim * self.mlp_ratio)
+        self.feed_forward = Mlp(
+            hidden_features=mlp_hidden_dim,
+            out_features=self.dim,
+            act_layer=self.act_layer,
+            drop=self.drop,
+            name="feed_forward",
+        )
+
+    def call(self, x, training=None):
+        attn_input = self.attention_norm(x)
+        attn_output = self.attention(
+            attn_input, is_causal=self.is_causal, training=training
+        )
+        x_attn = x + self.ls1(attn_output)
+
+        ffn_input = self.ffn_norm(x_attn)
+        ffn_output = self.feed_forward(ffn_input, training=training)
+        x_ffn = x_attn + self.ls2(ffn_output)
+
+        return x_ffn
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "dim": self.dim,
+                "num_heads": self.num_heads,
+                "mlp_ratio": self.mlp_ratio,
+                "init_values": self.init_values,
+                "is_causal": self.is_causal,
+                "act_layer": self.act_layer,
+                "drop": self.drop,
+                "qkv_bias": self.qkv_bias,
+            }
+        )
+        return config

--- a/paz/models/foundation/dinov3/layers/block_test.py
+++ b/paz/models/foundation/dinov3/layers/block_test.py
@@ -1,0 +1,611 @@
+import os
+import torch
+import numpy as np
+import sys
+
+os.environ["KERAS_BACKEND"] = "jax"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from torch import nn
+from functools import partial
+import keras
+import jax
+import jax.numpy as jnp
+from keras import layers
+import pytest
+
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.block import (
+    SelfAttentionBlock,
+    CausalSelfAttentionBlock,
+)
+
+# ==============================================================================
+# PyTorch Reference Implementation (unchangeable)
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import (
+    PT_SelfAttention,
+    PT_CausalSelfAttention,
+    PT_Mlp,
+    PT_SelfAttentionBlock,
+    PT_CausalSelfAttentionBlock,
+)
+
+
+# ==============================================================================
+# TESTING HELPER FUNCTIONS
+# ==============================================================================
+
+
+def transfer_weights_pt_to_pt_causal(pt_ref_block, pt_causal_block):
+    """
+    Helper to transfer weights from a reference PT SelfAttentionBlock to a
+    PT CausalSelfAttentionBlock. This function is specific and not redundant.
+    """
+    with torch.no_grad():
+        pt_causal_block.attention_norm.weight.data = (
+            pt_ref_block.norm1.weight.detach().clone()
+        )
+        pt_causal_block.attention_norm.bias.data = (
+            pt_ref_block.norm1.bias.detach().clone()
+        )
+        pt_causal_block.ffn_norm.weight.data = (
+            pt_ref_block.norm2.weight.detach().clone()
+        )
+        pt_causal_block.ffn_norm.bias.data = pt_ref_block.norm2.bias.detach().clone()
+        pt_causal_block.attention.qkv.weight.data = (
+            pt_ref_block.attn.qkv.weight.detach().clone()
+        )
+        if (
+            pt_ref_block.attn.qkv.bias is not None
+            and pt_causal_block.attention.qkv.bias is not None
+        ):
+            pt_causal_block.attention.qkv.bias.data = (
+                pt_ref_block.attn.qkv.bias.detach().clone()
+            )
+        pt_causal_block.attention.proj.weight.data = (
+            pt_ref_block.attn.proj.weight.detach().clone()
+        )
+        if (
+            pt_ref_block.attn.proj.bias is not None
+            and pt_causal_block.attention.proj.bias is not None
+        ):
+            pt_causal_block.attention.proj.bias.data = (
+                pt_ref_block.attn.proj.bias.detach().clone()
+            )
+        pt_causal_block.feed_forward.fc1.weight.data = (
+            pt_ref_block.mlp.fc1.weight.detach().clone()
+        )
+        if (
+            pt_ref_block.mlp.fc1.bias is not None
+            and pt_causal_block.feed_forward.fc1.bias is not None
+        ):
+            pt_causal_block.feed_forward.fc1.bias.data = (
+                pt_ref_block.mlp.fc1.bias.detach().clone()
+            )
+        pt_causal_block.feed_forward.fc2.weight.data = (
+            pt_ref_block.mlp.fc2.weight.detach().clone()
+        )
+        if (
+            pt_ref_block.mlp.fc2.bias is not None
+            and pt_causal_block.feed_forward.fc2.bias is not None
+        ):
+            pt_causal_block.feed_forward.fc2.bias.data = (
+                pt_ref_block.mlp.fc2.bias.detach().clone()
+            )
+        if not isinstance(pt_ref_block.ls1, nn.Identity):
+            pt_causal_block.ls1.gamma.data = pt_ref_block.ls1.gamma.detach().clone()
+        if not isinstance(pt_ref_block.ls2, nn.Identity):
+            pt_causal_block.ls2.gamma.data = pt_ref_block.ls2.gamma.detach().clone()
+
+
+def transfer_weights_generic(keras_block, pt_block, layer_name_map):
+    """
+    A generic function to transfer weights from a PyTorch block to a Keras block,
+    replacing the two previous redundant functions.
+    """
+    for keras_attr_str, pt_attr_str in layer_name_map.items():
+        pt_layer = pt_block
+        for part in pt_attr_str.split("."):
+            pt_layer = getattr(pt_layer, part)
+
+        keras_layer = keras_block
+        for part in keras_attr_str.split("."):
+            keras_layer = getattr(keras_layer, part)
+
+        weights_to_set = []
+        if hasattr(pt_layer, "weight"):
+            weight_data = pt_layer.weight.detach().numpy()
+            if isinstance(keras_layer, layers.Dense):
+                weights_to_set.append(weight_data.T)
+            else:
+                weights_to_set.append(weight_data)
+
+        if hasattr(pt_layer, "bias") and pt_layer.bias is not None:
+            weights_to_set.append(pt_layer.bias.detach().numpy())
+
+        if "ls" in keras_attr_str and hasattr(pt_layer, "gamma"):
+            weights_to_set.append(pt_layer.gamma.detach().numpy())
+
+        if weights_to_set:
+            keras_layer.set_weights(weights_to_set)
+
+
+# ==============================================================================
+# tests
+# ==============================================================================
+
+# Define paths to your local DINOv3 repository and the downloaded weights
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+dinov3_files_exist = os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)
+
+
+@pytest.mark.parametrize(
+    "dim, num_heads, mlp_ratio, qkv_bias, init_values",
+    [
+        (64, 8, 4.0, True, None),
+        (128, 4, 2.0, False, None),
+        (96, 6, 4.0, True, 1e-4),
+        (32, 4, 3.0, False, 1e-4),
+    ],
+)
+def test_self_attention_block_consistency(
+    dim, num_heads, mlp_ratio, qkv_bias, init_values
+):
+    np.random.seed(42)
+    torch.manual_seed(42)
+    pt_model = PT_SelfAttentionBlock(
+        dim=dim,
+        num_heads=num_heads,
+        ffn_ratio=mlp_ratio,
+        qkv_bias=qkv_bias,
+        proj_bias=True,
+        ffn_bias=True,
+        init_values=init_values,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6),
+        attn_class=PT_SelfAttention,
+        ffn_layer=PT_Mlp,
+        act_layer=nn.GELU,
+    )
+    if init_values:
+        pt_model.ls1.reset_parameters()
+        pt_model.ls2.reset_parameters()
+    pt_model.eval()
+
+    keras_model = SelfAttentionBlock(
+        dim=dim,
+        num_heads=num_heads,
+        mlp_ratio=mlp_ratio,
+        qkv_bias=qkv_bias,
+        init_values=init_values,
+    )
+
+    np_input = np.random.rand(4, 16, dim).astype("float32")
+    _ = keras_model(np_input)
+
+    layer_map = {
+        "norm1": "norm1",
+        "norm2": "norm2",
+        "attn.qkv": "attn.qkv",
+        "attn.proj": "attn.proj",
+        "mlp.fc1": "mlp.fc1",
+        "mlp.fc2": "mlp.fc2",
+    }
+    if init_values:
+        layer_map.update({"ls1": "ls1", "ls2": "ls2"})
+    transfer_weights_generic(keras_model, pt_model, layer_map)
+
+    pt_output = pt_model(torch.from_numpy(np_input)).detach().numpy()
+    keras_output = keras_model(np_input, training=False)
+    if hasattr(keras_output, "to_numpy"):
+        keras_output = keras_output.to_numpy()
+
+    np.testing.assert_allclose(pt_output, keras_output, atol=1e-5, rtol=1e-5)
+    print(f"Consistency test passed for SelfAttentionBlock with dim={dim}")
+
+
+@pytest.mark.parametrize(
+    "dim, num_heads, mlp_ratio, init_values, qkv_bias",
+    [(64, 8, 4.0, None, True), (128, 4, 2.0, 1e-5, False)],
+)
+def test_causal_self_attention_block_consistency(
+    dim, num_heads, mlp_ratio, init_values, qkv_bias
+):
+    np.random.seed(42)
+    torch.manual_seed(42)
+    pt_model = PT_CausalSelfAttentionBlock(
+        dim=dim,
+        num_heads=num_heads,
+        ffn_ratio=mlp_ratio,
+        ls_init_value=init_values,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6),
+    )
+    pt_model.attention = PT_CausalSelfAttention(dim, num_heads, qkv_bias=qkv_bias)
+    if init_values:
+        pt_model.ls1.reset_parameters()
+        pt_model.ls2.reset_parameters()
+    pt_model.eval()
+
+    keras_model = CausalSelfAttentionBlock(
+        dim=dim,
+        num_heads=num_heads,
+        mlp_ratio=mlp_ratio,
+        init_values=init_values,
+        qkv_bias=qkv_bias,
+    )
+
+    np_input = np.random.rand(4, 16, dim).astype("float32")
+    _ = keras_model(np_input)
+
+    layer_map = {
+        "attention_norm": "attention_norm",
+        "ffn_norm": "ffn_norm",
+        "attention.qkv": "attention.qkv",
+        "attention.proj": "attention.proj",
+        "feed_forward.fc1": "feed_forward.fc1",
+        "feed_forward.fc2": "feed_forward.fc2",
+    }
+    if init_values:
+        layer_map.update({"ls1": "ls1", "ls2": "ls2"})
+    transfer_weights_generic(keras_model, pt_model, layer_map)
+
+    pt_output = pt_model(torch.from_numpy(np_input)).detach().numpy()
+    keras_output = np.asarray(keras_model(np_input, training=False))
+
+    np.testing.assert_allclose(pt_output, keras_output, atol=1e-5, rtol=1e-5)
+    print(f"Consistency test passed for CausalSelfAttentionBlock with dim={dim}")
+
+
+@pytest.mark.parametrize(
+    "block_class, dim, num_heads, drop_rate",
+    [
+        (SelfAttentionBlock, 64, 8, 0.1),
+        (SelfAttentionBlock, 96, 6, 0.5),
+        (SelfAttentionBlock, 128, 4, 0.5),
+        (CausalSelfAttentionBlock, 64, 8, 0.1),
+        (CausalSelfAttentionBlock, 96, 6, 0.5),
+        (CausalSelfAttentionBlock, 128, 4, 0.5),
+    ],
+)
+def test_block_training_mode(block_class, dim, num_heads, drop_rate):
+    """A single, parametrized test for training mode behavior."""
+    np.random.seed(123)
+    init_kwargs = {"dim": dim, "num_heads": num_heads, "drop": drop_rate}
+    if block_class == SelfAttentionBlock:
+        init_kwargs.update({"attn_drop": drop_rate, "drop_path": drop_rate})
+
+    keras_model = block_class(**init_kwargs)
+    np_input = np.random.rand(4, 16, dim).astype("float32")
+
+    train_raw = keras_model(np_input, training=True)
+    train_output = train_raw[0] if isinstance(train_raw, tuple) else train_raw
+
+    eval_raw = keras_model(np_input, training=False)
+    eval_output = eval_raw[0] if isinstance(eval_raw, tuple) else eval_raw
+
+    if hasattr(train_output, "to_numpy"):
+        train_output = train_output.to_numpy()
+    if hasattr(eval_output, "to_numpy"):
+        eval_output = eval_output.to_numpy()
+
+    assert train_output.shape == np_input.shape
+    assert not np.allclose(train_output, eval_output)
+    print(f"Training mode test passed for {block_class.__name__}")
+
+
+@pytest.mark.skipif(not dinov3_files_exist, reason="DINOv3 model/weights not found.")
+def test_dinov3_block_pretrained_weights_match():
+    """Validates the Keras SelfAttentionBlock against pre-trained DINOv3 weights."""
+    dinov3_model = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model.eval()
+    torch_block = dinov3_model.blocks[0]
+
+    PRETRAINED_DIM = dinov3_model.embed_dim
+    PRETRAINED_NUM_HEADS = torch_block.attn.num_heads
+    QKV_BIAS = torch_block.attn.qkv.bias is not None
+    MLP_RATIO = torch_block.mlp.fc1.out_features / PRETRAINED_DIM
+    INIT_VALUES = (
+        torch_block.ls1.init_values
+        if not isinstance(torch_block.ls1, nn.Identity)
+        else None
+    )
+
+    keras_block = SelfAttentionBlock(
+        dim=PRETRAINED_DIM,
+        num_heads=PRETRAINED_NUM_HEADS,
+        mlp_ratio=MLP_RATIO,
+        qkv_bias=QKV_BIAS,
+        init_values=INIT_VALUES,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+    )
+
+    x_torch = torch.rand(2, 201, PRETRAINED_DIM)
+    x_keras = x_torch.numpy()
+    _ = keras_block(np.zeros_like(x_keras, dtype="float32"))
+
+    layer_map = {
+        "norm1": "norm1",
+        "norm2": "norm2",
+        "attn.qkv": "attn.qkv",
+        "attn.proj": "attn.proj",
+        "mlp.fc1": "mlp.fc1",
+        "mlp.fc2": "mlp.fc2",
+    }
+    if INIT_VALUES:
+        layer_map.update({"ls1": "ls1", "ls2": "ls2"})
+    transfer_weights_generic(keras_block, torch_block, layer_map)
+
+    torch_out = torch_block(x_torch).detach().numpy()
+    keras_out = keras_block(x_keras, training=False)
+    if hasattr(keras_out, "to_numpy"):
+        keras_out = keras_out.to_numpy()
+
+    mean_abs_diff = np.mean(np.abs(torch_out - keras_out))
+    print(f"\nPre-trained SelfAttentionBlock Mean Absolute Difference: {mean_abs_diff}")
+    np.testing.assert_allclose(torch_out, keras_out, atol=1e-3)
+    assert (
+        mean_abs_diff < 1e-5
+    ), f"Mean absolute difference {mean_abs_diff} exceeds tolerance."
+
+
+@pytest.mark.skipif(not dinov3_files_exist, reason="DINOv3 model/weights not found.")
+def test_dinov3_causal_block_pretrained_weights_match():
+    """Validates the Keras CausalSelfAttentionBlock against pre-trained DINOv3 weights."""
+    dinov3_model = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model.eval()
+    ref_block = dinov3_model.blocks[0]
+
+    dim = dinov3_model.embed_dim
+    heads = ref_block.attn.num_heads
+    qkv_bias = ref_block.attn.qkv.bias is not None
+    mlp_ratio = ref_block.mlp.fc1.out_features / dim
+    init_values = (
+        ref_block.ls1.init_values if hasattr(ref_block.ls1, "init_values") else None
+    )
+
+    pt_causal_block = PT_CausalSelfAttentionBlock(
+        dim, heads, mlp_ratio, init_values, norm_layer=partial(nn.LayerNorm, eps=1e-6)
+    )
+    pt_causal_block.attention = PT_CausalSelfAttention(dim, heads, qkv_bias=qkv_bias)
+    transfer_weights_pt_to_pt_causal(ref_block, pt_causal_block)
+    pt_causal_block.eval()
+
+    keras_block = CausalSelfAttentionBlock(
+        dim, heads, mlp_ratio, init_values, qkv_bias=qkv_bias
+    )
+    np_input = np.random.rand(2, 201, dim).astype("float32")
+    _ = keras_block(np_input)
+
+    layer_map = {
+        "attention_norm": "attention_norm",
+        "ffn_norm": "ffn_norm",
+        "attention.qkv": "attention.qkv",
+        "attention.proj": "attention.proj",
+        "feed_forward.fc1": "feed_forward.fc1",
+        "feed_forward.fc2": "feed_forward.fc2",
+    }
+    if init_values:
+        layer_map.update({"ls1": "ls1", "ls2": "ls2"})
+    transfer_weights_generic(keras_block, pt_causal_block, layer_map)
+
+    pt_output = pt_causal_block(torch.from_numpy(np_input)).detach().numpy()
+    keras_output = np.asarray(keras_block(np_input, training=False))
+    mean_abs_diff = np.mean(np.abs(pt_output - keras_output))
+
+    print(
+        f"\nPre-trained CausalSelfAttentionBlock Mean Absolute Difference: {mean_abs_diff}"
+    )
+    np.testing.assert_allclose(pt_output, keras_output, atol=1e-4)
+    assert mean_abs_diff < 1e-5
+
+
+@pytest.mark.parametrize(
+    "dim, num_heads, sequence_length",
+    [
+        (64, 8, 32),
+        (128, 4, 16),
+    ],
+)
+def test_causality_functional(dim, num_heads, sequence_length):
+    """
+    Tests the CausalSelfAttentionBlock for causal masking.
+    An output at timestep `t` should not depend on inputs from `t+1`.
+    """
+    np.random.seed(42)
+    # 1. Initialize the model
+    model = CausalSelfAttentionBlock(dim=dim, num_heads=num_heads)
+
+    # 2. Create an initial input and get the output
+    original_input = np.random.rand(1, sequence_length, dim).astype("float32")
+    original_output = model(original_input, training=False)
+    if hasattr(original_output, "to_numpy"):
+        original_output = original_output.to_numpy()
+
+    # 3. Create a modified input where only the LAST token is changed
+    modified_input = np.copy(original_input)
+    modified_input[:, -1, :] = np.random.rand(1, dim)
+
+    # 4. Get the output from the modified input
+    modified_output = model(modified_input, training=False)
+    if hasattr(modified_output, "to_numpy"):
+        modified_output = modified_output.to_numpy()
+
+    # 5. Assert that all outputs EXCEPT the last one are identical
+    np.testing.assert_allclose(
+        original_output[:, :-1, :],
+        modified_output[:, :-1, :],
+        atol=1e-6,
+        err_msg="Outputs before the last token should be identical, causality is broken.",
+    )
+
+    # 6. Assert that the last output token IS different
+    assert not np.allclose(
+        original_output[:, -1, :],
+        modified_output[:, -1, :],
+    ), "The last output token should have changed."
+
+    print(f"\nCausality test passed for dim={dim}, heads={num_heads}")
+
+
+@pytest.mark.parametrize(
+    "block_class, dim, num_heads",
+    [
+        (SelfAttentionBlock, 64, 8),
+        (CausalSelfAttentionBlock, 32, 4),
+    ],
+)
+def test_serialization(block_class, dim, num_heads, tmp_path):
+    """
+    Tests if the custom blocks can be saved and loaded correctly.
+    """
+    # 1. Create a model with the custom layer
+    np_input = np.random.rand(2, 16, dim).astype("float32")
+    layer = block_class(dim=dim, num_heads=num_heads, name="custom_block")
+    model = keras.Sequential([keras.layers.Input(shape=(16, dim)), layer])
+
+    # 2. Get the output of the original model
+    original_output = model(np_input)
+
+    # 3. Save and load the model
+    model_path = tmp_path / "model.keras"
+    model.save(model_path)
+    loaded_model = keras.models.load_model(
+        model_path, custom_objects={block_class.__name__: block_class}
+    )
+
+    # 4. Get the output of the loaded model
+    loaded_output = loaded_model(np_input)
+
+    # 5. Assert that outputs are identical
+    np.testing.assert_allclose(
+        original_output,
+        loaded_output,
+        atol=1e-6,
+        err_msg="Output of loaded model does not match original.",
+    )
+
+    # 6. Assert that weights are identical
+    for w1, w2 in zip(model.weights, loaded_model.weights):
+        np.testing.assert_allclose(
+            w1.numpy(),
+            w2.numpy(),
+            err_msg="Weights of loaded model do not match original.",
+        )
+
+    print(f"\nSerialization test passed for {block_class.__name__}")
+
+
+@pytest.mark.parametrize(
+    "dim, num_heads, qkv_bias",
+    [(32, 4, True), (32, 4, False)],
+)
+def test_gradients_consistency(dim, num_heads, qkv_bias):
+    """
+    Verifies that the backward pass (gradients) is consistent
+    between the Keras/JAX and PyTorch implementations.
+    """
+    np.random.seed(123)
+    torch.manual_seed(123)
+
+    # --- PyTorch Setup ---
+    pt_model = PT_CausalSelfAttentionBlock(
+        dim=dim,
+        num_heads=num_heads,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6),
+    )
+    pt_model.attention = PT_CausalSelfAttention(dim, num_heads, qkv_bias=qkv_bias)
+    pt_model.eval()
+
+    # --- Keras Setup ---
+    keras_model = CausalSelfAttentionBlock(
+        dim=dim, num_heads=num_heads, qkv_bias=qkv_bias
+    )
+    np_input = np.random.rand(2, 16, dim).astype("float32")
+    _ = keras_model(np_input)  # Build layer
+
+    # --- COMPLETE Weight Transfer ---
+    layer_map = {
+        "attention_norm": "attention_norm",
+        "ffn_norm": "ffn_norm",
+        "attention.qkv": "attention.qkv",
+        "attention.proj": "attention.proj",
+        "feed_forward.fc1": "feed_forward.fc1",
+        "feed_forward.fc2": "feed_forward.fc2",
+    }
+    transfer_weights_generic(keras_model, pt_model, layer_map)
+
+    # --- PyTorch Gradient Calculation ---
+    pt_input = torch.from_numpy(np_input).requires_grad_(True)
+    pt_output = pt_model(pt_input)
+    pt_loss = pt_output.sum()
+    pt_loss.backward()
+
+    pt_grad_input = pt_input.grad.numpy()
+    pt_grad_qkv_w = pt_model.attention.qkv.weight.grad.numpy()
+
+    # --- Keras/JAX Gradient Calculation ---
+    jax_input = jnp.array(np_input)
+
+    def get_keras_loss(weights, inp):
+        keras_model.set_weights(weights)
+        output = keras_model(inp, training=False)
+        return jnp.sum(output)
+
+    grad_fn = jax.grad(get_keras_loss, argnums=[0, 1])
+
+    initial_weights_vars = keras_model.weights
+    initial_weights_np = keras_model.get_weights()  # This gives NumPy arrays
+
+    keras_grads_w, keras_grad_input = grad_fn(initial_weights_np, jax_input)
+
+    qkv_kernel_path = keras_model.attention.qkv.kernel.path
+    qkv_weight_index = -1
+    for i, weight_var in enumerate(initial_weights_vars):
+        if weight_var.path == qkv_kernel_path:
+            qkv_weight_index = i
+            break
+
+    if qkv_weight_index == -1:
+        raise ValueError("Could not find QKV kernel in the model's weights.")
+
+    keras_grad_qkv_w = keras_grads_w[qkv_weight_index]
+
+    # --- Comparison ---
+    print("\nComparing gradients...")
+    np.testing.assert_allclose(
+        pt_grad_input,
+        np.array(keras_grad_input),
+        atol=1e-5,
+        rtol=1e-5,
+        err_msg="Input gradients do not match.",
+    )
+    np.testing.assert_allclose(
+        pt_grad_qkv_w.T,
+        np.array(keras_grad_qkv_w),
+        atol=1e-5,
+        rtol=1e-5,
+        err_msg="QKV weight gradients do not match.",
+    )
+    print(
+        f"Gradient consistency test passed for dim={dim}, heads={num_heads}, bias={qkv_bias}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/ffn_layers.py
+++ b/paz/models/foundation/dinov3/layers/ffn_layers.py
@@ -1,0 +1,116 @@
+import keras
+from keras import layers
+from typing import List, Optional
+from paz.models.foundation.dinov3.utils import cat_keep_shapes, uncat_with_shapes
+
+
+class ListForwardMixin:
+    """A mixin to handle forward passes on lists of tensors."""
+
+    def call_list(
+        self, x_list: List[keras.KerasTensor], training: bool = False
+    ) -> List[keras.KerasTensor]:
+        """
+        Processes a list of tensors by concatenating, running the forward pass,
+        and then splitting them back to their original shapes.
+        """
+        x_flat, shapes, num_tokens = cat_keep_shapes(x_list)
+        x_flat_out = self(x_flat, training=training)
+        return uncat_with_shapes(x_flat_out, shapes, num_tokens)
+
+
+class Mlp(layers.Layer, ListForwardMixin):
+    def __init__(
+        self,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: str = "gelu",
+        drop: float = 0.0,
+        bias: bool = True,
+        approximate_gelu: bool = False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.hidden_features_config = hidden_features
+        self.out_features_config = out_features
+        if act_layer == "gelu":
+            self.act = lambda x: keras.activations.gelu(x, approximate=approximate_gelu)
+        else:
+            self.act = keras.activations.get(act_layer)
+        self.drop_rate = drop
+        self.use_bias = bias
+
+    def build(self, input_shape: tuple):
+        in_features = input_shape[-1]
+        hidden_features = self.hidden_features_config or in_features
+        out_features = self.out_features_config or in_features
+
+        self.fc1 = keras.layers.Dense(
+            hidden_features, use_bias=self.use_bias, name="fc1"
+        )
+        self.fc2 = layers.Dense(out_features, use_bias=self.use_bias, name="fc2")
+        self.drop = layers.Dropout(self.drop_rate)
+        super().build(input_shape)
+
+    def _forward_tensor(
+        self, x: keras.KerasTensor, training: bool = False
+    ) -> keras.KerasTensor:
+        """Processes a single tensor input."""
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x, training=training)
+        x = self.fc2(x)
+        x = self.drop(x, training=training)
+        return x
+
+    def call(self, x: keras.KerasTensor, training: bool = False) -> keras.KerasTensor:
+        """Handles both a single tensor and a list of tensors."""
+        if isinstance(x, list):
+            return self.call_list(x, training=training)
+        else:
+            return self._forward_tensor(x, training=training)
+
+
+class SwiGLUFFN(layers.Layer, ListForwardMixin):
+    """Keras implementation of the SwiGLUFFN module."""
+
+    def __init__(
+        self,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        bias: bool = True,
+        align_to: int = 8,
+        **kwargs,
+    ):
+
+        super().__init__(**kwargs)
+        self.hidden_features_config = hidden_features
+        self.out_features_config = out_features
+        self.use_bias = bias
+        self.align_to = align_to
+
+    def build(self, input_shape: tuple):
+        in_features = input_shape[-1]
+        out_features = self.out_features_config or in_features
+        hidden_features = self.hidden_features_config or in_features
+
+        d = int(hidden_features * 2 / 3)
+        swiglu_hidden_features = (
+            (d + self.align_to - 1) // self.align_to * self.align_to
+        )
+
+        self.w1 = layers.Dense(
+            swiglu_hidden_features, use_bias=self.use_bias, name="w1"
+        )
+        self.w2 = layers.Dense(
+            swiglu_hidden_features, use_bias=self.use_bias, name="w2"
+        )
+        self.w3 = layers.Dense(out_features, use_bias=self.use_bias, name="w3")
+
+        super().build(input_shape)
+
+    def call(self, x: keras.KerasTensor) -> keras.KerasTensor:
+        x1 = self.w1(x)
+        x2 = self.w2(x)
+        hidden = keras.activations.silu(x1) * x2
+        return self.w3(hidden)

--- a/paz/models/foundation/dinov3/layers/ffn_layers_test.py
+++ b/paz/models/foundation/dinov3/layers/ffn_layers_test.py
@@ -1,0 +1,364 @@
+import os
+import torch
+import numpy as np
+import sys
+
+os.environ["KERAS_BACKEND"] = "jax"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import numpy as np
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import torch
+import torch.nn as nn
+import jax.numpy as jnp
+
+import pytest
+
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.ffn_layers import (
+    Mlp,
+    SwiGLUFFN,
+)
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import (
+    PT_Mlp,
+    PT_SwiGLUFFN,
+)
+
+# ==============================================================================
+# Helper Functions for Creating and Testing Layer Pairs
+# ==============================================================================
+
+
+def create_mlp_pair(
+    in_dim,
+    drop=0.0,
+    bias=True,
+    hidden_features=None,
+    out_features=None,
+    approximate_gelu=False,
+):
+    """Creates, builds, and transfers weights for a Keras and PyTorch Mlp pair."""
+    # 1. Create and configure PyTorch model
+    pt_act_layer = lambda: nn.GELU(approximate="tanh" if approximate_gelu else "none")
+    pt_model = PT_Mlp(
+        in_features=in_dim,
+        hidden_features=hidden_features,
+        out_features=out_features,
+        act_layer=pt_act_layer,
+        drop=drop,
+        bias=bias,
+    )
+    pt_model.eval()
+
+    # 2. Create and build Keras model
+    keras_model = Mlp(
+        hidden_features=hidden_features,
+        out_features=out_features,
+        drop=drop,
+        bias=bias,
+        approximate_gelu=approximate_gelu,
+    )
+    keras_model(jnp.ones((1, 1, in_dim)))
+
+    # ... rest of the weight transfer is the same
+    pt_weights = pt_model.state_dict()
+    fc1_weights = [pt_weights["fc1.weight"].T.numpy()]
+    if bias:
+        fc1_weights.append(pt_weights["fc1.bias"].numpy())
+    keras_model.fc1.set_weights(fc1_weights)
+
+    fc2_weights = [pt_weights["fc2.weight"].T.numpy()]
+    if bias:
+        fc2_weights.append(pt_weights["fc2.bias"].numpy())
+    keras_model.fc2.set_weights(fc2_weights)
+
+    return pt_model, keras_model
+
+
+def create_swiglu_pair(
+    in_dim, bias=True, align_to=8, hidden_features=None, out_features=None
+):
+    """Creates, builds, and transfers weights for a Keras and PyTorch SwiGLUFFN pair."""
+    # 1. Create and configure PyTorch model
+    pt_model = PT_SwiGLUFFN(
+        in_features=in_dim,
+        hidden_features=hidden_features,
+        out_features=out_features,
+        bias=bias,
+        align_to=align_to,
+    )
+    pt_model.eval()  # Set to evaluation mode
+
+    # 2. Create and build Keras model
+    keras_model = SwiGLUFFN(
+        hidden_features=hidden_features,
+        out_features=out_features,
+        bias=bias,
+        align_to=align_to,
+    )
+    keras_model(jnp.ones((1, 1, in_dim)))  # Build the layer
+
+    # 3. Transfer weights from PyTorch to Keras
+    pt_weights = pt_model.state_dict()
+    for i in range(1, 4):
+        layer_name = f"w{i}"
+        keras_layer = getattr(keras_model, layer_name)
+        pt_layer_weights = [pt_weights[f"{layer_name}.weight"].T.numpy()]
+        if bias:
+            pt_layer_weights.append(pt_weights[f"{layer_name}.bias"].numpy())
+        keras_layer.set_weights(pt_layer_weights)
+
+    return pt_model, keras_model
+
+
+# ==============================================================================
+# Test Fixtures and Cases
+# ==============================================================================
+
+
+@pytest.fixture(scope="module")
+def params():
+    """Provides a dictionary of common parameters for tests."""
+    # Set a fixed seed for reproducibility
+    torch.manual_seed(0)
+    np.random.seed(0)
+    return {
+        "batch_size": 4,
+        "seq_len": 16,
+        "in_dim": 64,
+        "hidden_dim": 128,
+        "drop_rate": 0.5,
+    }
+
+
+# --- Test Cases for Mlp ---
+def test_mlp_basic(params):
+    """🧪 Test Mlp: Basic case with specified dimensions."""
+    pt_mlp, keras_mlp = create_mlp_pair(
+        in_dim=params["in_dim"], hidden_features=params["hidden_dim"]
+    )
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_mlp(input_pt).detach().numpy()
+    output_keras = keras_mlp(jnp.array(input_pt.numpy()), training=False)
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_mlp_defaults(params):
+    """🧪 Test Mlp: Defaulting hidden and out features to input dimension."""
+    pt_mlp, keras_mlp = create_mlp_pair(in_dim=params["in_dim"])
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_mlp(input_pt).detach().numpy()
+    output_keras = keras_mlp(jnp.array(input_pt.numpy()), training=False)
+    assert output_keras.shape[-1] == params["in_dim"]
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_mlp_no_bias(params):
+    """🧪 Test Mlp: Operation without bias terms."""
+    pt_mlp, keras_mlp = create_mlp_pair(
+        in_dim=params["in_dim"], hidden_features=params["hidden_dim"], bias=False
+    )
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_mlp(input_pt).detach().numpy()
+    output_keras = keras_mlp(jnp.array(input_pt.numpy()), training=False)
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_mlp_dropout_inference(params):
+    """🧪 Test Mlp: Ensure dropout is handled correctly during inference."""
+    # Create models with a non-zero dropout rate
+    pt_mlp, keras_mlp = create_mlp_pair(
+        in_dim=params["in_dim"],
+        hidden_features=params["hidden_dim"],
+        drop=params["drop_rate"],
+    )
+
+    # Generate a random input tensor
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+
+    # Get the output from the PyTorch model (in eval mode, dropout is off)
+    output_pt = pt_mlp(input_pt).detach().numpy()
+
+    # Get the output from the Keras model with training=False to disable dropout
+    output_keras = keras_mlp(jnp.array(input_pt.numpy()), training=False)
+
+    # Assert that the outputs are nearly identical
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_mlp_with_pretrained_dinov3_weights(params):
+    """🧪 Test Mlp by loading real DINOv3 ViT-S/16 pretrained weights."""
+    try:
+        DINO_REPO_PATH = (
+            r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+        )
+        DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+
+        if not os.path.isdir(DINO_REPO_PATH) or not os.path.isfile(DINO_WEIGHT_PATH):
+            raise FileNotFoundError("DINOv3 repository or weight file not found.")
+
+        # Load the full DINOv3 model from the local repository
+        full_dinov3_model = torch.hub.load(
+            DINO_REPO_PATH, "dinov3_vits16", source="local", pretrained=False
+        )
+        state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+        full_dinov3_model.load_state_dict(state_dict)
+        full_dinov3_model.eval()
+
+        # Extract the first MLP block as the reference PyTorch model
+        torch_model = full_dinov3_model.blocks[0].mlp
+
+    except (FileNotFoundError, ModuleNotFoundError, ImportError, AttributeError) as e:
+        pytest.skip(
+            f"DINOv3 assets not found, skipping pretrained MLP test. Reason: {e}"
+        )
+
+    # Get model dimensions from the loaded torch model
+    dinov3_embed_dim = torch_model.fc1.in_features
+    dinov3_hidden_dim = torch_model.fc1.out_features
+
+    # Create the Keras model with a matching configuration
+    keras_model = Mlp(
+        hidden_features=dinov3_hidden_dim,
+        out_features=dinov3_embed_dim,
+        approximate_gelu=False,  # Use precise GELU to match PyTorch
+    )
+    # Build the Keras layer by calling it with a dummy input
+    keras_model(jnp.ones((1, 1, dinov3_embed_dim)))
+
+    # Transfer weights from the PyTorch layer to the Keras layer
+    keras_model.fc1.set_weights(
+        [
+            torch_model.fc1.weight.T.detach().numpy(),
+            torch_model.fc1.bias.detach().numpy(),
+        ]
+    )
+    keras_model.fc2.set_weights(
+        [
+            torch_model.fc2.weight.T.detach().numpy(),
+            torch_model.fc2.bias.detach().numpy(),
+        ]
+    )
+
+    # --- Run forward pass and compare outputs ---
+    input_tensor = torch.randn(
+        params["batch_size"], params["seq_len"], dinov3_embed_dim
+    )
+    output_pt = torch_model(input_tensor).detach().numpy()
+    output_keras = keras_model(jnp.array(input_tensor.numpy()), training=False)
+
+    # Calculate and validate the mean absolute difference
+    mean_abs_diff = np.mean(np.abs(output_pt - output_keras))
+    print(f"\nMean Absolute Difference: {mean_abs_diff}")
+
+    # Assert that the outputs are numerically very close
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-4)
+    assert (
+        mean_abs_diff < 1e-5
+    ), f"Mean absolute difference {mean_abs_diff} exceeds tolerance."
+
+
+# --- Test Cases for swiglu ---
+def test_swiglu_basic(params):
+    """🧪 Test SwiGLUFFN: Basic case with specified dimensions."""
+    pt_swiglu, keras_swiglu = create_swiglu_pair(
+        in_dim=params["in_dim"], hidden_features=params["hidden_dim"]
+    )
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_swiglu(input_pt).detach().numpy()
+    output_keras = keras_swiglu(jnp.array(input_pt.numpy()))
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_swiglu_defaults(params):
+    """🧪 Test SwiGLUFFN: Defaulting hidden and out features to input dimension."""
+    pt_swiglu, keras_swiglu = create_swiglu_pair(in_dim=params["in_dim"])
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_swiglu(input_pt).detach().numpy()
+    output_keras = keras_swiglu(jnp.array(input_pt.numpy()))
+    assert output_keras.shape[-1] == params["in_dim"]
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_swiglu_no_bias(params):
+    """🧪 Test SwiGLUFFN: Operation without bias terms."""
+    pt_swiglu, keras_swiglu = create_swiglu_pair(
+        in_dim=params["in_dim"], hidden_features=params["hidden_dim"], bias=False
+    )
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_swiglu(input_pt).detach().numpy()
+    output_keras = keras_swiglu(jnp.array(input_pt.numpy()))
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_swiglu_alignment(params):
+    """🧪 Test SwiGLUFFN: Non-default alignment value."""
+    pt_swiglu, keras_swiglu = create_swiglu_pair(
+        in_dim=params["in_dim"], hidden_features=params["hidden_dim"], align_to=16
+    )
+    input_pt = torch.randn(params["batch_size"], params["seq_len"], params["in_dim"])
+    output_pt = pt_swiglu(input_pt).detach().numpy()
+    output_keras = keras_swiglu(jnp.array(input_pt.numpy()))
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+def test_swiglu_with_pretrained_dinov3_weights(params):
+    """🧪 Test SwiGLUFFN with mock DINOv3 ViT-S/16 pretrained weights."""
+    dinov3_embed_dim = 384
+    dinov3_hidden_dim = 1536  # DINOv3 ViT-S uses an FFN size of 1536
+
+    # 1. Create mock pre-trained weights using the PyTorch layer's structure
+    torch_model_for_weights = PT_SwiGLUFFN(
+        in_features=dinov3_embed_dim, hidden_features=dinov3_hidden_dim
+    )
+    mock_weights = torch_model_for_weights.state_dict()
+
+    # 2. Configure the actual PyTorch model and load weights
+    torch_model = PT_SwiGLUFFN(
+        in_features=dinov3_embed_dim, hidden_features=dinov3_hidden_dim
+    )
+    torch_model.load_state_dict(mock_weights)
+    torch_model.eval()
+
+    keras_model = SwiGLUFFN(
+        hidden_features=dinov3_hidden_dim, out_features=dinov3_embed_dim
+    )
+    keras_model(jnp.ones((1, 1, dinov3_embed_dim)))
+    keras_model.w1.set_weights(
+        [mock_weights["w1.weight"].T.numpy(), mock_weights["w1.bias"].numpy()]
+    )
+    keras_model.w2.set_weights(
+        [mock_weights["w2.weight"].T.numpy(), mock_weights["w2.bias"].numpy()]
+    )
+    keras_model.w3.set_weights(
+        [mock_weights["w3.weight"].T.numpy(), mock_weights["w3.bias"].numpy()]
+    )
+
+    input_tensor = torch.randn(
+        params["batch_size"], params["seq_len"], dinov3_embed_dim
+    )
+    output_pt = torch_model(input_tensor).detach().numpy()
+    output_keras = keras_model(jnp.array(input_tensor.numpy()))
+    np.testing.assert_allclose(output_pt, output_keras, atol=1e-6)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/layer_scale.py
+++ b/paz/models/foundation/dinov3/layers/layer_scale.py
@@ -1,0 +1,33 @@
+import keras
+import keras.ops as ops
+
+
+class LayerScale(keras.layers.Layer):
+    def __init__(
+        self, dimension, init_values=1e-5, inplace=False, data_type=None, **kwargs
+    ):
+        super().__init__(dtype=data_type, **kwargs)
+        self.dimension = dimension
+        self.init_values = init_values
+        self.inplace = inplace
+
+        self.gamma = self.add_weight(
+            name="gamma",
+            shape=(self.dimension,),
+            initializer=keras.initializers.Constant(self.init_values),
+            trainable=True,
+        )
+
+    def call(self, x):
+        return ops.multiply(x, self.gamma)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "dimension": self.dimension,
+                "init_values": self.init_values,
+                "inplace": self.inplace,
+            }
+        )
+        return config

--- a/paz/models/foundation/dinov3/layers/layer_scale_test.py
+++ b/paz/models/foundation/dinov3/layers/layer_scale_test.py
@@ -1,0 +1,180 @@
+import os
+import sys
+import pytest
+import torch
+import numpy as np
+
+os.environ["KERAS_BACKEND"] = "jax"
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.layer_scale import LayerScale
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import PT_LayerScale
+
+
+# ==============================================================================
+# Helper Functions and Fixtures
+# ==============================================================================
+def port_weights(torch_model, keras_model):
+    """Copies the gamma weight from the PyTorch model to the Keras model."""
+    keras_model.gamma.assign(torch_model.gamma.detach().cpu().numpy())
+
+
+# ==============================================================================
+# Test Suite for LayerScale
+# ==============================================================================
+
+
+# --- Pytest Fixtures ---
+@pytest.fixture(scope="module")
+def params():
+    """Provides common parameters for the tests and sets random seeds."""
+    torch.manual_seed(0)
+    np.random.seed(0)
+    return {"DIM": 128, "BATCH": 4, "SEQ_LEN": 64}
+
+
+# --- Test Cases ---
+def test_basic_functionality(params):
+    """Tests if the Keras LayerScale output matches the PyTorch equivalent."""
+    # 1. Initialize models
+    torch_ls = PT_LayerScale(params["DIM"], init_values=1e-5)
+    keras_ls = LayerScale(params["DIM"], init_values=1e-5)
+
+    # 2. Prepare input tensors
+    x_torch = torch.rand(params["BATCH"], params["DIM"])
+    x_keras = x_torch.cpu().numpy()
+
+    # 3. Build Keras layer and port weights for consistency
+    _ = keras_ls(x_keras)
+    port_weights(torch_ls, keras_ls)
+
+    # 4. Get and compare outputs
+    torch_out = torch_ls(x_torch).detach().cpu().numpy()
+    keras_out = keras_ls(x_keras)
+
+    np.testing.assert_allclose(
+        torch_out, keras_out, atol=1e-7, err_msg="Basic functionality test failed."
+    )
+
+
+def test_non_default_initialization(params):
+    """Tests the layers with a non-default initial value."""
+    init_val = 0.1
+    torch_ls = PT_LayerScale(params["DIM"], init_values=init_val)
+    keras_ls = LayerScale(params["DIM"], init_values=init_val)
+
+    x_torch = torch.rand(params["BATCH"], params["DIM"])
+    x_keras = x_torch.cpu().numpy()
+
+    _ = keras_ls(x_keras)
+    port_weights(torch_ls, keras_ls)
+
+    torch_out = torch_ls(x_torch).detach().cpu().numpy()
+    keras_out = keras_ls(x_keras)
+
+    np.testing.assert_allclose(
+        torch_out,
+        keras_out,
+        atol=1e-5,
+        err_msg="Non-default initialization test failed.",
+    )
+
+
+def test_3d_input_broadcasting(params):
+    """Tests if the layer correctly broadcasts the gamma weight over a 3D input."""
+    torch_ls = PT_LayerScale(params["DIM"])
+    keras_ls = LayerScale(params["DIM"])
+
+    x_torch = torch.rand(params["BATCH"], params["SEQ_LEN"], params["DIM"])
+    x_keras = x_torch.cpu().numpy()
+
+    _ = keras_ls(x_keras)
+    port_weights(torch_ls, keras_ls)
+
+    torch_out = torch_ls(x_torch).detach().cpu().numpy()
+    keras_out = keras_ls(x_keras)
+
+    np.testing.assert_allclose(
+        torch_out, keras_out, atol=1e-7, err_msg="3D input broadcasting test failed."
+    )
+
+
+def test_keras_trainability(params):
+    """Verifies that the gamma variable is the only trainable weight."""
+    keras_ls = LayerScale(params["DIM"])
+    _ = keras_ls(np.zeros((1, params["DIM"])))
+
+    assert (
+        len(keras_ls.trainable_weights) == 1
+    ), f"Expected 1 trainable weight, found {len(keras_ls.trainable_weights)}"
+    assert keras_ls.trainable_weights[0].name.startswith(
+        "gamma"
+    ), f"Trainable weight name should be 'gamma', but got '{keras_ls.trainable_weights[0].name}'"
+
+
+# --- DINOv3 Pre-trained Weights Test ---
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+dinov3_files_exist = os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)
+
+
+@pytest.mark.skipif(
+    not dinov3_files_exist, reason="DINOv3 local model/weight files not found."
+)
+def test_dinov3_pretrained_weights_match(params):
+    """
+    Tests LayerScale by loading weights from a pre-trained DINOv3 model
+    and verifying the outputs match the original PyTorch layer.
+    """
+    # 1. Load the full pre-trained DINOv3 model
+    dinov3_model = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model.eval()
+
+    # 2. Extract a real LayerScale module from the first block
+    torch_pretrained_ls = dinov3_model.blocks[0].ls1
+    PRETRAINED_DIM = torch_pretrained_ls.gamma.shape[0]
+
+    # 3. Initialize the Keras layer
+    keras_ls_pretrained = LayerScale(dimension=PRETRAINED_DIM)
+
+    # 4. Prepare a matching random input
+    x_torch_pretrained = torch.rand(params["BATCH"], params["SEQ_LEN"], PRETRAINED_DIM)
+    x_keras_pretrained = x_torch_pretrained.cpu().numpy()
+
+    # 5. Build Keras layer and port the pre-trained weights
+    _ = keras_ls_pretrained(x_keras_pretrained)
+    port_weights(torch_pretrained_ls, keras_ls_pretrained)
+
+    # 6. Get outputs and compare
+    torch_out_pretrained = (
+        torch_pretrained_ls(x_torch_pretrained).detach().cpu().numpy()
+    )
+    keras_out_pretrained = keras_ls_pretrained(x_keras_pretrained)
+
+    np.testing.assert_allclose(
+        torch_out_pretrained,
+        keras_out_pretrained,
+        atol=1e-6,
+        err_msg="Pre-trained DINOv3 weights test failed.",
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/patch_embed.py
+++ b/paz/models/foundation/dinov3/layers/patch_embed.py
@@ -1,0 +1,55 @@
+from keras.layers import Conv2D, Identity
+import keras
+
+
+def make_2tuple(x):
+    if isinstance(x, (list, tuple)):
+        assert len(x) == 2, f"Expected tuple of length 2, but got {len(x)}"
+        return tuple(x)
+    assert isinstance(x, int), f"Expected int or tuple, but got {type(x)}"
+    return (x, x)
+
+
+class PatchEmbed(keras.layers.Layer):
+    def __init__(
+        self,
+        img_size=224,
+        patch_size=16,
+        in_channels=3,
+        embed_dim=768,
+        norm_layer=None,
+        flatten_embedding=True,
+        use_bias=True,
+        **kwargs,
+    ):
+        kwargs.pop("in_chans", None)
+        super().__init__(**kwargs)
+        self.img_size = make_2tuple(img_size)
+        self.patch_size = make_2tuple(patch_size)
+        self.in_channels = in_channels
+        self.embed_dim = embed_dim
+        self.flatten_embedding = flatten_embedding
+        self.grid_size = (
+            self.img_size[0] // self.patch_size[0],
+            self.img_size[1] // self.patch_size[1],
+        )
+        self.num_patches = self.grid_size[0] * self.grid_size[1]
+
+        self.projection = Conv2D(
+            filters=self.embed_dim,
+            kernel_size=self.patch_size,
+            strides=self.patch_size,
+            padding="valid",
+            use_bias=use_bias,
+            name="projection",
+        )
+        self.norm = norm_layer(name="norm") if norm_layer else Identity()
+
+    def call(self, x):
+        x = self.projection(x)
+        B, H_new, W_new, C_new = keras.ops.shape(x)
+        x = keras.ops.reshape(x, (B, H_new * W_new, C_new))
+        x = self.norm(x)
+        if not self.flatten_embedding:
+            x = keras.ops.reshape(x, (B, H_new, W_new, C_new))
+        return x

--- a/paz/models/foundation/dinov3/layers/patch_embed_test.py
+++ b/paz/models/foundation/dinov3/layers/patch_embed_test.py
@@ -1,0 +1,233 @@
+import os
+import sys
+import pytest
+import torch
+import numpy as np
+
+os.environ["KERAS_BACKEND"] = "jax"
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from keras.layers import LayerNormalization
+
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.patch_embed import PatchEmbed
+
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import PT_PatchEmbed
+
+
+# ==============================================================================
+# Test Suite for PatchEmbed Layer
+# ==============================================================================
+
+# --- Helper Functions ---
+def port_weights(torch_model, keras_model):
+    """Port weights from PyTorch PatchEmbed to Keras PatchEmbed."""
+    # Port convolution weights (OIHW -> HWIO)
+    torch_kernel = torch_model.proj.weight.detach().cpu().numpy()
+    keras_model.projection.kernel.assign(np.transpose(torch_kernel, (2, 3, 1, 0)))
+
+    # Port convolution bias if it exists
+    if torch_model.proj.bias is not None:
+        keras_model.projection.bias.assign(torch_model.proj.bias.detach().cpu().numpy())
+
+    # Port LayerNorm weights if it's not an Identity layer
+    if isinstance(torch_model.norm, nn.LayerNorm):
+        keras_model.norm.gamma.assign(torch_model.norm.weight.detach().cpu().numpy())
+        keras_model.norm.beta.assign(torch_model.norm.bias.detach().cpu().numpy())
+
+
+# --- Pytest Fixtures ---
+@pytest.fixture(scope="module")
+def params():
+    """Provides common parameters and sets random seeds."""
+    torch.manual_seed(0)
+    np.random.seed(0)
+    return {
+        "IMG_SIZE": 224,
+        "PATCH_SIZE": 16,
+        "IN_CHANNELS": 3,
+        "EMBED_DIM": 384,
+        "BATCH_SIZE": 4,
+    }
+
+
+@pytest.fixture
+def input_data(params):
+    """Generates matching numpy (Keras) and torch input tensors."""
+    p = params
+    # Keras input: (B, H, W, C)
+    keras_input = np.random.rand(
+        p["BATCH_SIZE"], p["IMG_SIZE"], p["IMG_SIZE"], p["IN_CHANNELS"]
+    ).astype("float32")
+    # PyTorch input: (B, C, H, W)
+    torch_input = torch.from_numpy(np.transpose(keras_input, (0, 3, 1, 2)))
+    return keras_input, torch_input
+
+
+# --- Test Cases ---
+def test_basic_functionality(params, input_data):
+    """Tests the PatchEmbed layer without Layer Normalization."""
+    p = params
+    keras_in, torch_in = input_data
+
+    # Initialize models
+    torch_pe = PT_PatchEmbed(
+        p["IMG_SIZE"], p["PATCH_SIZE"], p["IN_CHANNELS"], p["EMBED_DIM"]
+    )
+    keras_pe = PatchEmbed(
+        p["IMG_SIZE"], p["PATCH_SIZE"], p["IN_CHANNELS"], p["EMBED_DIM"]
+    )
+
+    # Build Keras layer and port weights
+    _ = keras_pe(keras_in)
+    port_weights(torch_pe, keras_pe)
+
+    # Compare outputs
+    torch_out = torch_pe(torch_in).detach().cpu().numpy()
+    keras_out = np.array(keras_pe(keras_in))
+
+    np.testing.assert_allclose(torch_out, keras_out, atol=1e-5)
+
+
+def test_with_layer_normalization(params, input_data):
+    """Tests the PatchEmbed layer with Layer Normalization."""
+    p = params
+    keras_in, torch_in = input_data
+
+    # Initialize models with LayerNorm
+    torch_pe = PT_PatchEmbed(
+        p["IMG_SIZE"],
+        p["PATCH_SIZE"],
+        p["IN_CHANNELS"],
+        p["EMBED_DIM"],
+        norm_layer=nn.LayerNorm,
+    )
+    keras_pe = PatchEmbed(
+        p["IMG_SIZE"],
+        p["PATCH_SIZE"],
+        p["IN_CHANNELS"],
+        p["EMBED_DIM"],
+        norm_layer=lambda **kwargs: LayerNormalization(epsilon=1e-5, **kwargs),
+    )
+
+    _ = keras_pe(keras_in)
+    port_weights(torch_pe, keras_pe)
+
+    torch_out = torch_pe(torch_in).detach().cpu().numpy()
+    keras_out = np.array(keras_pe(keras_in))
+
+    np.testing.assert_allclose(torch_out, keras_out, atol=1e-5)
+
+
+def test_flatten_embedding_false(params, input_data):
+    """Tests the layer's output shape when flatten_embedding is False."""
+    p = params
+    keras_in, torch_in = input_data
+
+    torch_pe = PT_PatchEmbed(
+        p["IMG_SIZE"],
+        p["PATCH_SIZE"],
+        p["IN_CHANNELS"],
+        p["EMBED_DIM"],
+        flatten_embedding=False,
+    )
+    keras_pe = PatchEmbed(
+        p["IMG_SIZE"],
+        p["PATCH_SIZE"],
+        p["IN_CHANNELS"],
+        p["EMBED_DIM"],
+        flatten_embedding=False,
+    )
+
+    _ = keras_pe(keras_in)
+    port_weights(torch_pe, keras_pe)
+
+    torch_out = torch_pe(torch_in).detach().cpu().numpy()
+    keras_out = np.array(keras_pe(keras_in))
+
+    # Check shape: (B, H_new, W_new, C_new)
+    expected_h = p["IMG_SIZE"] // p["PATCH_SIZE"]
+    expected_w = p["IMG_SIZE"] // p["PATCH_SIZE"]
+    assert keras_out.shape == (p["BATCH_SIZE"], expected_h, expected_w, p["EMBED_DIM"])
+    np.testing.assert_allclose(torch_out, keras_out, atol=1e-5)
+
+
+# --- DINOv3 Pre-trained Weights Test ---
+
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+dinov3_files_exist = os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)
+
+
+@pytest.mark.skipif(
+    not dinov3_files_exist, reason="DINOv3 local model/weight files not found."
+)
+def test_dinov3_pretrained_weights_match(params):
+    """Tests the layer by loading weights from a pre-trained DINOv3 model."""
+    # 1. Load the pre-trained DINOv3 model
+    dinov3_model = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model.eval()
+    torch_pretrained_pe = dinov3_model.patch_embed
+
+    # 2. Configure the Keras layer to match the pre-trained model
+    conv_has_bias = torch_pretrained_pe.proj.bias is not None
+    keras_norm_layer = None
+    if isinstance(torch_pretrained_pe.norm, nn.LayerNorm):
+        epsilon = torch_pretrained_pe.norm.eps
+        keras_norm_layer = lambda **kwargs: LayerNormalization(
+            epsilon=epsilon, **kwargs
+        )
+
+    keras_pe_pretrained = PatchEmbed(
+        img_size=torch_pretrained_pe.img_size,
+        patch_size=torch_pretrained_pe.patch_size,
+        in_channels=torch_pretrained_pe.in_chans,
+        embed_dim=torch_pretrained_pe.embed_dim,
+        norm_layer=keras_norm_layer,
+        flatten_embedding=torch_pretrained_pe.flatten_embedding,
+        use_bias=conv_has_bias,
+    )
+
+    # 3. Create identical random input data
+    img_h, img_w = torch_pretrained_pe.img_size
+    x_keras_pretrained = np.random.rand(
+        params["BATCH_SIZE"], img_h, img_w, torch_pretrained_pe.in_chans
+    ).astype("float32")
+    x_torch_pretrained = torch.from_numpy(
+        np.transpose(x_keras_pretrained, (0, 3, 1, 2))
+    )
+
+    # 4. Build Keras model, port weights, and compare outputs
+    _ = keras_pe_pretrained(x_keras_pretrained)
+    port_weights(torch_pretrained_pe, keras_pe_pretrained)
+
+    torch_out = torch_pretrained_pe(x_torch_pretrained).detach().cpu().numpy()
+    keras_out = np.array(keras_pe_pretrained(x_keras_pretrained))
+
+    np.testing.assert_allclose(
+        torch_out,
+        keras_out,
+        atol=1e-5,
+        err_msg="Final outputs with DINOv3 weights do not match.",
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/rms_norm.py
+++ b/paz/models/foundation/dinov3/layers/rms_norm.py
@@ -1,0 +1,34 @@
+import keras
+from keras import ops
+
+
+@keras.saving.register_keras_serializable()
+class RMSNorm(keras.Layer):
+    def __init__(self, epsilon: float = 1e-5, **kwargs):
+        super().__init__(**kwargs)
+        self.epsilon = epsilon
+
+    def build(self, input_shape):
+        dim = input_shape[-1]
+        self.weight = self.add_weight(
+            shape=(dim,),
+            initializer="ones",
+            trainable=True,
+            name="weight",
+        )
+        super().build(input_shape)
+
+    def call(self, x):
+        x_dtype = x.dtype
+        x_f32 = ops.cast(x, "float32")
+
+        variance = ops.mean(ops.square(x_f32), axis=-1, keepdims=True)
+        norm_x = x_f32 * ops.rsqrt(variance + self.epsilon)
+
+        norm_x = ops.cast(norm_x, x_dtype)
+        return norm_x * self.weight
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"epsilon": self.epsilon})
+        return config

--- a/paz/models/foundation/dinov3/layers/rms_norm_test.py
+++ b/paz/models/foundation/dinov3/layers/rms_norm_test.py
@@ -1,0 +1,207 @@
+import os
+import sys
+
+os.environ["KERAS_BACKEND"] = "jax"
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import pytest
+import numpy as np
+import jax
+import keras
+import torch
+from keras import ops
+
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.rms_norm import RMSNorm
+
+# ==============================================================================
+# PyTorch Reference Implementation (unchangeable)
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import PT_RMSNorm
+
+# ==============================================================================
+# Test Suite
+# ==============================================================================
+
+
+@pytest.fixture
+def params():
+    """Provides common parameters for tests."""
+    return {
+        "dim": 128,
+        "batch_size": 4,
+        "seq_len": 64,
+        "epsilon": 1e-5,
+    }
+
+
+def run_and_compare(keras_model, torch_model, input_np, atol=1e-5):
+    """Helper function to execute models and assert closeness."""
+    # Keras/JAX execution
+    output_keras = keras_model(input_np)
+    output_keras_np = np.array(output_keras)
+
+    # PyTorch execution
+    input_torch = torch.from_numpy(input_np)
+    output_torch = torch_model(input_torch)
+    output_torch_np = output_torch.detach().numpy()
+
+    # Compare shapes and values
+    assert output_keras_np.shape == output_torch_np.shape
+    np.testing.assert_allclose(output_keras_np, output_torch_np, atol=atol)
+    return output_keras_np, output_torch_np
+
+
+# === Main Equivalence Tests ===
+
+
+def test_basic_equivalence(params):
+    """Tests if outputs are identical for a standard float32 input."""
+    shape = (params["batch_size"], params["seq_len"], params["dim"])
+    input_np = np.random.rand(*shape).astype("float32")
+
+    keras_model = RMSNorm(epsilon=params["epsilon"])
+    torch_model = PT_RMSNorm(dim=params["dim"], eps=params["epsilon"])
+
+    run_and_compare(keras_model, torch_model, input_np)
+
+
+@pytest.mark.parametrize(
+    "shape_params",
+    [
+        (128,),
+        (16, 64),
+        (4, 10, 32),
+        (2, 8, 8, 16),
+    ],
+)
+def test_different_shapes(shape_params):
+    """Tests equivalence across various input tensor shapes."""
+    dim = shape_params[-1]
+    input_np = np.random.rand(*shape_params).astype("float32")
+    keras_model = RMSNorm()
+    torch_model = PT_RMSNorm(dim=dim)
+    run_and_compare(keras_model, torch_model, input_np)
+
+
+def test_gradients(params):
+    """Ensures the backward pass (gradients) is also equivalent."""
+    shape = (params["batch_size"], params["dim"])
+    input_np = np.random.rand(*shape).astype("float32")
+    downstream_grad_np = np.random.rand(*shape).astype("float32")
+
+    # PyTorch Gradients
+    torch_model = PT_RMSNorm(dim=params["dim"])
+    torch_model.train()
+    input_torch = torch.from_numpy(input_np)
+    output_torch = torch_model(input_torch)
+    output_torch.backward(gradient=torch.from_numpy(downstream_grad_np))
+    grad_torch = torch_model.weight.grad.numpy()
+
+    # Keras/JAX Gradients
+    keras_model = RMSNorm(epsilon=params["epsilon"])
+    keras_model.build(input_np.shape)
+
+    def get_loss(trainable_weights):
+        temp_keras_model = RMSNorm(epsilon=params["epsilon"])
+        temp_keras_model.build(input_np.shape)
+        temp_keras_model.set_weights(trainable_weights)
+        output = temp_keras_model(input_np)
+        return ops.sum(output * downstream_grad_np)
+
+    grad_fn = jax.grad(get_loss)
+    grad_jax_list = grad_fn(keras_model.trainable_weights)
+    grad_jax = grad_jax_list[0]
+
+    np.testing.assert_allclose(np.array(grad_jax), grad_torch, atol=1e-5)
+
+
+# === Edge Case Tests ===
+
+
+def test_zero_input(params):
+    """Tests that an all-zero input produces an all-zero output."""
+    shape = (params["batch_size"], params["dim"])
+    input_np = np.zeros(shape, dtype="float32")
+    keras_model = RMSNorm(epsilon=params["epsilon"])
+    torch_model = PT_RMSNorm(dim=params["dim"], eps=params["epsilon"])
+    output_keras, _ = run_and_compare(keras_model, torch_model, input_np)
+    assert not np.any(output_keras)
+
+
+def test_nan_propagation(params):
+    """Tests if NaN in the input correctly propagates to the output."""
+    shape = (params["batch_size"], params["dim"])
+    input_np = np.random.rand(*shape).astype("float32")
+    input_np[0, 5] = np.nan
+
+    keras_model = RMSNorm(epsilon=params["epsilon"])
+    torch_model = PT_RMSNorm(dim=params["dim"], eps=params["epsilon"])
+
+    output_keras = np.array(keras_model(input_np))
+    output_torch = torch_model(torch.from_numpy(input_np)).detach().numpy()
+
+    assert np.isnan(output_keras[0, 5])
+    assert np.isnan(output_torch[0, 5])
+
+
+# === Pre-trained Weights Tests ===
+
+# Define paths to local model files. Update these to match your system.
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+dinov3_files_exist = os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)
+
+
+@pytest.mark.skipif(
+    not dinov3_files_exist, reason="DINOv3 local model/weight files not found."
+)
+def test_dinov3_real_pretrained_weights(params):
+    """
+    Tests equivalence by loading ACTUAL pre-trained weights from a DINOv3
+    model file and comparing outputs.
+    """
+    # 1. Load the pre-trained DINOv3 model from local source
+    dinov3_model = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model.eval()
+
+    # 2. Extract the real LayerNorm layer and its parameters
+    torch_pretrained_norm = dinov3_model.blocks[0].norm1
+    dino_dim = torch_pretrained_norm.weight.shape[0]
+    dino_eps = torch_pretrained_norm.eps
+
+    # 3. Use the built-in Keras LayerNormalization layer
+    keras_model = keras.layers.LayerNormalization(
+        epsilon=dino_eps,
+        # Ensure parameter names match for weight loading
+        gamma_initializer="ones",
+        beta_initializer="zeros",
+    )
+
+    # 4. Create matching random input data
+    shape = (params["batch_size"], params["seq_len"], dino_dim)
+    input_np = np.random.rand(*shape).astype("float32")
+
+    # 5. Build Keras layer and port the pre-trained weights
+    keras_model.build(input_np.shape)
+    pretrained_weight = torch_pretrained_norm.weight.detach().cpu().numpy()
+    pretrained_bias = torch_pretrained_norm.bias.detach().cpu().numpy()
+    keras_model.set_weights([pretrained_weight, pretrained_bias])
+
+    # 6. Run forward pass and compare outputs
+    run_and_compare(keras_model, torch_pretrained_norm, input_np, atol=1e-5)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/rope_position_encoding.py
+++ b/paz/models/foundation/dinov3/layers/rope_position_encoding.py
@@ -1,0 +1,176 @@
+import keras
+from keras import ops, random
+import math
+import numpy as np
+from keras.initializers import Initializer
+
+
+@keras.saving.register_keras_serializable(package="MyInitializers")
+class RopePeriodsInitializer(Initializer):
+    def __init__(self, D_head, base, min_period, max_period):
+        self.D_head = D_head
+        self.base = base
+        self.min_period = min_period
+        self.max_period = max_period
+
+    def __call__(self, shape, dtype=None):
+        dim_div_4 = self.D_head // 4
+        if self.base is not None:
+            arange_tensor = ops.arange(dim_div_4, dtype=dtype)
+            exponents = 2 * arange_tensor / (self.D_head // 2)
+            new_periods = ops.power(self.base, exponents)
+        else:
+            base = self.max_period / self.min_period
+            exponents = ops.linspace(0, 1, dim_div_4, dtype=dtype)
+            new_periods = ops.power(base, exponents)
+            new_periods = new_periods / base
+            new_periods = new_periods * self.max_period
+        return new_periods
+
+    def get_config(self):
+        return {
+            "D_head": self.D_head,
+            "base": self.base,
+            "min_period": self.min_period,
+            "max_period": self.max_period,
+        }
+
+
+class RopePositionEmbedding(keras.Layer):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        base: float | None = 100.0,
+        min_period: float | None = None,
+        max_period: float | None = None,
+        normalize_coords: str = "separate",
+        shift_coords: float | None = None,
+        jitter_coords: float | None = None,
+        rescale_coords: float | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        if not (embed_dim % (4 * num_heads) == 0):
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by 4 * num_heads ({4*num_heads})."
+            )
+
+        both_periods = min_period is not None and max_period is not None
+        if (base is None and not both_periods) or (base is not None and both_periods):
+            raise ValueError(
+                "Either `base` or `min_period`+`max_period` must be provided."
+            )
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.base = base
+        self.min_period = min_period
+        self.max_period = max_period
+        self.normalize_coords = normalize_coords
+        self.shift_coords = shift_coords
+        self.jitter_coords = jitter_coords
+        self.rescale_coords = rescale_coords
+        self.D_head = embed_dim // num_heads
+
+    def build(self, input_shape=None):
+        self.periods = self.add_weight(
+            shape=(self.D_head // 4,),
+            initializer=RopePeriodsInitializer(
+                self.D_head, self.base, self.min_period, self.max_period
+            ),
+            trainable=False,
+            name="periods",
+            dtype=self.dtype,
+        )
+        self._initialize_periods()
+        self.built = True
+
+    def _initialize_periods(self):
+        dim_div_4 = self.D_head // 4
+        if self.base is not None:
+            arange_tensor = ops.arange(dim_div_4, dtype=self.dtype)
+            exponents = 2 * arange_tensor / (self.D_head // 2)
+            new_periods = ops.power(self.base, exponents)
+        else:
+            base = self.max_period / self.min_period
+            exponents = ops.linspace(0, 1, dim_div_4, dtype=self.dtype)
+            new_periods = ops.power(base, exponents)
+            new_periods = new_periods / base
+            new_periods = new_periods * self.max_period
+        self.periods.assign(new_periods)
+
+    def call(self, H: int, W: int, training: bool = False):
+        coords_h_int = ops.arange(H, dtype="int32")
+        coords_w_int = ops.arange(W, dtype="int32")
+        coords_h = ops.cast(coords_h_int, dtype=self.dtype) + 0.5
+        coords_w = ops.cast(coords_w_int, dtype=self.dtype) + 0.5
+        if self.normalize_coords == "max":
+            max_HW = max(H, W)
+            coords_h = coords_h / max_HW
+            coords_w = coords_w / max_HW
+        elif self.normalize_coords == "min":
+            min_HW = min(H, W)
+            coords_h = coords_h / min_HW
+            coords_w = coords_w / min_HW
+        elif self.normalize_coords == "separate":
+            coords_h = coords_h / H
+            coords_w = coords_w / W
+        else:
+            raise ValueError(f"Unknown normalize_coords: {self.normalize_coords}")
+        grid_h, grid_w = ops.meshgrid(coords_h, coords_w, indexing="ij")
+        coords = ops.stack([grid_h, grid_w], axis=-1)
+        coords = ops.reshape(coords, (-1, 2))
+        coords = 2.0 * coords - 1.0
+        if training and self.shift_coords is not None:
+            shift_hw = random.uniform(
+                (2,),
+                minval=-self.shift_coords,
+                maxval=self.shift_coords,
+                dtype=self.dtype,
+            )
+            coords += shift_hw
+        if training and self.jitter_coords is not None:
+            jitter_max = math.log(self.jitter_coords)
+            jitter_min = -jitter_max
+            log_jitter = random.uniform(
+                (2,), minval=jitter_min, maxval=jitter_max, dtype=self.dtype
+            )
+            coords *= ops.exp(log_jitter)
+        if training and self.rescale_coords is not None:
+            rescale_max = math.log(self.rescale_coords)
+            rescale_min = -rescale_max
+            log_rescale = random.uniform(
+                (1,), minval=rescale_min, maxval=rescale_max, dtype=self.dtype
+            )
+            coords *= ops.exp(log_rescale)
+
+        coords = ops.expand_dims(coords, axis=-1)
+        periods_exp = ops.expand_dims(ops.expand_dims(self.periods, axis=0), axis=0)
+
+        angles = 2.0 * math.pi * coords / periods_exp
+
+        angles = ops.reshape(angles, (-1, self.D_head // 2))
+        angles = ops.tile(angles, [1, 2])
+
+        cos = ops.cos(angles)
+        sin = ops.sin(angles)
+        return (sin, cos)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "embed_dim": self.embed_dim,
+                "num_heads": self.num_heads,
+                "base": self.base,
+                "min_period": self.min_period,
+                "max_period": self.max_period,
+                "normalize_coords": self.normalize_coords,
+                "shift_coords": self.shift_coords,
+                "jitter_coords": self.jitter_coords,
+                "rescale_coords": self.rescale_coords,
+            }
+        )
+        return config

--- a/paz/models/foundation/dinov3/layers/rope_position_encoding_test.py
+++ b/paz/models/foundation/dinov3/layers/rope_position_encoding_test.py
@@ -1,0 +1,206 @@
+import os
+import sys
+
+os.environ["KERAS_BACKEND"] = "jax"
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import torch
+import pytest
+import numpy as np
+
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.rope_position_encoding import (
+    RopePositionEmbedding,
+)
+
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import (
+    PT_RopePositionEmbedding,
+)
+
+
+# ==============================================================================
+# Test fixtures, helper, and test cases functions
+# ==============================================================================
+@pytest.fixture
+def params():
+    """Provides common parameters for tests."""
+    return {
+        "embed_dim": 256,
+        "num_heads": 8,
+        "H": 32,
+        "W": 24,
+    }
+
+
+def run_and_compare(keras_model, torch_model, H, W, training, atol=1e-5):
+    """Helper function to execute models and assert closeness."""
+    # Set training mode for PyTorch model
+    torch_model.train(training)
+
+    # PyTorch execution
+    sin_torch, cos_torch = torch_model(H=H, W=W)
+    sin_torch_np = sin_torch.detach().cpu().numpy()
+    cos_torch_np = cos_torch.detach().cpu().numpy()
+
+    # Keras execution - Pass the training flag here
+    sin_keras, cos_keras = keras_model(H=H, W=W, training=training)
+    sin_keras_np = np.array(sin_keras)
+    cos_keras_np = np.array(cos_keras)
+
+    # Compare shapes and values
+    assert sin_keras_np.shape == sin_torch_np.shape
+    assert cos_keras_np.shape == cos_torch_np.shape
+    np.testing.assert_allclose(sin_keras_np, sin_torch_np, atol=atol)
+    np.testing.assert_allclose(cos_keras_np, cos_torch_np, atol=atol)
+
+
+def test_base_parametrization(params):
+    """Tests equivalence when using the `base` parameter."""
+    torch.manual_seed(0)
+    torch_model = PT_RopePositionEmbedding(
+        embed_dim=params["embed_dim"],
+        num_heads=params["num_heads"],
+        base=100.0,
+        dtype=torch.float32,
+    )
+    keras_model = RopePositionEmbedding(
+        embed_dim=params["embed_dim"],
+        num_heads=params["num_heads"],
+        base=100.0,
+        dtype="float32",
+    )
+    run_and_compare(keras_model, torch_model, params["H"], params["W"], training=False)
+
+
+def test_period_parametrization(params):
+    """Tests equivalence when using `min_period` and `max_period`."""
+    torch.manual_seed(0)
+    torch_model = PT_RopePositionEmbedding(
+        embed_dim=params["embed_dim"],
+        num_heads=params["num_heads"],
+        base=None,
+        min_period=1.0,
+        max_period=100.0,
+        dtype=torch.float32,
+    )
+    keras_model = RopePositionEmbedding(
+        embed_dim=params["embed_dim"],
+        num_heads=params["num_heads"],
+        base=None,
+        min_period=1.0,
+        max_period=100.0,
+        dtype="float32",
+    )
+    run_and_compare(keras_model, torch_model, params["H"], params["W"], training=False)
+
+
+@pytest.mark.parametrize("normalize", ["max", "min", "separate"])
+def test_normalize_coords(params, normalize):
+    """Tests all `normalize_coords` options."""
+    torch.manual_seed(0)
+    torch_model = PT_RopePositionEmbedding(
+        embed_dim=params["embed_dim"],
+        num_heads=params["num_heads"],
+        normalize_coords=normalize,
+        dtype=torch.float32,
+    )
+    keras_model = RopePositionEmbedding(
+        embed_dim=params["embed_dim"],
+        num_heads=params["num_heads"],
+        normalize_coords=normalize,
+        dtype="float32",
+    )
+    run_and_compare(keras_model, torch_model, params["H"], params["W"], training=False)
+
+
+def test_training_augmentations_are_different(params):
+    """
+    Tests that training mode produces different (randomized) outputs
+    compared to eval mode.
+    """
+    torch.manual_seed(42)
+    init_args = {
+        "embed_dim": params["embed_dim"],
+        "num_heads": params["num_heads"],
+        "shift_coords": 0.1,
+        "jitter_coords": 2.0,
+        "rescale_coords": 2.0,
+        "dtype": "float32",
+    }
+    torch_init_args = init_args.copy()
+    torch_init_args["dtype"] = torch.float32
+    keras_model = RopePositionEmbedding(**init_args)
+    torch_model = PT_RopePositionEmbedding(**torch_init_args)
+    sin_eval_keras, cos_eval_keras = keras_model(
+        H=params["H"], W=params["W"], training=False
+    )
+    sin_train_keras, cos_train_keras = keras_model(
+        H=params["H"], W=params["W"], training=True
+    )
+    assert not np.allclose(np.array(sin_eval_keras), np.array(sin_train_keras))
+    assert not np.allclose(np.array(cos_eval_keras), np.array(cos_train_keras))
+    torch_model.eval()
+    sin_eval_torch, cos_eval_torch = torch_model(H=params["H"], W=params["W"])
+    torch_model.train()
+    sin_train_torch, cos_train_torch = torch_model(H=params["H"], W=params["W"])
+    assert not np.allclose(sin_eval_torch.numpy(), sin_train_torch.numpy())
+    assert not np.allclose(cos_eval_torch.numpy(), cos_train_torch.numpy())
+    assert sin_train_keras.shape == sin_eval_keras.shape
+    assert cos_train_keras.shape == cos_eval_keras.shape
+
+
+DINO_REPO_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+dinov3_files_exist = os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)
+
+
+@pytest.mark.skipif(
+    not dinov3_files_exist, reason="DINOv3 local model/weight files not found."
+)
+def test_dinov3_real_pretrained_weights(params):
+    dinov3_model = torch.hub.load(
+        DINO_REPO_PATH, "dinov3_vits16", source="local", weights=DINO_WEIGHT_PATH
+    )
+    dinov3_model.eval()
+    torch_pretrained_rope = dinov3_model.rope_embed
+    dino_embed_dim = dinov3_model.embed_dim
+    dino_num_heads = dinov3_model.blocks[0].attn.num_heads
+    keras_model = RopePositionEmbedding(
+        embed_dim=dino_embed_dim,
+        num_heads=dino_num_heads,
+        base=torch_pretrained_rope.base,
+        min_period=torch_pretrained_rope.min_period,
+        max_period=torch_pretrained_rope.max_period,
+        normalize_coords=torch_pretrained_rope.normalize_coords,
+        shift_coords=torch_pretrained_rope.shift_coords,
+        jitter_coords=torch_pretrained_rope.jitter_coords,
+        rescale_coords=torch_pretrained_rope.rescale_coords,
+        dtype="float32",
+    )
+    keras_model.build(input_shape=None)
+    torch_periods_np = torch_pretrained_rope.periods.cpu().numpy()
+    keras_model.set_weights([torch_periods_np])
+    run_and_compare(
+        keras_model,
+        torch_pretrained_rope,
+        H=params["H"],
+        W=params["W"],
+        training=False,
+        atol=1e-5,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/layers/torch_layers_for_testing.py
+++ b/paz/models/foundation/dinov3/layers/torch_layers_for_testing.py
@@ -1,0 +1,790 @@
+import math
+import logging
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from typing import List, Tuple, Optional, Callable, Union, Literal
+from functools import partial
+import numpy as np
+
+
+def PT_cat_keep_shapes(
+    x_list: List[Tensor],
+) -> Tuple[Tensor, List[Tuple[int]], List[int]]:
+    shapes = [x.shape for x in x_list]
+    num_tokens = [x.select(dim=-1, index=0).numel() for x in x_list]
+    flattened = torch.cat([x.flatten(0, -2) for x in x_list])
+    return flattened, shapes, num_tokens
+
+
+def PT_uncat_with_shapes(
+    flattened: Tensor, shapes: List[Tuple[int]], num_tokens: List[int]
+) -> List[Tensor]:
+    outputs_splitted = torch.split_with_sizes(flattened, num_tokens, dim=0)
+    shapes_adjusted = [
+        shape[:-1] + torch.Size([flattened.shape[-1]]) for shape in shapes
+    ]
+    outputs_reshaped = [
+        o.reshape(shape) for o, shape in zip(outputs_splitted, shapes_adjusted)
+    ]
+    return outputs_reshaped
+
+
+def PT_rope_rotate_half(x: Tensor) -> Tensor:
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat([-x2, x1], dim=-1)
+
+
+def PT_rope_apply(x: Tensor, sin: Tensor, cos: Tensor) -> Tensor:
+    return (x * cos) + (PT_rope_rotate_half(x) * sin)
+
+
+class PT_LinearKMaskedBias(nn.Linear):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        o = self.out_features
+        assert o % 3 == 0
+        if self.bias is not None:
+            self.register_buffer(
+                "bias_mask", torch.full_like(self.bias, fill_value=math.nan)
+            )
+
+    def forward(self, input: Tensor) -> Tensor:
+        masked_bias = (
+            self.bias * self.bias_mask.to(self.bias.dtype)
+            if self.bias is not None
+            else None
+        )
+        return F.linear(input, self.weight, masked_bias)
+
+
+class PT_SelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        mask_k_bias: bool = False,
+        device=None,
+    ) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = head_dim**-0.5
+
+        linear_class = PT_LinearKMaskedBias if mask_k_bias else nn.Linear
+        self.qkv = linear_class(dim, dim * 3, bias=qkv_bias, device=device)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim, bias=proj_bias, device=device)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def apply_rope(
+        self, q: Tensor, k: Tensor, rope: Tensor | Tuple[Tensor, Tensor]
+    ) -> Tuple[Tensor, Tensor]:
+        # All operations will use the dtype of rope, the output is cast back to the dtype of q and k
+        q_dtype = q.dtype
+        k_dtype = k.dtype
+        sin, cos = rope
+        rope_dtype = sin.dtype
+        q = q.to(dtype=rope_dtype)
+        k = k.to(dtype=rope_dtype)
+        N = q.shape[-2]
+        prefix = N - sin.shape[-2]
+        assert prefix >= 0
+        q_prefix = q[:, :, :prefix, :]
+        q = PT_rope_apply(q[:, :, prefix:, :], sin, cos)  # [B, head, hw, D//head]
+        q = torch.cat((q_prefix, q), dim=-2)  # [B, head, N, D//head]
+        k_prefix = k[:, :, :prefix, :]
+        k = PT_rope_apply(k[:, :, prefix:, :], sin, cos)  # [B, head, hw, D//head]
+        k = torch.cat((k_prefix, k), dim=-2)  # [B, head, N, D//head]
+        q = q.to(dtype=q_dtype)
+        k = k.to(dtype=k_dtype)
+        return q, k
+
+    def forward(self, x: Tensor, attn_bias=None, rope: Tensor = None) -> Tensor:
+        qkv = self.qkv(x)
+        attn_v = self.compute_attention(qkv=qkv, attn_bias=attn_bias, rope=rope)
+        x = self.proj(attn_v)
+        x = self.proj_drop(x)
+        return x
+
+    def forward_list(self, x_list, attn_bias=None, rope_list=None) -> List[Tensor]:
+        assert len(x_list) == len(rope_list)  # should be enforced by the Block
+        x_flat, shapes, num_tokens = PT_cat_keep_shapes(x_list)
+        qkv_flat = self.qkv(x_flat)
+        qkv_list = PT_uncat_with_shapes(qkv_flat, shapes, num_tokens)
+        att_out = []
+        for _, (qkv, _, rope) in enumerate(zip(qkv_list, shapes, rope_list)):
+            att_out.append(self.compute_attention(qkv, attn_bias=attn_bias, rope=rope))
+        x_flat, shapes, num_tokens = PT_cat_keep_shapes(att_out)
+        x_flat = self.proj(x_flat)
+        return PT_uncat_with_shapes(x_flat, shapes, num_tokens)
+
+    def compute_attention(self, qkv: Tensor, attn_bias=None, rope=None) -> Tensor:
+        assert attn_bias is None
+        B, N, _ = qkv.shape
+        C = self.qkv.in_features
+
+        qkv = qkv.reshape(B, N, 3, self.num_heads, C // self.num_heads)
+        q, k, v = torch.unbind(qkv, 2)
+        q, k, v = [t.transpose(1, 2) for t in [q, k, v]]
+        if rope is not None:
+            q, k = self.apply_rope(q, k, rope)
+        x = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        x = x.transpose(1, 2)
+        return x.reshape([B, N, C])
+
+
+class PT_CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = attn_drop
+        self.proj = nn.Linear(dim, dim, bias=proj_bias)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def init_weights(
+        self,
+        init_attn_std: float | None = None,
+        init_proj_std: float | None = None,
+        factor: float = 1.0,
+    ) -> None:
+        init_attn_std = init_attn_std or (self.dim**-0.5)
+        init_proj_std = init_proj_std or init_attn_std * factor
+        nn.init.normal_(self.qkv.weight, std=init_attn_std)
+        nn.init.normal_(self.proj.weight, std=init_proj_std)
+        if self.qkv.bias is not None:
+            nn.init.zeros_(self.qkv.bias)
+        if self.proj.bias is not None:
+            nn.init.zeros_(self.proj.bias)
+
+    def forward(self, x: Tensor, is_causal: bool = True) -> Tensor:
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads)
+        q, k, v = torch.unbind(qkv, 2)
+        q, k, v = [t.transpose(1, 2) for t in [q, k, v]]
+        x = torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=self.attn_drop if self.training else 0,
+            is_causal=is_causal,
+        )
+        x = x.transpose(1, 2).contiguous().view(B, N, C)
+        x = self.proj_drop(self.proj(x))
+        return x
+
+
+class PT_ListForwardMixin(object):
+    def forward(self, x: Tensor):
+        raise NotImplementedError
+
+    def forward_list(self, x_list: List[Tensor]) -> List[Tensor]:
+        x_flat, shapes, num_tokens = PT_cat_keep_shapes(x_list)
+        x_flat = self.forward(x_flat)
+        return PT_uncat_with_shapes(x_flat, shapes, num_tokens)
+
+
+class PT_Mlp(nn.Module, PT_ListForwardMixin):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        drop: float = 0.0,
+        bias: bool = True,
+        device=None,
+    ) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features, bias=bias, device=device)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features, bias=bias, device=device)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class PT_SwiGLUFFN(nn.Module, PT_ListForwardMixin):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: Optional[Callable[..., nn.Module]] = None,
+        drop: float = 0.0,
+        bias: bool = True,
+        align_to: int = 8,
+        device=None,
+    ) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        d = int(hidden_features * 2 / 3)
+        swiglu_hidden_features = d + (-d % align_to)
+        self.w1 = nn.Linear(
+            in_features, swiglu_hidden_features, bias=bias, device=device
+        )
+        self.w2 = nn.Linear(
+            in_features, swiglu_hidden_features, bias=bias, device=device
+        )
+        self.w3 = nn.Linear(
+            swiglu_hidden_features, out_features, bias=bias, device=device
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        x1 = self.w1(x)
+        x2 = self.w2(x)
+        hidden = F.silu(x1) * x2
+        return self.w3(hidden)
+
+
+class PT_LayerScale(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        init_values: Union[float, Tensor] = 1e-5,
+        inplace: bool = False,
+        device=None,
+    ) -> None:
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(torch.empty(dim, device=device))
+        self.init_values = init_values
+
+    def reset_parameters(self):
+        nn.init.constant_(self.gamma, self.init_values)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+
+
+def PT_make_2tuple(x):
+    if isinstance(x, tuple):
+        assert len(x) == 2
+        return x
+
+    assert isinstance(x, int)
+    return (x, x)
+
+
+class PT_PatchEmbed(nn.Module):
+    """
+    2D image to patch embedding: (B,C,H,W) -> (B,N,D)
+
+    Args:
+        img_size: Image size.
+        patch_size: Patch token size.
+        in_chans: Number of input image channels.
+        embed_dim: Number of linear projection output channels.
+        norm_layer: Normalization layer.
+    """
+
+    def __init__(
+        self,
+        img_size: Union[int, Tuple[int, int]] = 224,
+        patch_size: Union[int, Tuple[int, int]] = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        norm_layer: Callable | None = None,
+        flatten_embedding: bool = True,
+    ) -> None:
+        super().__init__()
+
+        image_HW = PT_make_2tuple(img_size)
+        patch_HW = PT_make_2tuple(patch_size)
+        patch_grid_size = (
+            image_HW[0] // patch_HW[0],
+            image_HW[1] // patch_HW[1],
+        )
+
+        self.img_size = image_HW
+        self.patch_size = patch_HW
+        self.patches_resolution = patch_grid_size
+        self.num_patches = patch_grid_size[0] * patch_grid_size[1]
+
+        self.in_chans = in_chans
+        self.embed_dim = embed_dim
+
+        self.flatten_embedding = flatten_embedding
+
+        self.proj = nn.Conv2d(
+            in_chans, embed_dim, kernel_size=patch_HW, stride=patch_HW
+        )
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        _, _, H, W = x.shape
+        # patch_H, patch_W = self.patch_size
+        # assert H % patch_H == 0, f"Input image height {H} is not a multiple of patch height {patch_H}"
+        # assert W % patch_W == 0, f"Input image width {W} is not a multiple of patch width: {patch_W}"
+
+        x = self.proj(x)  # B C H W
+        H, W = x.size(2), x.size(3)
+        x = x.flatten(2).transpose(1, 2)  # B HW C
+        x = self.norm(x)
+        if not self.flatten_embedding:
+            x = x.reshape(-1, H, W, self.embed_dim)  # B H W C
+        return x
+
+    def flops(self) -> float:
+        Ho, Wo = self.patches_resolution
+        flops = (
+            Ho
+            * Wo
+            * self.embed_dim
+            * self.in_chans
+            * (self.patch_size[0] * self.patch_size[1])
+        )
+        if self.norm is not None:
+            flops += Ho * Wo * self.embed_dim
+        return flops
+
+    def reset_parameters(self):
+        k = 1 / (self.in_chans * (self.patch_size[0] ** 2))
+        nn.init.uniform_(self.proj.weight, -math.sqrt(k), math.sqrt(k))
+        if self.proj.bias is not None:
+            nn.init.uniform_(self.proj.bias, -math.sqrt(k), math.sqrt(k))
+
+
+class PT_RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def reset_parameters(self) -> None:
+        nn.init.constant_(self.weight, 1)
+
+    def _norm(self, x: Tensor) -> Tensor:
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+class PT_RopePositionEmbedding(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        *,
+        num_heads: int,
+        base: float | None = 100.0,
+        min_period: float | None = None,
+        max_period: float | None = None,
+        normalize_coords: Literal["min", "max", "separate"] = "separate",
+        shift_coords: float | None = None,
+        jitter_coords: float | None = None,
+        rescale_coords: float | None = None,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        assert embed_dim % (4 * num_heads) == 0
+        both_periods = min_period is not None and max_period is not None
+        if (base is None and not both_periods) or (base is not None and both_periods):
+            raise ValueError(
+                "Either `base` or `min_period`+`max_period` must be provided."
+            )
+
+        D_head = embed_dim // num_heads
+        self.base = base
+        self.min_period = min_period
+        self.max_period = max_period
+        self.D_head = D_head
+        self.normalize_coords = normalize_coords
+        self.shift_coords = shift_coords
+        self.jitter_coords = jitter_coords
+        self.rescale_coords = rescale_coords
+
+        # Needs persistent=True because we do teacher.load_state_dict(student.state_dict()) to initialize the teacher
+        self.dtype = dtype  # Don't rely on self.periods.dtype
+        self.register_buffer(
+            "periods",
+            torch.empty(D_head // 4, device=device, dtype=dtype),
+            persistent=True,
+        )
+        self._init_weights()
+
+    def forward(self, *, H: int, W: int) -> tuple[Tensor, Tensor]:
+        device = self.periods.device
+        dtype = self.dtype
+        dd = {"device": device, "dtype": dtype}
+
+        # Prepare coords in range [-1, +1]
+        if self.normalize_coords == "max":
+            max_HW = max(H, W)
+            coords_h = torch.arange(0.5, H, **dd) / max_HW  # [H]
+            coords_w = torch.arange(0.5, W, **dd) / max_HW  # [W]
+        elif self.normalize_coords == "min":
+            min_HW = min(H, W)
+            coords_h = torch.arange(0.5, H, **dd) / min_HW  # [H]
+            coords_w = torch.arange(0.5, W, **dd) / min_HW  # [W]
+        elif self.normalize_coords == "separate":
+            coords_h = torch.arange(0.5, H, **dd) / H  # [H]
+            coords_w = torch.arange(0.5, W, **dd) / W  # [W]
+        else:
+            raise ValueError(f"Unknown normalize_coords: {self.normalize_coords}")
+        coords = torch.stack(
+            torch.meshgrid(coords_h, coords_w, indexing="ij"), dim=-1
+        )  # [H, W, 2]
+        coords = coords.flatten(0, 1)  # [HW, 2]
+        coords = 2.0 * coords - 1.0  # Shift range [0, 1] to [-1, +1]
+
+        # Shift coords by adding a uniform value in [-shift, shift]
+        if self.training and self.shift_coords is not None:
+            shift_hw = torch.empty(2, **dd).uniform_(
+                -self.shift_coords, self.shift_coords
+            )
+            coords += shift_hw[None, :]
+
+        # Jitter coords by multiplying the range [-1, 1] by a log-uniform value in [1/jitter, jitter]
+        if self.training and self.jitter_coords is not None:
+            jitter_max = np.log(self.jitter_coords)
+            jitter_min = -jitter_max
+            jitter_hw = torch.empty(2, **dd).uniform_(jitter_min, jitter_max).exp()
+            coords *= jitter_hw[None, :]
+
+        # Rescale coords by multiplying the range [-1, 1] by a log-uniform value in [1/rescale, rescale]
+        if self.training and self.rescale_coords is not None:
+            rescale_max = np.log(self.rescale_coords)
+            rescale_min = -rescale_max
+            rescale_hw = torch.empty(1, **dd).uniform_(rescale_min, rescale_max).exp()
+            coords *= rescale_hw
+
+        # Prepare angles and sin/cos
+        angles = (
+            2 * math.pi * coords[:, :, None] / self.periods[None, None, :]
+        )  # [HW, 2, D//4]
+        angles = angles.flatten(1, 2)  # [HW, D//2]
+        angles = angles.tile(2)  # [HW, D]
+        cos = torch.cos(angles)  # [HW, D]
+        sin = torch.sin(angles)  # [HW, D]
+
+        return (sin, cos)  # 2 * [HW, D]
+
+    def _init_weights(self):
+        device = self.periods.device
+        dtype = self.dtype
+        if self.base is not None:
+            periods = self.base ** (
+                2
+                * torch.arange(self.D_head // 4, device=device, dtype=dtype)
+                / (self.D_head // 2)
+            )  # [D//4]
+        else:
+            base = self.max_period / self.min_period
+            exponents = torch.linspace(
+                0, 1, self.D_head // 4, device=device, dtype=dtype
+            )  # [D//4] range [0, 1]
+            periods = base**exponents  # range [1, max_period / min_period]
+            periods = periods / base  # range [min_period / max_period, 1]
+            periods = periods * self.max_period  # range [min_period, max_period]
+        self.periods.data = periods
+
+
+class PT_SelfAttentionBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        ffn_ratio: float = 4.0,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        ffn_bias: bool = True,
+        drop: float = 0.0,
+        attn_drop: float = 0.0,
+        init_values=None,
+        drop_path: float = 0.0,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        norm_layer: Callable[..., nn.Module] = nn.LayerNorm,
+        attn_class: Callable[..., nn.Module] = PT_SelfAttention,
+        ffn_layer: Callable[..., nn.Module] = PT_Mlp,
+        mask_k_bias: bool = False,
+        device=None,
+    ) -> None:
+        super().__init__()
+        # print(f"biases: qkv: {qkv_bias}, proj: {proj_bias}, ffn: {ffn_bias}")
+        self.norm1 = norm_layer(dim)
+        self.attn = attn_class(
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            proj_bias=proj_bias,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+            mask_k_bias=mask_k_bias,
+            device=device,
+        )
+        self.ls1 = (
+            PT_LayerScale(dim, init_values=init_values, device=device)
+            if init_values
+            else nn.Identity()
+        )
+
+        self.norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * ffn_ratio)
+        self.mlp = ffn_layer(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=drop,
+            bias=ffn_bias,
+            device=device,
+        )
+        self.ls2 = (
+            PT_LayerScale(dim, init_values=init_values, device=device)
+            if init_values
+            else nn.Identity()
+        )
+
+        self.sample_drop_ratio = drop_path
+
+    @staticmethod
+    def _maybe_index_rope(
+        rope: tuple[Tensor, Tensor] | None, indices: Tensor
+    ) -> tuple[Tensor, Tensor] | None:
+        if rope is None:
+            return None
+
+        sin, cos = rope
+        assert sin.ndim == cos.ndim
+        if sin.ndim == 4:
+            # If the rope embedding has a batch dimension (is different for each batch element), index into it
+            return sin[indices], cos[indices]  # [batch, heads, patches, embed_dim]
+        else:
+            # No batch dimension, do not index
+            return sin, cos  # [heads, patches, embed_dim] or [patches, embed_dim]
+
+    def _forward(self, x: Tensor, rope=None) -> Tensor:
+        """
+        This is the reference implementation for a single tensor, matching what is done below for a list.
+        We call the list op on [x] instead of this function.
+        """
+        b, _, _ = x.shape
+        sample_subset_size = max(int(b * (1 - self.sample_drop_ratio)), 1)
+        residual_scale_factor = b / sample_subset_size
+
+        if self.training and self.sample_drop_ratio > 0.0:
+            indices_1 = (torch.randperm(b, device=x.device))[:sample_subset_size]
+
+            x_subset_1 = x[indices_1]
+            rope_subset = self._maybe_index_rope(rope, indices_1)
+            residual_1 = self.attn(self.norm1(x_subset_1), rope=rope_subset)
+
+            x_attn = torch.index_add(
+                x,
+                dim=0,
+                source=self.ls1(residual_1),
+                index=indices_1,
+                alpha=residual_scale_factor,
+            )
+
+            indices_2 = (torch.randperm(b, device=x.device))[:sample_subset_size]
+
+            x_subset_2 = x_attn[indices_2]
+            residual_2 = self.mlp(self.norm2(x_subset_2))
+
+            x_ffn = torch.index_add(
+                x_attn,
+                dim=0,
+                source=self.ls2(residual_2),
+                index=indices_2,
+                alpha=residual_scale_factor,
+            )
+        else:
+            x_attn = x + self.ls1(self.attn(self.norm1(x), rope=rope))
+            x_ffn = x_attn + self.ls2(self.mlp(self.norm2(x_attn)))
+
+        return x_ffn
+
+    def _forward_list(self, x_list: List[Tensor], rope_list=None) -> List[Tensor]:
+        """
+        This list operator concatenates the tokens from the list of inputs together to save
+        on the elementwise operations. Torch-compile memory-planning allows hiding the overhead
+        related to concat ops.
+        """
+        b_list = [x.shape[0] for x in x_list]
+        sample_subset_sizes = [
+            max(int(b * (1 - self.sample_drop_ratio)), 1) for b in b_list
+        ]
+        residual_scale_factors = [
+            b / sample_subset_size
+            for b, sample_subset_size in zip(b_list, sample_subset_sizes)
+        ]
+
+        if self.training and self.sample_drop_ratio > 0.0:
+            indices_1_list = [
+                (torch.randperm(b, device=x.device))[:sample_subset_size]
+                for x, b, sample_subset_size in zip(x_list, b_list, sample_subset_sizes)
+            ]
+            x_subset_1_list = [
+                x[indices_1] for x, indices_1 in zip(x_list, indices_1_list)
+            ]
+
+            if rope_list is not None:
+                rope_subset_list = [
+                    self._maybe_index_rope(rope, indices_1)
+                    for rope, indices_1 in zip(rope_list, indices_1_list)
+                ]
+            else:
+                rope_subset_list = rope_list
+
+            flattened, shapes, num_tokens = PT_cat_keep_shapes(x_subset_1_list)
+            norm1 = PT_uncat_with_shapes(self.norm1(flattened), shapes, num_tokens)
+            residual_1_list = self.attn.forward_list(norm1, rope_list=rope_subset_list)
+
+            x_attn_list = [
+                torch.index_add(
+                    x,
+                    dim=0,
+                    source=self.ls1(residual_1),
+                    index=indices_1,
+                    alpha=residual_scale_factor,
+                )
+                for x, residual_1, indices_1, residual_scale_factor in zip(
+                    x_list, residual_1_list, indices_1_list, residual_scale_factors
+                )
+            ]
+
+            indices_2_list = [
+                (torch.randperm(b, device=x.device))[:sample_subset_size]
+                for x, b, sample_subset_size in zip(x_list, b_list, sample_subset_sizes)
+            ]
+            x_subset_2_list = [
+                x[indices_2] for x, indices_2 in zip(x_attn_list, indices_2_list)
+            ]
+            flattened, shapes, num_tokens = PT_cat_keep_shapes(x_subset_2_list)
+            norm2_flat = self.norm2(flattened)
+            norm2_list = PT_uncat_with_shapes(norm2_flat, shapes, num_tokens)
+
+            residual_2_list = self.mlp.forward_list(norm2_list)
+
+            x_ffn = [
+                torch.index_add(
+                    x_attn,
+                    dim=0,
+                    source=self.ls2(residual_2),
+                    index=indices_2,
+                    alpha=residual_scale_factor,
+                )
+                for x_attn, residual_2, indices_2, residual_scale_factor in zip(
+                    x_attn_list, residual_2_list, indices_2_list, residual_scale_factors
+                )
+            ]
+        else:
+            x_out = []
+            for x, rope in zip(x_list, rope_list):
+                x_attn = x + self.ls1(self.attn(self.norm1(x), rope=rope))
+                x_ffn = x_attn + self.ls2(self.mlp(self.norm2(x_attn)))
+                x_out.append(x_ffn)
+            x_ffn = x_out
+
+        return x_ffn
+
+    def forward(self, x_or_x_list, rope_or_rope_list=None) -> List[Tensor]:
+        if isinstance(x_or_x_list, Tensor):
+            # for reference:
+            # return self._forward(x_or_x_list, rope=rope_or_rope_list)
+            # in order to match implementations we call the list op:
+            return self._forward_list([x_or_x_list], rope_list=[rope_or_rope_list])[0]
+        elif isinstance(x_or_x_list, list):
+            if rope_or_rope_list is None:
+                rope_or_rope_list = [None for x in x_or_x_list]
+            # return [self._forward(x, rope=rope) for x, rope in zip(x_or_x_list, rope_or_rope_list)]
+            return self._forward_list(x_or_x_list, rope_list=rope_or_rope_list)
+        else:
+            raise AssertionError
+
+
+class PT_CausalSelfAttentionBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        ffn_ratio: float = 4.0,
+        ls_init_value: Optional[float] = None,
+        is_causal: bool = True,
+        act_layer: Callable = nn.GELU,
+        norm_layer: Callable = nn.LayerNorm,
+        dropout_prob: float = 0.0,
+    ):
+        super().__init__()
+
+        self.dim = dim
+        self.is_causal = is_causal
+        self.ls1 = (
+            PT_LayerScale(dim, init_values=ls_init_value)
+            if ls_init_value
+            else nn.Identity()
+        )
+        self.attention_norm = norm_layer(dim)
+        self.attention = PT_CausalSelfAttention(
+            dim, num_heads, attn_drop=dropout_prob, proj_drop=dropout_prob
+        )
+
+        self.ffn_norm = norm_layer(dim)
+        ffn_hidden_dim = int(dim * ffn_ratio)
+        self.feed_forward = PT_Mlp(
+            in_features=dim,
+            hidden_features=ffn_hidden_dim,
+            drop=dropout_prob,
+            act_layer=act_layer,
+        )
+
+        self.ls2 = (
+            PT_LayerScale(dim, init_values=ls_init_value)
+            if ls_init_value
+            else nn.Identity()
+        )
+
+    def init_weights(
+        self,
+        init_attn_std: float | None = None,
+        init_proj_std: float | None = None,
+        init_fc_std: float | None = None,
+        factor: float = 1.0,
+    ) -> None:
+        init_attn_std = init_attn_std or (self.dim**-0.5)
+        init_proj_std = init_proj_std or init_attn_std * factor
+        init_fc_std = init_fc_std or (2 * self.dim) ** -0.5
+        self.attention.init_weights(init_attn_std, init_proj_std)
+        self.attention_norm.reset_parameters()
+        nn.init.normal_(self.feed_forward.fc1.weight, std=init_fc_std)
+        nn.init.normal_(self.feed_forward.fc2.weight, std=init_proj_std)
+        self.ffn_norm.reset_parameters()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ):
+
+        x_attn = x + self.ls1(self.attention(self.attention_norm(x), self.is_causal))
+        x_ffn = x_attn + self.ls2(self.feed_forward(self.ffn_norm(x_attn)))
+        return x_ffn

--- a/paz/models/foundation/dinov3/models/torch_vision_transformer_for_testing.py
+++ b/paz/models/foundation/dinov3/models/torch_vision_transformer_for_testing.py
@@ -1,0 +1,445 @@
+import torch
+import logging
+from functools import partial
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from torch import Tensor, nn
+from paz.models.foundation.dinov3.utils import named_apply
+from paz.models.foundation.dinov3.layers.torch_layers_for_testing import (
+    PT_LayerScale,
+    PT_Mlp,
+    PT_PatchEmbed,
+    PT_RMSNorm,
+    PT_RopePositionEmbedding,
+    PT_SelfAttentionBlock,
+    PT_SwiGLUFFN,
+)
+
+
+logger = logging.getLogger("dinov3")
+
+ffn_layer_dict = {
+    "mlp": PT_Mlp,
+    "swiglu": PT_SwiGLUFFN,
+}
+
+
+norm_layer_dict = {
+    "layernorm": partial(nn.LayerNorm, eps=1e-6),
+    "rmsnorm": PT_RMSNorm,
+}
+
+dtype_dict = {
+    "fp32": torch.float32,
+    "float32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+
+
+def PT_init_weights_vit(module: nn.Module, name: str = ""):
+    if isinstance(module, nn.Linear):
+        torch.nn.init.trunc_normal_(module.weight, std=0.02)
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+        if hasattr(module, "bias_mask") and module.bias_mask is not None:
+            o = module.out_features
+            module.bias_mask.fill_(1)
+            module.bias_mask[o // 3 : 2 * o // 3].fill_(0)
+    if isinstance(module, nn.LayerNorm):
+        module.reset_parameters()
+    if isinstance(module, PT_LayerScale):
+        module.reset_parameters()
+    if isinstance(module, PT_PatchEmbed):
+        module.reset_parameters()
+    if isinstance(module, PT_RMSNorm):
+        module.reset_parameters()
+
+
+class PT_DinoVisionTransformer(nn.Module):
+    def __init__(
+        self,
+        *,
+        img_size: int = 224,
+        patch_size: int = 16,
+        in_chans: int = 3,
+        pos_embed_rope_base: float = 100.0,
+        pos_embed_rope_min_period: float | None = None,
+        pos_embed_rope_max_period: float | None = None,
+        pos_embed_rope_normalize_coords: Literal["min", "max", "separate"] = "separate",
+        pos_embed_rope_shift_coords: float | None = None,
+        pos_embed_rope_jitter_coords: float | None = None,
+        pos_embed_rope_rescale_coords: float | None = None,
+        pos_embed_rope_dtype: str = "bf16",
+        embed_dim: int = 768,
+        depth: int = 12,
+        num_heads: int = 12,
+        ffn_ratio: float = 4.0,
+        qkv_bias: bool = True,
+        drop_path_rate: float = 0.0,
+        layerscale_init: float | None = None,
+        norm_layer: str = "layernorm",
+        ffn_layer: str = "mlp",
+        ffn_bias: bool = True,
+        proj_bias: bool = True,
+        n_storage_tokens: int = 0,
+        mask_k_bias: bool = False,
+        untie_cls_and_patch_norms: bool = False,
+        untie_global_and_local_cls_norm: bool = False,
+        device: Any | None = None,
+        **ignored_kwargs,
+    ):
+        super().__init__()
+        if len(ignored_kwargs) > 0:
+            logger.warning(f"Ignored kwargs: {ignored_kwargs}")
+        del ignored_kwargs
+
+        norm_layer_cls = norm_layer_dict[norm_layer]
+
+        self.num_features = self.embed_dim = (
+            embed_dim  # num_features for consistency with other models
+        )
+        self.n_blocks = depth
+        self.num_heads = num_heads
+        self.patch_size = patch_size
+
+        self.patch_embed = PT_PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            flatten_embedding=False,
+        )
+
+        self.cls_token = nn.Parameter(torch.empty(1, 1, embed_dim, device=device))
+        self.n_storage_tokens = n_storage_tokens
+        if self.n_storage_tokens > 0:
+            self.storage_tokens = nn.Parameter(
+                torch.empty(1, n_storage_tokens, embed_dim, device=device)
+            )
+        logger.info(f"using base={pos_embed_rope_base} for rope new")
+        logger.info(f"using min_period={pos_embed_rope_min_period} for rope new")
+        logger.info(f"using max_period={pos_embed_rope_max_period} for rope new")
+        logger.info(
+            f"using normalize_coords={pos_embed_rope_normalize_coords} for rope new"
+        )
+        logger.info(f"using shift_coords={pos_embed_rope_shift_coords} for rope new")
+        logger.info(
+            f"using rescale_coords={pos_embed_rope_rescale_coords} for rope new"
+        )
+        logger.info(f"using jitter_coords={pos_embed_rope_jitter_coords} for rope new")
+        logger.info(f"using dtype={pos_embed_rope_dtype} for rope new")
+        self.rope_embed = PT_RopePositionEmbedding(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            base=pos_embed_rope_base,
+            min_period=pos_embed_rope_min_period,
+            max_period=pos_embed_rope_max_period,
+            normalize_coords=pos_embed_rope_normalize_coords,
+            shift_coords=pos_embed_rope_shift_coords,
+            jitter_coords=pos_embed_rope_jitter_coords,
+            rescale_coords=pos_embed_rope_rescale_coords,
+            dtype=dtype_dict[pos_embed_rope_dtype],
+            device=device,
+        )
+        logger.info(f"using {ffn_layer} layer as FFN")
+        ffn_layer_cls = ffn_layer_dict[ffn_layer]
+        ffn_ratio_sequence = [ffn_ratio] * depth
+        blocks_list = [
+            PT_SelfAttentionBlock(
+                dim=embed_dim,
+                num_heads=num_heads,
+                ffn_ratio=ffn_ratio_sequence[i],
+                qkv_bias=qkv_bias,
+                proj_bias=proj_bias,
+                ffn_bias=ffn_bias,
+                drop_path=drop_path_rate,
+                norm_layer=norm_layer_cls,
+                act_layer=nn.GELU,
+                ffn_layer=ffn_layer_cls,
+                init_values=layerscale_init,
+                mask_k_bias=mask_k_bias,
+                device=device,
+            )
+            for i in range(depth)
+        ]
+
+        self.chunked_blocks = False
+        self.blocks = nn.ModuleList(blocks_list)
+
+        # This norm is applied to everything, or when untying, to patch and mask tokens.
+        self.norm = norm_layer_cls(embed_dim)
+
+        self.untie_cls_and_patch_norms = untie_cls_and_patch_norms
+        if untie_cls_and_patch_norms:
+            # When untying, this norm is applied to CLS tokens and registers.
+            self.cls_norm = norm_layer_cls(embed_dim)
+        else:
+            self.cls_norm = None
+
+        self.untie_global_and_local_cls_norm = untie_global_and_local_cls_norm
+        if untie_global_and_local_cls_norm:
+            # When untying, this norm is applied to local CLS tokens and registers.
+            # This norm is never used during eval.
+            self.local_cls_norm = norm_layer_cls(embed_dim)
+        else:
+            self.local_cls_norm = None
+        self.head = nn.Identity()
+        self.mask_token = nn.Parameter(torch.empty(1, embed_dim, device=device))
+
+    def init_weights(self):
+        self.rope_embed._init_weights()
+        nn.init.normal_(self.cls_token, std=0.02)
+        if self.n_storage_tokens > 0:
+            nn.init.normal_(self.storage_tokens, std=0.02)
+        nn.init.zeros_(self.mask_token)
+        named_apply(PT_init_weights_vit, self)
+
+    def prepare_tokens_with_masks(
+        self, x: Tensor, masks=None
+    ) -> Tuple[Tensor, Tuple[int]]:
+        x = self.patch_embed(x)
+        B, H, W, _ = x.shape
+        x = x.flatten(1, 2)
+
+        if masks is not None:
+            x = torch.where(
+                masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x
+            )
+            cls_token = self.cls_token
+        else:
+            cls_token = self.cls_token + 0 * self.mask_token
+        if self.n_storage_tokens > 0:
+            storage_tokens = self.storage_tokens
+        else:
+            storage_tokens = torch.empty(
+                1,
+                0,
+                cls_token.shape[-1],
+                dtype=cls_token.dtype,
+                device=cls_token.device,
+            )
+
+        x = torch.cat(
+            [
+                cls_token.expand(B, -1, -1),
+                storage_tokens.expand(B, -1, -1),
+                x,
+            ],
+            dim=1,
+        )
+
+        return x, (H, W)
+
+    def forward_features_list(
+        self, x_list: List[Tensor], masks_list: List[Tensor]
+    ) -> List[Dict[str, Tensor]]:
+        x = []
+        rope = []
+        for t_x, t_masks in zip(x_list, masks_list):
+            t2_x, hw_tuple = self.prepare_tokens_with_masks(t_x, t_masks)
+            x.append(t2_x)
+            rope.append(hw_tuple)
+        for _, blk in enumerate(self.blocks):
+            if self.rope_embed is not None:
+                rope_sincos = [self.rope_embed(H=H, W=W) for H, W in rope]
+            else:
+                rope_sincos = [None for r in rope]
+            x = blk(x, rope_sincos)
+        all_x = x
+        output = []
+        for idx, (x, masks) in enumerate(zip(all_x, masks_list)):
+            if self.untie_cls_and_patch_norms or self.untie_global_and_local_cls_norm:
+                if self.untie_global_and_local_cls_norm and self.training and idx == 1:
+                    # Assume second entry of list corresponds to local crops.
+                    # We only ever apply this during training.
+                    x_norm_cls_reg = self.local_cls_norm(
+                        x[:, : self.n_storage_tokens + 1]
+                    )
+                elif self.untie_cls_and_patch_norms:
+                    x_norm_cls_reg = self.cls_norm(x[:, : self.n_storage_tokens + 1])
+                else:
+                    x_norm_cls_reg = self.norm(x[:, : self.n_storage_tokens + 1])
+                x_norm_patch = self.norm(x[:, self.n_storage_tokens + 1 :])
+            else:
+                x_norm = self.norm(x)
+                x_norm_cls_reg = x_norm[:, : self.n_storage_tokens + 1]
+                x_norm_patch = x_norm[:, self.n_storage_tokens + 1 :]
+            output.append(
+                {
+                    "x_norm_clstoken": x_norm_cls_reg[:, 0],
+                    "x_storage_tokens": x_norm_cls_reg[:, 1:],
+                    "x_norm_patchtokens": x_norm_patch,
+                    "x_prenorm": x,
+                    "masks": masks,
+                }
+            )
+        return output
+
+    def forward_features(
+        self, x: Tensor | List[Tensor], masks: Optional[Tensor] = None
+    ) -> List[Dict[str, Tensor]]:
+        if isinstance(x, torch.Tensor):
+            return self.forward_features_list([x], [masks])[0]
+        else:
+            return self.forward_features_list(x, masks)
+
+    def _get_intermediate_layers_not_chunked(
+        self, x: Tensor, n: int = 1
+    ) -> List[Tensor]:
+        x, (H, W) = self.prepare_tokens_with_masks(x)
+        # If n is an int, take the n last blocks. If it's a list, take them
+        output, total_block_len = [], len(self.blocks)
+        blocks_to_take = (
+            range(total_block_len - n, total_block_len) if isinstance(n, int) else n
+        )
+        for i, blk in enumerate(self.blocks):
+            if self.rope_embed is not None:
+                rope_sincos = self.rope_embed(H=H, W=W)
+            else:
+                rope_sincos = None
+            x = blk(x, rope_sincos)
+            if i in blocks_to_take:
+                output.append(x)
+        assert len(output) == len(
+            blocks_to_take
+        ), f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        return output
+
+    def get_intermediate_layers(
+        self,
+        x: torch.Tensor,
+        *,
+        n: Union[int, Sequence] = 1,  # Layers or n last layers to take
+        reshape: bool = False,
+        return_class_token: bool = False,
+        return_extra_tokens: bool = False,
+        norm: bool = True,
+    ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor, ...]]]:
+        outputs = self._get_intermediate_layers_not_chunked(x, n)
+        if norm:
+            outputs_normed = []
+            for out in outputs:
+                if self.untie_cls_and_patch_norms:
+                    x_norm_cls_reg = self.cls_norm(out[:, : self.n_storage_tokens + 1])
+                    x_norm_patch = self.norm(out[:, self.n_storage_tokens + 1 :])
+                    outputs_normed.append(
+                        torch.cat((x_norm_cls_reg, x_norm_patch), dim=1)
+                    )
+                else:
+                    outputs_normed.append(self.norm(out))
+            outputs = outputs_normed
+        class_tokens = [out[:, 0] for out in outputs]
+        extra_tokens = [out[:, 1 : self.n_storage_tokens + 1] for out in outputs]
+        outputs = [out[:, self.n_storage_tokens + 1 :] for out in outputs]
+        if reshape:
+            B, _, h, w = x.shape
+            outputs = [
+                out.reshape(B, h // self.patch_size, w // self.patch_size, -1)
+                .permute(0, 3, 1, 2)
+                .contiguous()
+                for out in outputs
+            ]
+        if not return_class_token and not return_extra_tokens:
+            return tuple(outputs)
+        elif return_class_token and not return_extra_tokens:
+            return tuple(zip(outputs, class_tokens))
+        elif not return_class_token and return_extra_tokens:
+            return tuple(zip(outputs, extra_tokens))
+        elif return_class_token and return_extra_tokens:
+            return tuple(zip(outputs, class_tokens, extra_tokens))
+
+    def forward(
+        self, *args, is_training: bool = False, **kwargs
+    ) -> List[Dict[str, Tensor]] | Tensor:
+        ret = self.forward_features(*args, **kwargs)
+        if is_training:
+            return ret
+        else:
+            return self.head(ret["x_norm_clstoken"])
+
+
+def PT_vit_small(patch_size=16, **kwargs):
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def PT_vit_base(patch_size=16, **kwargs):
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def PT_vit_large(patch_size=16, **kwargs):
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def PT_vit_so400m(patch_size=16, **kwargs):
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1152,
+        depth=27,
+        num_heads=18,
+        ffn_ratio=3.777777778,
+        **kwargs,
+    )
+    return model
+
+
+def PT_vit_huge2(patch_size=16, **kwargs):
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1280,
+        depth=32,
+        num_heads=20,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def PT_vit_giant2(patch_size=16, **kwargs):
+    """
+    Close to ViT-giant, with embed-dim 1536 and 24 heads => embed-dim per head 64
+    """
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1536,
+        depth=40,
+        num_heads=24,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def PT_vit_7b(patch_size=16, **kwargs):
+    model = PT_DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=4096,
+        depth=40,
+        num_heads=32,
+        ffn_ratio=3,
+        **kwargs,
+    )
+    return model

--- a/paz/models/foundation/dinov3/models/vision_transformer.py
+++ b/paz/models/foundation/dinov3/models/vision_transformer.py
@@ -1,0 +1,453 @@
+import numpy as np
+import math
+from functools import partial
+from typing import Any, Dict, List, Literal, Sequence, Union
+
+
+from paz.models.foundation.dinov3.layers import (
+    Mlp,
+    PatchEmbed,
+    RMSNorm,
+    RopePositionEmbedding,
+    SelfAttentionBlock,
+    SwiGLUFFN,
+)
+from paz.models.foundation.dinov3.utils import named_apply
+
+import keras
+from keras import layers, ops, random
+
+ffn_layer_dict_keras = {
+    "mlp": Mlp,
+    "swiglu": SwiGLUFFN,
+    "swiglu32": partial(SwiGLUFFN, align_to=32),
+    "swiglu64": partial(SwiGLUFFN, align_to=64),
+    "swiglu128": partial(SwiGLUFFN, align_to=128),
+}
+
+
+# ==============================================================================
+# Numerically Stable Keras Layer Implementation
+# ==============================================================================
+@keras.saving.register_keras_serializable()
+class StableLayerNormalization(layers.Layer):
+    def __init__(self, epsilon=1e-6, **kwargs):
+        super().__init__(**kwargs)
+        self.epsilon = epsilon
+
+    def build(self, input_shape):
+        dim = input_shape[-1]
+        self.gamma = self.add_weight(
+            name="gamma", shape=(dim,), initializer="ones", trainable=True
+        )
+        self.beta = self.add_weight(
+            name="beta", shape=(dim,), initializer="zeros", trainable=True
+        )
+        super().build(input_shape)
+
+    def call(self, x):
+        x_dtype = x.dtype
+        x_f32 = ops.cast(x, "float32")
+        mean = ops.mean(x_f32, axis=-1, keepdims=True)
+        variance = ops.mean(ops.square(x_f32 - mean), axis=-1, keepdims=True)
+        norm_x = (x_f32 - mean) * ops.rsqrt(variance + self.epsilon)
+        norm_x = ops.cast(norm_x, x_dtype)
+        return norm_x * self.gamma + self.beta
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"epsilon": self.epsilon})
+        return config
+
+
+def init_weights_vit(module, name: str = ""):
+    layer = module
+    if isinstance(layer, layers.Dense):
+        trunc_normal = keras.initializers.TruncatedNormal(mean=0.0, stddev=0.02)
+        layer.kernel.assign(
+            trunc_normal(shape=layer.kernel.shape, dtype=layer.kernel.dtype)
+        )
+        if layer.use_bias and layer.bias is not None:
+            layer.bias.assign(ops.zeros_like(layer.bias))
+        if hasattr(layer, "bias_mask") and layer.bias_mask is not None:
+            o = layer.units
+            start_idx, end_idx = o // 3, 2 * o // 3
+            new_mask_values = np.ones(layer.bias_mask.shape, dtype=np.float32)
+            if start_idx < end_idx:
+                new_mask_values[start_idx:end_idx] = 0
+            layer.bias_mask.assign(new_mask_values)
+    elif isinstance(layer, (layers.LayerNormalization, StableLayerNormalization)):
+        if hasattr(layer, "gamma") and layer.gamma is not None:
+            layer.gamma.assign(ops.ones_like(layer.gamma))
+        if hasattr(layer, "beta") and layer.beta is not None:
+            layer.beta.assign(ops.zeros_like(layer.beta))
+    elif isinstance(layer, PatchEmbed):
+        k = 1.0 / (layer.in_channels * (layer.patch_size[0] ** 2))
+        limit = math.sqrt(k)
+        initializer = keras.initializers.RandomUniform(minval=-limit, maxval=limit)
+        proj_layer = layer.projection
+        proj_layer.kernel.assign(
+            initializer(shape=proj_layer.kernel.shape, dtype=proj_layer.kernel.dtype)
+        )
+        if proj_layer.use_bias and proj_layer.bias is not None:
+            proj_layer.bias.assign(
+                initializer(shape=proj_layer.bias.shape, dtype=proj_layer.bias.dtype)
+            )
+    elif hasattr(layer, "reset_parameters") and callable(layer.reset_parameters):
+        layer.reset_parameters()
+
+
+class DinoVisionTransformer(keras.Model):
+    def __init__(
+        self,
+        *,
+        img_size: int = 224,
+        patch_size: int = 16,
+        in_chans: int = 3,
+        pos_embed_rope_base: float = 100.0,
+        pos_embed_rope_min_period: float | None = None,
+        pos_embed_rope_max_period: float | None = None,
+        pos_embed_rope_normalize_coords: Literal["min", "max", "separate"] = "separate",
+        pos_embed_rope_shift_coords: float | None = None,
+        pos_embed_rope_jitter_coords: float | None = None,
+        pos_embed_rope_rescale_coords: float | None = None,
+        pos_embed_rope_dtype: str = "bf16",
+        embed_dim: int = 768,
+        depth: int = 12,
+        num_heads: int = 12,
+        ffn_ratio: float = 4.0,
+        qkv_bias: bool = True,
+        proj_bias: bool = True,
+        ffn_bias: bool = True,
+        drop_path_rate: float = 0.0,
+        norm_layer: str = "layernorm",
+        ffn_layer: str = "mlp",
+        layerscale_init: float | None = None,
+        n_storage_tokens: int = 0,
+        mask_k_bias: bool = False,
+        untie_cls_and_patch_norms: bool = False,
+        untie_global_and_local_cls_norm: bool = False,
+        **ignored_kwargs,
+    ):
+        super().__init__()
+        if len(ignored_kwargs) > 0:
+            print(f"Keras model ignored kwargs: {ignored_kwargs}")
+
+        if norm_layer == "layernorm":
+            norm_layer_cls = partial(StableLayerNormalization, epsilon=1e-6)
+
+        elif norm_layer == "rmsnorm":
+            norm_layer_cls = partial(RMSNorm, epsilon=1e-6)  # FIX: Use correct epsilon
+        else:
+            raise ValueError(f"Unknown norm_layer: {norm_layer}")
+
+        ffn_layer_cls = ffn_layer_dict_keras[ffn_layer]
+
+        self.num_features = self.embed_dim = embed_dim
+        self.patch_size = patch_size
+        self.patch_embed = PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_channels=in_chans,
+            embed_dim=embed_dim,
+            norm_layer=None,
+            flatten_embedding=False,
+        )
+        self.cls_token = self.add_weight(
+            name="cls_token", shape=(1, 1, embed_dim), initializer="zeros"
+        )
+        self.n_storage_tokens = n_storage_tokens
+        self.storage_tokens = (
+            self.add_weight(
+                name="storage_tokens",
+                shape=(1, n_storage_tokens, embed_dim),
+                initializer="zeros",
+            )
+            if n_storage_tokens > 0
+            else None
+        )
+        self.rope_embed = RopePositionEmbedding(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            base=pos_embed_rope_base,
+            min_period=pos_embed_rope_min_period,
+            max_period=pos_embed_rope_max_period,
+            normalize_coords=pos_embed_rope_normalize_coords,
+            shift_coords=pos_embed_rope_shift_coords,
+            jitter_coords=pos_embed_rope_jitter_coords,
+            rescale_coords=pos_embed_rope_rescale_coords,
+            dtype="float32",
+        )
+        self.blocks = [
+            SelfAttentionBlock(
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=ffn_ratio,
+                qkv_bias=qkv_bias,
+                proj_bias=proj_bias,
+                ffn_bias=ffn_bias,
+                drop_path=drop_path_rate,
+                norm_layer=norm_layer_cls,
+                ffn_layer=ffn_layer_cls,
+                init_values=layerscale_init,
+                mask_k_bias=mask_k_bias,
+                name=f"blocks_{i}",
+            )
+            for i in range(depth)
+        ]
+        self.norm = norm_layer_cls(name="norm")
+        self.cls_norm = (
+            norm_layer_cls(name="cls_norm") if untie_cls_and_patch_norms else None
+        )
+        self.local_cls_norm = (
+            norm_layer_cls(name="local_cls_norm")
+            if untie_global_and_local_cls_norm
+            else None
+        )
+        self.head = layers.Identity(name="head")
+        self.mask_token = self.add_weight(
+            name="mask_token", shape=(1, embed_dim), initializer="random_normal"
+        )
+        self.untie_cls_and_patch_norms = untie_cls_and_patch_norms
+        self.untie_global_and_local_cls_norm = untie_global_and_local_cls_norm
+
+    def init_weights(self):
+        if hasattr(self.rope_embed, "_init_weights"):
+            self.rope_embed._init_weights()
+        # FIX: Use random.normal to match PyTorch's nn.init.normal_
+        self.cls_token.assign(random.normal(self.cls_token.shape, stddev=0.02))
+        if self.storage_tokens is not None:
+            self.storage_tokens.assign(
+                random.normal(self.storage_tokens.shape, stddev=0.02)
+            )
+        self.mask_token.assign(ops.zeros_like(self.mask_token))
+        named_apply(init_weights_vit, self)
+
+    def prepare_tokens_with_masks(self, x, masks=None):
+        x_patched = self.patch_embed(x)
+        B, H, W, C = ops.shape(x_patched)
+        x_flat = ops.reshape(x_patched, (B, H * W, C))
+        if masks is not None:
+            mask_expanded = ops.expand_dims(masks, axis=-1)
+            mask_token_b = ops.broadcast_to(self.mask_token, (B, H * W, C))
+            x_flat = ops.where(
+                mask_expanded, ops.cast(mask_token_b, x_flat.dtype), x_flat
+            )
+            cls_token = self.cls_token
+        else:
+            cls_token = self.cls_token + 0 * self.mask_token
+        storage_tokens = (
+            self.storage_tokens
+            if self.n_storage_tokens > 0
+            else ops.zeros((1, 0, cls_token.shape[-1]), dtype=cls_token.dtype)
+        )
+        tokens = [
+            ops.cast(ops.repeat(cls_token, B, axis=0), x_flat.dtype),
+            ops.cast(ops.repeat(storage_tokens, B, axis=0), x_flat.dtype),
+            x_flat,
+        ]
+        return ops.concatenate(tokens, axis=1), (H, W)
+
+    def forward_features_list(
+        self, x_list: List, masks_list: List, training: bool = False
+    ) -> List[Dict[str, Any]]:
+        x, rope = [], []
+        for t_x, t_masks in zip(x_list, masks_list):
+            t2_x, hw_tuple = self.prepare_tokens_with_masks(t_x, t_masks)
+            x.append(t2_x)
+            rope.append(hw_tuple)
+        for blk in self.blocks:
+            rope_sincos = [self.rope_embed(H=H, W=W) for H, W in rope]
+            x = blk(x, rope=rope_sincos, training=training)
+        output = []
+        for idx, (x_item, masks) in enumerate(zip(x, masks_list)):
+            if self.untie_cls_and_patch_norms or self.untie_global_and_local_cls_norm:
+                if self.untie_global_and_local_cls_norm and training and idx == 1:
+                    x_norm_cls_reg = self.local_cls_norm(
+                        x_item[:, : self.n_storage_tokens + 1]
+                    )
+                elif self.untie_cls_and_patch_norms:
+                    x_norm_cls_reg = self.cls_norm(
+                        x_item[:, : self.n_storage_tokens + 1]
+                    )
+                else:
+                    x_norm_cls_reg = self.norm(x_item[:, : self.n_storage_tokens + 1])
+                x_norm_patch = self.norm(x_item[:, self.n_storage_tokens + 1 :])
+            else:
+                x_norm = self.norm(x_item)
+                x_norm_cls_reg = x_norm[:, : self.n_storage_tokens + 1]
+                x_norm_patch = x_norm[:, self.n_storage_tokens + 1 :]
+            output.append(
+                {
+                    "x_norm_clstoken": x_norm_cls_reg[:, 0],
+                    "x_storage_tokens": x_norm_cls_reg[:, 1:],
+                    "x_norm_patchtokens": x_norm_patch,
+                    "x_prenorm": x_item,
+                    "masks": masks,
+                }
+            )
+        return output
+
+    def forward_features(self, x, masks=None, training=False):
+        if isinstance(x, list):
+            return self.forward_features_list(x, masks, training=training)
+        else:
+            return self.forward_features_list([x], [masks], training=training)[0]
+
+    def _get_intermediate_layers_not_chunked(
+        self, x, n: int = 1, training: bool = False
+    ) -> List:
+        x, (H, W) = self.prepare_tokens_with_masks(x)
+        output = []
+        total_block_len = len(self.blocks)
+        blocks_to_take = (
+            range(total_block_len - n, total_block_len) if isinstance(n, int) else n
+        )
+        rope_sincos = self.rope_embed(H=H, W=W)
+        for i, blk in enumerate(self.blocks):
+            x = blk(x, rope=rope_sincos, training=training)
+            if i in blocks_to_take:
+                output.append(x)
+        return output
+
+    def get_intermediate_layers(
+        self,
+        x,
+        n: Union[int, Sequence] = 1,
+        reshape: bool = False,
+        return_class_token: bool = False,
+        return_extra_tokens: bool = False,
+        norm: bool = True,
+        training: bool = False,
+    ):
+        outputs = self._get_intermediate_layers_not_chunked(x, n, training=training)
+        if norm:
+            outputs_normed = []
+            for out in outputs:
+                if self.untie_cls_and_patch_norms:
+                    x_norm_cls_reg = self.cls_norm(out[:, : self.n_storage_tokens + 1])
+                    x_norm_patch = self.norm(out[:, self.n_storage_tokens + 1 :])
+                    outputs_normed.append(
+                        ops.concatenate([x_norm_cls_reg, x_norm_patch], axis=1)
+                    )
+                else:
+                    outputs_normed.append(self.norm(out))
+            outputs = outputs_normed
+        class_tokens = [out[:, 0] for out in outputs]
+        extra_tokens = [out[:, 1 : self.n_storage_tokens + 1] for out in outputs]
+        outputs = [out[:, self.n_storage_tokens + 1 :] for out in outputs]
+        if reshape:
+            B = ops.shape(x)[0]
+            # Keras input is channels-last, so H/W are at indices 1 and 2
+            H_img, W_img = ops.shape(x)[1], ops.shape(x)[2]
+            H, W = H_img // self.patch_size, W_img // self.patch_size
+            outputs = [
+                ops.transpose(ops.reshape(out, (B, H, W, -1)), [0, 3, 1, 2])
+                for out in outputs
+            ]
+        if not return_class_token and not return_extra_tokens:
+            return tuple(outputs)
+        if return_class_token and not return_extra_tokens:
+            return tuple(zip(outputs, class_tokens))
+        if not return_class_token and return_extra_tokens:
+            return tuple(zip(outputs, extra_tokens))
+        if return_class_token and return_extra_tokens:
+            return tuple(zip(outputs, class_tokens, extra_tokens))
+
+    def call(self, x, masks=None, training: bool = False):
+        ret = self.forward_features(x, masks=masks, training=training)
+        if training:
+            # When training, the model expects a dictionary for loss calculation
+            return {
+                "x_norm_clstoken": ret["x_norm_clstoken"],
+                "x_norm_patchtokens": ret["x_norm_patchtokens"],
+            }
+        # In inference, just return the final class token representation
+        return self.head(ret["x_norm_clstoken"])
+
+
+def vit_small(patch_size=16, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def vit_base(patch_size=16, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def vit_large(patch_size=16, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def vit_so400m(patch_size=16, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1152,
+        depth=27,
+        num_heads=18,
+        ffn_ratio=3.777777778,
+        **kwargs,
+    )
+    return model
+
+
+def vit_huge2(patch_size=16, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1280,
+        depth=32,
+        num_heads=20,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def vit_giant2(patch_size=16, **kwargs):
+    """
+    Close to ViT-giant, with embed-dim 1536 and 24 heads => embed-dim per head 64
+    """
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1536,
+        depth=40,
+        num_heads=24,
+        ffn_ratio=4,
+        **kwargs,
+    )
+    return model
+
+
+def vit_7b(patch_size=16, **kwargs):
+    model = DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=4096,
+        depth=40,
+        num_heads=32,
+        ffn_ratio=3,
+        **kwargs,
+    )
+    return model

--- a/paz/models/foundation/dinov3/models/vision_transformer_test.py
+++ b/paz/models/foundation/dinov3/models/vision_transformer_test.py
@@ -1,0 +1,918 @@
+import os
+import sys
+import pytest
+import torch
+import numpy as np
+
+os.environ["KERAS_BACKEND"] = "jax"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", ".."))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import torch
+
+from paz.models.foundation.dinov3.layers import (
+    Mlp,
+    SwiGLUFFN,
+)
+
+import keras
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.models.vision_transformer import (
+    vit_small,
+    vit_base,
+    vit_large,
+)
+
+# ==============================================================================
+# PyTorch Reference Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.models.torch_vision_transformer_for_testing import (
+    PT_vit_small,
+    PT_vit_base,
+    PT_vit_large,
+)
+
+
+# ==============================================================================
+# Test Suite
+# ==============================================================================
+def transfer_weights_from_pt_to_keras(pt_model, keras_model):
+    pt_state_dict = pt_model.state_dict()
+
+    # --- Standalone Weights ---
+    keras_model.cls_token.assign(pt_state_dict["cls_token"].numpy())
+    keras_model.mask_token.assign(pt_state_dict["mask_token"].numpy())
+    if "storage_tokens" in pt_state_dict and keras_model.storage_tokens is not None:
+        keras_model.storage_tokens.assign(pt_state_dict["storage_tokens"].numpy())
+
+    # --- Patch Embedding ---
+    pe_weights = [pt_state_dict["patch_embed.proj.weight"].permute(2, 3, 1, 0).numpy()]
+    if "patch_embed.proj.bias" in pt_state_dict:
+        pe_weights.append(pt_state_dict["patch_embed.proj.bias"].numpy())
+    keras_model.patch_embed.projection.set_weights(pe_weights)
+
+    # --- Transformer Blocks ---
+    for i in range(len(keras_model.blocks)):
+        block = keras_model.blocks[i]
+        pt_block = pt_model.blocks[i]
+        pt_block_prefix = f"blocks.{i}"
+
+        # Norms
+        norm1_weights = [pt_state_dict[f"{pt_block_prefix}.norm1.weight"].numpy()]
+        if hasattr(pt_block.norm1, "bias") and pt_block.norm1.bias is not None:
+            norm1_weights.append(pt_state_dict[f"{pt_block_prefix}.norm1.bias"].numpy())
+        block.norm1.set_weights(norm1_weights)
+
+        norm2_weights = [pt_state_dict[f"{pt_block_prefix}.norm2.weight"].numpy()]
+        if hasattr(pt_block.norm2, "bias") and pt_block.norm2.bias is not None:
+            norm2_weights.append(pt_state_dict[f"{pt_block_prefix}.norm2.bias"].numpy())
+        block.norm2.set_weights(norm2_weights)
+
+        # Attention Layers
+        qkv_weights = [pt_state_dict[f"{pt_block_prefix}.attn.qkv.weight"].T.numpy()]
+        if pt_block.attn.qkv.bias is not None:
+            qkv_weights.append(
+                pt_state_dict[f"{pt_block_prefix}.attn.qkv.bias"].numpy()
+            )
+        block.attn.qkv.set_weights(qkv_weights)
+
+        proj_weights = [pt_state_dict[f"{pt_block_prefix}.attn.proj.weight"].T.numpy()]
+        if pt_block.attn.proj.bias is not None:
+            proj_weights.append(
+                pt_state_dict[f"{pt_block_prefix}.attn.proj.bias"].numpy()
+            )
+        block.attn.proj.set_weights(proj_weights)
+
+        # LayerScale
+        if hasattr(block, "ls1") and hasattr(block.ls1, "gamma"):
+            block.ls1.gamma.assign(
+                pt_state_dict[f"{pt_block_prefix}.ls1.gamma"].numpy()
+            )
+        if hasattr(block, "ls2") and hasattr(block.ls2, "gamma"):
+            block.ls2.gamma.assign(
+                pt_state_dict[f"{pt_block_prefix}.ls2.gamma"].numpy()
+            )
+
+        # FFN Layers (Handles both Mlp and SwiGLUFFN)
+        if isinstance(block.mlp, Mlp):
+            fc1_weights = [pt_state_dict[f"{pt_block_prefix}.mlp.fc1.weight"].T.numpy()]
+            if pt_block.mlp.fc1.bias is not None:
+                fc1_weights.append(
+                    pt_state_dict[f"{pt_block_prefix}.mlp.fc1.bias"].numpy()
+                )
+            block.mlp.fc1.set_weights(fc1_weights)
+            fc2_weights = [pt_state_dict[f"{pt_block_prefix}.mlp.fc2.weight"].T.numpy()]
+            if pt_block.mlp.fc2.bias is not None:
+                fc2_weights.append(
+                    pt_state_dict[f"{pt_block_prefix}.mlp.fc2.bias"].numpy()
+                )
+            block.mlp.fc2.set_weights(fc2_weights)
+        elif isinstance(block.mlp, SwiGLUFFN):
+            w1_weights = [pt_state_dict[f"{pt_block_prefix}.mlp.w1.weight"].T.numpy()]
+            if pt_block.mlp.w1.bias is not None:
+                w1_weights.append(
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w1.bias"].numpy()
+                )
+            block.mlp.w1.set_weights(w1_weights)
+            w2_weights = [pt_state_dict[f"{pt_block_prefix}.mlp.w2.weight"].T.numpy()]
+            if pt_block.mlp.w2.bias is not None:
+                w2_weights.append(
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w2.bias"].numpy()
+                )
+            block.mlp.w2.set_weights(w2_weights)
+            w3_weights = [pt_state_dict[f"{pt_block_prefix}.mlp.w3.weight"].T.numpy()]
+            if pt_block.mlp.w3.bias is not None:
+                w3_weights.append(
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w3.bias"].numpy()
+                )
+            block.mlp.w3.set_weights(w3_weights)
+
+    # --- Final Layer Norm ---
+    final_norm_weights = [pt_state_dict["norm.weight"].numpy()]
+    if hasattr(keras_model.norm, "beta"):
+        final_norm_weights.append(pt_state_dict["norm.bias"].numpy())
+    keras_model.norm.set_weights(final_norm_weights)
+
+    if "rope_embed.periods" in pt_state_dict:
+        rope_periods = pt_state_dict["rope_embed.periods"].numpy()
+        keras_model.rope_embed.set_weights([rope_periods])
+
+
+# ==============================================================================
+# Test Suite for small-Large (ViT-L/16)
+# ==============================================================================
+
+
+def test_final_output_equivalence_with_vitsmall():
+    # --- 1. Define paths and model config ---
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+
+    # Skip the test if the required files don't exist
+    if not (os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)):
+        pytest.skip("DINOv3 repository or weight file not found. Skipping this test.")
+
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    # Configuration for dinov3_vits16.
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    # --- 2. Create PyTorch and Keras Models using Factory Functions ---
+    print("\nInstantiating models using vit_small and PT_vit_small...")
+
+    pt_model = PT_vit_small(**model_kwargs)
+
+    state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+
+    pt_model.eval()
+    print("PyTorch model created and pre-trained weights loaded.")
+
+    keras_model = vit_small(**model_kwargs)
+    dummy_input_np = np.random.randn(1, 224, 224, 3).astype("float32")
+    keras_model(dummy_input_np)
+    print("Keras model created and built.")
+
+    # --- 3. Transfer Weights ---
+    print("Transferring weights from PyTorch to Keras...")
+    transfer_weights_from_pt_to_keras(pt_model, keras_model)
+    print("Weight transfer complete.")
+
+    # --- 4. Create Identical Inputs ---
+    keras_input = keras.ops.convert_to_tensor(dummy_input_np)
+    pt_input = torch.from_numpy(dummy_input_np.transpose(0, 3, 1, 2))
+    print("Generated identical inputs for both frameworks.")
+
+    # --- 5. Get Model Outputs ---
+    print("Performing inference...")
+    keras_output = keras_model(keras_input, training=False)
+    with torch.no_grad():
+        pt_output = pt_model(pt_input, is_training=False)
+
+    # --- 6. Compare Outputs ---
+    print("Comparing outputs...")
+    keras_output_np = keras.ops.convert_to_numpy(keras_output)
+    pt_output_np = pt_output.detach().cpu().numpy()
+    try:
+        np.testing.assert_allclose(
+            keras_output_np,
+            pt_output_np,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="Final model outputs do not match after loading pre-trained weights",
+        )
+    except AssertionError as e:
+        print("\n❌ Outputs do not match!")
+        print(
+            f"Max absolute difference: {np.max(np.abs(keras_output_np - pt_output_np))}"
+        )
+        print(
+            f"Mean absolute difference: {np.mean(np.abs(keras_output_np - pt_output_np))}"
+        )
+        raise e
+
+    print(
+        "\n✅ Success! Final outputs from vit_small and PT_vit_small match perfectly."
+    )
+
+
+def test_deep_dive_block_equivalence_vitsmall():
+    # --- 1. Define paths and model config ---
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vits16_pretrain_lvd1689m-08c60483.pth"
+
+    if not (os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)):
+        pytest.skip("DINOv3 repository or weight file not found. Skipping this test.")
+
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    # --- 2. Create, Load, and Build Models ---
+    print("\n--- Starting Deep-Dive Block Equivalence Test ---")
+    print("Instantiating models using vit_small and PT_vit_small...")
+
+    # Create and load the PyTorch model
+    pt_model = PT_vit_small(**model_kwargs)
+    state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+    pt_model.eval()
+    print("PyTorch model created and pre-trained weights loaded.")
+
+    # Create and build the Keras model
+    keras_model = vit_small(**model_kwargs)
+    # Build the model by passing a dummy input so weights can be assigned
+    keras_model(np.random.randn(1, 224, 224, 3).astype("float32"))
+    print("Keras model created and built.")
+
+    # --- 3. Transfer Weights ---
+    print("Transferring weights from PyTorch to Keras...")
+    transfer_weights_from_pt_to_keras(pt_model, keras_model)
+    print("Weight transfer complete.")
+
+    # --- 4. Deep Dive Comparison Logic ---
+    any_failure = False
+
+    def _compare_and_correct(keras_tensor, torch_tensor, layer_name, block_idx):
+        nonlocal any_failure
+        torch_np = torch_tensor.detach().cpu().numpy()
+        keras_np = keras.ops.convert_to_numpy(keras_tensor)
+        try:
+            mean_diff = np.mean(np.abs(keras_np - torch_np))
+            print(
+                f"    Comparing Block {block_idx} - {layer_name}: Mean abs diff = {mean_diff}"
+            )
+            if np.isnan(keras_np).any():
+                raise AssertionError("Keras output contains NaN values.")
+            if mean_diff > 1e-4:
+                raise AssertionError(
+                    f"Mean absolute difference {mean_diff} exceeds tolerance of 1e-4."
+                )
+            print(f"    ✅ Block {block_idx} - {layer_name}: Output matches.")
+            return keras_tensor
+        except AssertionError as e:
+            print(
+                f"    ❌ FAILURE at Block {block_idx} - {layer_name}: Output mismatch."
+            )
+            print(f"       {e}")
+            any_failure = True
+            print(f"       Correcting Keras tensor to continue analysis...")
+            return keras.ops.convert_to_tensor(torch_np)
+
+    for i in range(len(keras_model.blocks)):
+        print(f"\n--- Analyzing Block {i} ---")
+
+        # 1. Create a new, unique input for this block to isolate errors
+        np.random.seed(i)
+        image_np = np.random.randn(
+            1, model_kwargs["img_size"], model_kwargs["img_size"], 3
+        ).astype("float32")
+        keras_input = keras.ops.convert_to_tensor(image_np)
+        pt_input = torch.from_numpy(image_np.transpose(0, 3, 1, 2))
+
+        # 2. Get initial tokens
+        keras_tokens, (H_k, W_k) = keras_model.prepare_tokens_with_masks(keras_input)
+        pt_tokens, (H_pt, W_pt) = pt_model.prepare_tokens_with_masks(pt_input)
+
+        # 3. Get RoPE embeddings
+        rope_keras = keras_model.rope_embed(H=H_k, W=W_k, training=False)
+        rope_torch = pt_model.rope_embed(H=H_pt, W=W_pt)
+
+        # 4. Get the corresponding block from each model
+        keras_block = keras_model.blocks[i]
+        pt_block = pt_model.blocks[i]
+
+        # --- Deep Dive into the Block ---
+
+        # Layer 1: Normalization 1
+        keras_norm1_out = keras_block.norm1(keras_tokens)
+        pt_norm1_out = pt_block.norm1(pt_tokens)
+        keras_norm1_out = _compare_and_correct(
+            keras_norm1_out, pt_norm1_out, "Norm1", i
+        )
+
+        # Layer 2: Attention
+        keras_attn_out = keras_block.attn(
+            keras_norm1_out, rope=rope_keras, training=False
+        )
+        pt_attn_out = pt_block.attn(pt_norm1_out, rope=rope_torch)
+        keras_attn_out = _compare_and_correct(
+            keras_attn_out, pt_attn_out, "Attention", i
+        )
+
+        # Layer 3: LayerScale 1 & DropPath 1
+        keras_ls1_out = keras_block.ls1(keras_attn_out, training=False)
+        pt_ls1_out = pt_block.ls1(pt_attn_out)
+        keras_ls1_out = _compare_and_correct(
+            keras_ls1_out, pt_ls1_out, "LayerScale1", i
+        )
+
+        # Residual Connection 1
+        keras_res1_out = keras_tokens + keras_ls1_out
+        pt_res1_out = pt_tokens + pt_ls1_out
+        keras_res1_out = _compare_and_correct(
+            keras_res1_out, pt_res1_out, "Residual1", i
+        )
+
+        # Layer 4: Normalization 2
+        keras_norm2_out = keras_block.norm2(keras_res1_out)
+        pt_norm2_out = pt_block.norm2(pt_res1_out)
+        keras_norm2_out = _compare_and_correct(
+            keras_norm2_out, pt_norm2_out, "Norm2", i
+        )
+
+        # Layer 5: MLP (Feed-Forward Network)
+        keras_mlp_out = keras_block.mlp(keras_norm2_out, training=False)
+        pt_mlp_out = pt_block.mlp(pt_norm2_out)
+        keras_mlp_out = _compare_and_correct(keras_mlp_out, pt_mlp_out, "MLP", i)
+
+        # Layer 6: LayerScale 2 & DropPath 2
+        keras_ls2_out = keras_block.ls2(keras_mlp_out, training=False)
+        pt_ls2_out = pt_block.ls2(pt_mlp_out)
+        keras_ls2_out = _compare_and_correct(
+            keras_ls2_out, pt_ls2_out, "LayerScale2", i
+        )
+
+        # Residual Connection 2 (Final Block Output)
+        keras_final_out = keras_res1_out + keras_ls2_out
+        pt_final_out = pt_res1_out + pt_ls2_out
+        _compare_and_correct(keras_final_out, pt_final_out, "Final Block Output", i)
+
+    print("\n--- Deep-Dive Analysis Complete ---")
+    assert (
+        not any_failure
+    ), "One or more internal layers had an output mismatch. See logs for details."
+
+
+# ==============================================================================
+# Test Suite for ViT-Base (ViT-B/16)
+# ==============================================================================
+
+
+def test_final_output_equivalence_with_vitbase():
+    # --- 1. Define paths and model config ---
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth"
+
+    # Skip the test if the required files don't exist
+    if not (os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)):
+        pytest.skip("DINOv3 repository or weight file not found. Skipping this test.")
+
+    # Add DINO repo to Python path to allow torch.hub.load to find the model definition
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    # Configuration for dinov3_vitb16.
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    # --- 2. Create PyTorch and Keras Models using Factory Functions ---
+    print("\nInstantiating models using vit_base and PT_vit_base...")
+
+    # Create the PyTorch model using its factory function
+    pt_model = PT_vit_base(**model_kwargs)
+
+    # Load the pre-trained weights into the instantiated model
+    state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+
+    pt_model.eval()
+    print("PyTorch model created and pre-trained weights loaded.")
+
+    # Create the Keras model using its factory function
+    keras_model = vit_base(**model_kwargs)
+    # Build the Keras model by passing a dummy input
+    dummy_input_np = np.random.randn(1, 224, 224, 3).astype("float32")
+    keras_model(dummy_input_np)
+    print("Keras model created and built.")
+
+    # --- 3. Transfer Weights ---
+    print("Transferring weights from PyTorch to Keras...")
+    transfer_weights_from_pt_to_keras(pt_model, keras_model)
+    print("Weight transfer complete.")
+
+    # --- 4. Create Identical Inputs ---
+    keras_input = keras.ops.convert_to_tensor(dummy_input_np)
+    pt_input = torch.from_numpy(dummy_input_np.transpose(0, 3, 1, 2))
+    print("Generated identical inputs for both frameworks.")
+
+    # --- 5. Get Model Outputs ---
+    print("Performing inference...")
+    # Get Keras output (inference mode)
+    keras_output = keras_model(keras_input, training=False)
+    # Get PyTorch output (inference mode)
+    with torch.no_grad():
+        pt_output = pt_model(pt_input, is_training=False)
+
+    # --- 6. Compare Outputs ---
+    print("Comparing outputs...")
+    keras_output_np = keras.ops.convert_to_numpy(keras_output)
+    pt_output_np = pt_output.detach().cpu().numpy()
+
+    # Assert that the outputs are numerically close within a tolerance
+    try:
+        np.testing.assert_allclose(
+            keras_output_np,
+            pt_output_np,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="Final model outputs do not match after loading pre-trained weights",
+        )
+    except AssertionError as e:
+        print("\n❌ Outputs do not match!")
+        print(
+            f"Max absolute difference: {np.max(np.abs(keras_output_np - pt_output_np))}"
+        )
+        print(
+            f"Mean absolute difference: {np.mean(np.abs(keras_output_np - pt_output_np))}"
+        )
+        raise e
+
+    print("\n✅ Success! Final outputs from vit_base and PT_vit_base match perfectly.")
+
+
+def test_deep_dive_block_equivalence_vitbase():
+    # --- 1. Define paths and model config ---
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth"
+
+    if not (os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)):
+        pytest.skip("DINOv3 repository or weight file not found. Skipping this test.")
+
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    # Configuration for dinov3_vitb16.
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    # --- 2. Create, Load, and Build Models ---
+    print("\n--- Starting Deep-Dive Block Equivalence Test for ViT-Base ---")
+    print("Instantiating models using vit_base and PT_vit_base...")
+
+    # Create and load the PyTorch model
+    pt_model = PT_vit_base(**model_kwargs)
+    state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+    pt_model.eval()
+    print("PyTorch model created and pre-trained weights loaded.")
+
+    # Create and build the Keras model
+    keras_model = vit_base(**model_kwargs)
+    # Build the model by passing a dummy input so weights can be assigned
+    keras_model(np.random.randn(1, 224, 224, 3).astype("float32"))
+    print("Keras model created and built.")
+
+    # --- 3. Transfer Weights ---
+    print("Transferring weights from PyTorch to Keras...")
+    transfer_weights_from_pt_to_keras(pt_model, keras_model)
+    print("Weight transfer complete.")
+
+    # --- 4. Deep Dive Comparison Logic  ---
+    any_failure = False
+
+    def _compare_and_correct(keras_tensor, torch_tensor, layer_name, block_idx):
+        nonlocal any_failure
+        torch_np = torch_tensor.detach().cpu().numpy()
+        keras_np = keras.ops.convert_to_numpy(keras_tensor)
+        try:
+            mean_diff = np.mean(np.abs(keras_np - torch_np))
+            print(
+                f"    Comparing Block {block_idx} - {layer_name}: Mean abs diff = {mean_diff}"
+            )
+            if np.isnan(keras_np).any():
+                raise AssertionError("Keras output contains NaN values.")
+            if mean_diff > 1e-4:  # Using a stricter tolerance for deep dive
+                raise AssertionError(
+                    f"Mean absolute difference {mean_diff} exceeds tolerance of 1e-4."
+                )
+            print(f"    ✅ Block {block_idx} - {layer_name}: Output matches.")
+            return keras_tensor  # Return the original Keras tensor if it matches
+        except AssertionError as e:
+            print(
+                f"    ❌ FAILURE at Block {block_idx} - {layer_name}: Output mismatch."
+            )
+            print(f"       {e}")
+            any_failure = True
+            print(f"       Correcting Keras tensor to continue analysis...")
+            return keras.ops.convert_to_tensor(torch_np)
+
+    for i in range(len(keras_model.blocks)):
+        print(f"\n--- Analyzing Block {i} ---")
+
+        # 1. Create a new, unique input for this block to isolate errors
+        np.random.seed(i)
+        image_np = np.random.randn(
+            1, model_kwargs["img_size"], model_kwargs["img_size"], 3
+        ).astype("float32")
+        keras_input = keras.ops.convert_to_tensor(image_np)
+        pt_input = torch.from_numpy(image_np.transpose(0, 3, 1, 2))
+
+        # 2. Get initial tokens
+        keras_tokens, (H_k, W_k) = keras_model.prepare_tokens_with_masks(keras_input)
+        pt_tokens, (H_pt, W_pt) = pt_model.prepare_tokens_with_masks(pt_input)
+
+        # 3. Get RoPE embeddings
+        rope_keras = keras_model.rope_embed(H=H_k, W=W_k, training=False)
+        rope_torch = pt_model.rope_embed(H=H_pt, W=W_pt)
+
+        # 4. Get the corresponding block from each model
+        keras_block = keras_model.blocks[i]
+        pt_block = pt_model.blocks[i]
+
+        # --- Deep Dive into the Block ---
+
+        # Layer 1: Normalization 1
+        keras_norm1_out = keras_block.norm1(keras_tokens)
+        pt_norm1_out = pt_block.norm1(pt_tokens)
+        keras_norm1_out = _compare_and_correct(
+            keras_norm1_out, pt_norm1_out, "Norm1", i
+        )
+
+        # Layer 2: Attention
+        keras_attn_out = keras_block.attn(
+            keras_norm1_out, rope=rope_keras, training=False
+        )
+        pt_attn_out = pt_block.attn(pt_norm1_out, rope=rope_torch)
+        keras_attn_out = _compare_and_correct(
+            keras_attn_out, pt_attn_out, "Attention", i
+        )
+
+        # Layer 3: LayerScale 1 & DropPath 1 (DropPath is identity in eval mode)
+        keras_ls1_out = keras_block.ls1(keras_attn_out, training=False)
+        pt_ls1_out = pt_block.ls1(pt_attn_out)
+        keras_ls1_out = _compare_and_correct(
+            keras_ls1_out, pt_ls1_out, "LayerScale1", i
+        )
+
+        # Residual Connection 1
+        keras_res1_out = keras_tokens + keras_ls1_out
+        pt_res1_out = pt_tokens + pt_ls1_out
+        keras_res1_out = _compare_and_correct(
+            keras_res1_out, pt_res1_out, "Residual1", i
+        )
+
+        # Layer 4: Normalization 2
+        keras_norm2_out = keras_block.norm2(keras_res1_out)
+        pt_norm2_out = pt_block.norm2(pt_res1_out)
+        keras_norm2_out = _compare_and_correct(
+            keras_norm2_out, pt_norm2_out, "Norm2", i
+        )
+
+        # Layer 5: MLP (Feed-Forward Network)
+        keras_mlp_out = keras_block.mlp(keras_norm2_out, training=False)
+        pt_mlp_out = pt_block.mlp(pt_norm2_out)
+        keras_mlp_out = _compare_and_correct(keras_mlp_out, pt_mlp_out, "MLP", i)
+
+        # Layer 6: LayerScale 2 & DropPath 2 (DropPath is identity in eval mode)
+        keras_ls2_out = keras_block.ls2(keras_mlp_out, training=False)
+        pt_ls2_out = pt_block.ls2(pt_mlp_out)
+        keras_ls2_out = _compare_and_correct(
+            keras_ls2_out, pt_ls2_out, "LayerScale2", i
+        )
+
+        # Residual Connection 2 (Final Block Output)
+        keras_final_out = keras_res1_out + keras_ls2_out
+        pt_final_out = pt_res1_out + pt_ls2_out
+        _compare_and_correct(keras_final_out, pt_final_out, "Final Block Output", i)
+
+    print("\n--- Deep-Dive Analysis for ViT-Base Complete ---")
+    assert (
+        not any_failure
+    ), "One or more internal layers for ViT-Base had an output mismatch. See logs for details."
+
+
+# ==============================================================================
+# Test Suite for ViT-Large (ViT-L/16)
+# ==============================================================================
+
+
+def test_final_output_equivalence_with_vitlarge():
+    # --- 1. Define paths and model config ---
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vitl16_pretrain_lvd1689m-8aa4cbdd.pth"
+
+    if not (os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)):
+        pytest.skip("DINOv3 repository or weight file not found. Skipping this test.")
+
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    # --- 2. Create PyTorch and Keras Models using Factory Functions ---
+    print("\nInstantiating models using vit_large and PT_vit_large...")
+
+    pt_model = PT_vit_large(**model_kwargs)
+
+    # Load the pre-trained weights into the instantiated model
+    state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+
+    pt_model.eval()
+    print("PyTorch model created and pre-trained weights loaded.")
+
+    # Create the Keras model using its factory function
+    keras_model = vit_large(**model_kwargs)
+    # Build the Keras model by passing a dummy input
+    dummy_input_np = np.random.randn(1, 224, 224, 3).astype("float32")
+    keras_model(dummy_input_np)
+    print("Keras model created and built.")
+
+    # --- 3. Transfer Weights ---
+    print("Transferring weights from PyTorch to Keras...")
+    transfer_weights_from_pt_to_keras(pt_model, keras_model)
+    print("Weight transfer complete.")
+
+    # --- 4. Create Identical Inputs ---
+    keras_input = keras.ops.convert_to_tensor(dummy_input_np)
+    pt_input = torch.from_numpy(dummy_input_np.transpose(0, 3, 1, 2))
+    print("Generated identical inputs for both frameworks.")
+
+    # --- 5. Get Model Outputs ---
+    print("Performing inference...")
+    # Get Keras output (inference mode)
+    keras_output = keras_model(keras_input, training=False)
+    # Get PyTorch output (inference mode)
+    with torch.no_grad():
+        pt_output = pt_model(pt_input, is_training=False)
+
+    # --- 6. Compare Outputs ---
+    print("Comparing outputs...")
+    # Convert both outputs to numpy arrays for comparison
+    keras_output_np = keras.ops.convert_to_numpy(keras_output)
+    pt_output_np = pt_output.detach().cpu().numpy()
+
+    # Assert that the outputs are numerically close within a tolerance
+    try:
+        np.testing.assert_allclose(
+            keras_output_np,
+            pt_output_np,
+            rtol=1e-5,
+            atol=1e-5,
+            err_msg="Final model outputs do not match after loading pre-trained weights",
+        )
+    except AssertionError as e:
+        print("\n❌ Outputs do not match!")
+        print(
+            f"Max absolute difference: {np.max(np.abs(keras_output_np - pt_output_np))}"
+        )
+        print(
+            f"Mean absolute difference: {np.mean(np.abs(keras_output_np - pt_output_np))}"
+        )
+        raise e
+
+    print(
+        "\n✅ Success! Final outputs from vit_large and PT_vit_large match perfectly."
+    )
+
+
+def test_deep_dive_block_equivalence_vitlarge():
+    # --- 1. Define paths and model config ---
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    DINO_WEIGHT_PATH = r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3_vitl16_pretrain_lvd1689m-8aa4cbdd.pth"
+
+    # Skip the test if the required files don't exist
+    if not (os.path.isdir(DINO_REPO_PATH) and os.path.isfile(DINO_WEIGHT_PATH)):
+        pytest.skip("DINOv3 repository or weight file not found. Skipping this test.")
+
+    # Add DINO repo to Python path to allow torch.hub.load to find the model definition
+    if DINO_REPO_PATH not in sys.path:
+        sys.path.insert(0, DINO_REPO_PATH)
+
+    # Configuration for dinov3_vitl16.
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    # --- 2. Create, Load, and Build Models ---
+    print("\n--- Starting Deep-Dive Block Equivalence Test for ViT-Large ---")
+    print("Instantiating models using vit_large and PT_vit_large...")
+
+    # Create and load the PyTorch model
+    pt_model = PT_vit_large(**model_kwargs)
+    state_dict = torch.load(DINO_WEIGHT_PATH, map_location=torch.device("cpu"))
+    pt_model.load_state_dict(state_dict, strict=False)
+    pt_model.eval()
+    print("PyTorch model created and pre-trained weights loaded.")
+
+    # Create and build the Keras model
+    keras_model = vit_large(**model_kwargs)
+    # Build the model by passing a dummy input so weights can be assigned
+    keras_model(np.random.randn(1, 224, 224, 3).astype("float32"))
+    print("Keras model created and built.")
+
+    # --- 3. Transfer Weights ---
+    print("Transferring weights from PyTorch to Keras...")
+    transfer_weights_from_pt_to_keras(pt_model, keras_model)
+    print("Weight transfer complete.")
+
+    # --- 4. Deep Dive Comparison Logic ---
+    any_failure = False
+
+    def _compare_and_correct(keras_tensor, torch_tensor, layer_name, block_idx):
+        nonlocal any_failure
+        torch_np = torch_tensor.detach().cpu().numpy()
+        keras_np = keras.ops.convert_to_numpy(keras_tensor)
+        try:
+            mean_diff = np.mean(np.abs(keras_np - torch_np))
+            print(
+                f"    Comparing Block {block_idx} - {layer_name}: Mean abs diff = {mean_diff}"
+            )
+            if np.isnan(keras_np).any():
+                raise AssertionError("Keras output contains NaN values.")
+            if mean_diff > 1e-4:
+                raise AssertionError(
+                    f"Mean absolute difference {mean_diff} exceeds tolerance of 1e-4."
+                )
+            print(f"    ✅ Block {block_idx} - {layer_name}: Output matches.")
+            return keras_tensor
+        except AssertionError as e:
+            print(
+                f"    ❌ FAILURE at Block {block_idx} - {layer_name}: Output mismatch."
+            )
+            print(f"       {e}")
+            any_failure = True
+            print(f"       Correcting Keras tensor to continue analysis...")
+            return keras.ops.convert_to_tensor(torch_np)
+
+    # Sequentially test each block
+    for i in range(len(keras_model.blocks)):
+        print(f"\n--- Analyzing Block {i} ---")
+
+        # 1. Create a new, unique input for this block to isolate errors
+        np.random.seed(i)
+        image_np = np.random.randn(
+            1, model_kwargs["img_size"], model_kwargs["img_size"], 3
+        ).astype("float32")
+        keras_input = keras.ops.convert_to_tensor(image_np)
+        pt_input = torch.from_numpy(image_np.transpose(0, 3, 1, 2))
+
+        # 2. Get initial tokens
+        keras_tokens, (H_k, W_k) = keras_model.prepare_tokens_with_masks(keras_input)
+        pt_tokens, (H_pt, W_pt) = pt_model.prepare_tokens_with_masks(pt_input)
+
+        # 3. Get RoPE embeddings
+        rope_keras = keras_model.rope_embed(H=H_k, W=W_k, training=False)
+        rope_torch = pt_model.rope_embed(H=H_pt, W=W_pt)
+
+        # 4. Get the corresponding block from each model
+        keras_block = keras_model.blocks[i]
+        pt_block = pt_model.blocks[i]
+
+        # --- Deep Dive into the Block ---
+
+        # Layer 1: Normalization 1
+        keras_norm1_out = keras_block.norm1(keras_tokens)
+        pt_norm1_out = pt_block.norm1(pt_tokens)
+        keras_norm1_out = _compare_and_correct(
+            keras_norm1_out, pt_norm1_out, "Norm1", i
+        )
+
+        # Layer 2: Attention
+        keras_attn_out = keras_block.attn(
+            keras_norm1_out, rope=rope_keras, training=False
+        )
+        pt_attn_out = pt_block.attn(pt_norm1_out, rope=rope_torch)
+        keras_attn_out = _compare_and_correct(
+            keras_attn_out, pt_attn_out, "Attention", i
+        )
+
+        # Layer 3: LayerScale 1 & DropPath 1 (DropPath is identity in eval mode)
+        keras_ls1_out = keras_block.ls1(keras_attn_out, training=False)
+        pt_ls1_out = pt_block.ls1(pt_attn_out)
+        keras_ls1_out = _compare_and_correct(
+            keras_ls1_out, pt_ls1_out, "LayerScale1", i
+        )
+
+        # Residual Connection 1
+        keras_res1_out = keras_tokens + keras_ls1_out
+        pt_res1_out = pt_tokens + pt_ls1_out
+        keras_res1_out = _compare_and_correct(
+            keras_res1_out, pt_res1_out, "Residual1", i
+        )
+
+        # Layer 4: Normalization 2
+        keras_norm2_out = keras_block.norm2(keras_res1_out)
+        pt_norm2_out = pt_block.norm2(pt_res1_out)
+        keras_norm2_out = _compare_and_correct(
+            keras_norm2_out, pt_norm2_out, "Norm2", i
+        )
+
+        # Layer 5: MLP (Feed-Forward Network)
+        keras_mlp_out = keras_block.mlp(keras_norm2_out, training=False)
+        pt_mlp_out = pt_block.mlp(pt_norm2_out)
+        keras_mlp_out = _compare_and_correct(keras_mlp_out, pt_mlp_out, "MLP", i)
+
+        # Layer 6: LayerScale 2 & DropPath 2
+        keras_ls2_out = keras_block.ls2(keras_mlp_out, training=False)
+        pt_ls2_out = pt_block.ls2(pt_mlp_out)
+        keras_ls2_out = _compare_and_correct(
+            keras_ls2_out, pt_ls2_out, "LayerScale2", i
+        )
+
+        # Residual Connection 2 (Final Block Output)
+        keras_final_out = keras_res1_out + keras_ls2_out
+        pt_final_out = pt_res1_out + pt_ls2_out
+        _compare_and_correct(keras_final_out, pt_final_out, "Final Block Output", i)
+
+    print("\n--- Deep-Dive Analysis for ViT-Large Complete ---")
+    assert (
+        not any_failure
+    ), "One or more internal layers for ViT-Large had an output mismatch. See logs for details."
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/paz/models/foundation/dinov3/port_dino_weights_from_torch_to_keras.py
+++ b/paz/models/foundation/dinov3/port_dino_weights_from_torch_to_keras.py
@@ -1,0 +1,284 @@
+import os
+import sys
+import logging
+import torch
+import numpy as np
+
+# --- Configuration for Keras Backend and Environment ---
+
+os.environ["KERAS_BACKEND"] = "jax"
+script_path = os.path.abspath(__file__)
+script_dir = os.path.dirname(script_path)
+project_root = os.path.abspath(os.path.join(script_dir, "..", "..", "..", ".."))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import torch
+
+# ==============================================================================
+# Keras Layer Implementation
+# ==============================================================================
+from paz.models.foundation.dinov3.models.vision_transformer import (
+    vit_small,
+    vit_base,
+    vit_large,
+)
+
+# ==============================================================================
+# PyTorch to Keras Weight Porting Function (Adapted for DINOv3)
+# ==============================================================================
+
+
+def transfer_weights_from_pt_to_keras(pt_state_dict, keras_model):
+    """
+    Loads weights from a PyTorch DINOv3 state_dict into a native Keras DINOv3 model.
+
+    Args:
+        pt_state_dict: The state_dict from the pretrained PyTorch model.
+        keras_model: An instance of a Keras DinoVisionTransformer model.
+    """
+    logging.info(f"Starting weight porting for Keras model '{keras_model.name}'...")
+
+    # --- Standalone Weights (cls_token, mask_token, storage_tokens) ---
+    keras_model.cls_token.assign(pt_state_dict["cls_token"].numpy())
+    logging.info("✓ Ported cls_token.")
+
+    keras_model.mask_token.assign(pt_state_dict["mask_token"].numpy())
+    logging.info("✓ Ported mask_token.")
+
+    if "storage_tokens" in pt_state_dict and keras_model.storage_tokens is not None:
+        keras_model.storage_tokens.assign(pt_state_dict["storage_tokens"].numpy())
+        logging.info("✓ Ported storage_tokens.")
+
+    # --- Patch Embedding ---
+    patch_embed_layer = keras_model.patch_embed
+
+    pe_weights = [pt_state_dict["patch_embed.proj.weight"].permute(2, 3, 1, 0).numpy()]
+    if "patch_embed.proj.bias" in pt_state_dict:
+        pe_weights.append(pt_state_dict["patch_embed.proj.bias"].numpy())
+
+    patch_embed_layer.projection.set_weights(pe_weights)
+    logging.info("✓ Ported patch_embed weights.")
+
+    # --- RoPE Embedding (Only periods/inv_freq is set if present) ---
+    if "rope_embed.periods" in pt_state_dict:
+        rope_periods = pt_state_dict["rope_embed.periods"].float().numpy()
+        keras_model.rope_embed.set_weights([rope_periods])
+        logging.info("✓ Ported rope_embed periods.")
+
+    # --- Transformer Blocks ---
+    number_of_blocks = len(keras_model.blocks)
+    logging.info(f"Found {number_of_blocks} transformer blocks to port...")
+
+    for i in range(number_of_blocks):
+        block = keras_model.blocks[i]
+        pt_block_prefix = f"blocks.{i}"
+
+        # Norms (StableLayerNormalization/RMSNorm inherit set_weights from Layer)
+        block.norm1.set_weights(
+            [
+                pt_state_dict[f"{pt_block_prefix}.norm1.weight"].numpy(),
+                pt_state_dict[f"{pt_block_prefix}.norm1.bias"].numpy(),
+            ]
+        )
+        block.norm2.set_weights(
+            [
+                pt_state_dict[f"{pt_block_prefix}.norm2.weight"].numpy(),
+                pt_state_dict[f"{pt_block_prefix}.norm2.bias"].numpy(),
+            ]
+        )
+
+        # Attention Layers
+        block.attn.qkv.set_weights(
+            [
+                pt_state_dict[f"{pt_block_prefix}.attn.qkv.weight"].T.numpy(),
+                pt_state_dict[f"{pt_block_prefix}.attn.qkv.bias"].numpy(),
+            ]
+        )
+        block.attn.proj.set_weights(
+            [
+                pt_state_dict[f"{pt_block_prefix}.attn.proj.weight"].T.numpy(),
+                pt_state_dict[f"{pt_block_prefix}.attn.proj.bias"].numpy(),
+            ]
+        )
+
+        # LayerScale (ls1 and ls2)
+        layer_scale_1_key = f"{pt_block_prefix}.ls1.gamma"
+        if layer_scale_1_key in pt_state_dict and hasattr(block, "ls1"):
+            block.ls1.gamma.assign(pt_state_dict[layer_scale_1_key].numpy())
+
+        layer_scale_2_key = f"{pt_block_prefix}.ls2.gamma"
+        if layer_scale_2_key in pt_state_dict and hasattr(block, "ls2"):
+            block.ls2.gamma.assign(pt_state_dict[layer_scale_2_key].numpy())
+
+        # FFN Layers (Handles both Mlp and SwiGLUFFN)
+        # Check FFN type by checking keys for Mlp first
+        if f"{pt_block_prefix}.mlp.fc1.weight" in pt_state_dict:
+            # Mlp (fc1, fc2)
+            block.mlp.fc1.set_weights(
+                [
+                    pt_state_dict[f"{pt_block_prefix}.mlp.fc1.weight"].T.numpy(),
+                    pt_state_dict[f"{pt_block_prefix}.mlp.fc1.bias"].numpy(),
+                ]
+            )
+            block.mlp.fc2.set_weights(
+                [
+                    pt_state_dict[f"{pt_block_prefix}.mlp.fc2.weight"].T.numpy(),
+                    pt_state_dict[f"{pt_block_prefix}.mlp.fc2.bias"].numpy(),
+                ]
+            )
+        elif f"{pt_block_prefix}.mlp.w1.weight" in pt_state_dict:
+            # SwiGLUFFN (w1, w2, w3) - as found in vision_transformer_test.py
+            block.mlp.w1.set_weights(
+                [
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w1.weight"].T.numpy(),
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w1.bias"].numpy(),
+                ]
+            )
+            block.mlp.w2.set_weights(
+                [
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w2.weight"].T.numpy(),
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w2.bias"].numpy(),
+                ]
+            )
+            block.mlp.w3.set_weights(
+                [
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w3.weight"].T.numpy(),
+                    pt_state_dict[f"{pt_block_prefix}.mlp.w3.bias"].numpy(),
+                ]
+            )
+        else:
+            raise KeyError(
+                f"Could not find FFN weights for block {i}. "
+                "Neither standard MLP nor SwiGLUFFN keys were found."
+            )
+
+        logging.info(f"✓ Ported block {i}.")
+
+    # --- Final Normalization Layers ---
+    keras_model.norm.set_weights(
+        [
+            pt_state_dict["norm.weight"].numpy(),
+            pt_state_dict["norm.bias"].numpy(),
+        ]
+    )
+    logging.info("✓ Ported final 'norm' layer.")
+
+    if keras_model.cls_norm:
+        keras_model.cls_norm.set_weights(
+            [
+                pt_state_dict["cls_norm.weight"].numpy(),
+                pt_state_dict["cls_norm.bias"].numpy(),
+            ]
+        )
+        logging.info("✓ Ported final 'cls_norm' layer.")
+
+    if keras_model.local_cls_norm:
+        keras_model.local_cls_norm.set_weights(
+            [
+                pt_state_dict["local_cls_norm.weight"].numpy(),
+                pt_state_dict["local_cls_norm.bias"].numpy(),
+            ]
+        )
+        logging.info("✓ Ported final 'local_cls_norm' layer.")
+
+    logging.info("\n--- Weight porting complete! ---")
+    return keras_model
+
+
+# ==============================================================================
+# Execution Script
+# ==============================================================================
+
+if __name__ == "__main__":
+
+    DINO_REPO_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3\dinov3"
+    )
+    MODELS_WEIGHTS_DIR_PATH = (
+        r"D:\DFKI_SeaMe_project\Tasks\Task2_porting_paz_model_to_keras3/"
+    )
+    MODEL_CONSTRUCTORS = {
+        "dinov3_vits16": vit_small,
+        "dinov3_vitb16": vit_base,
+        "dinov3_vitl16": vit_large,
+    }
+
+    MODEL_WEIGHTS_PATHS = {
+        "dinov3_vits16": r"dinov3_vits16_pretrain_lvd1689m-08c60483.pth",
+        "dinov3_vitb16": r"dinov3_vitb16_pretrain_lvd1689m-73cec8be.pth",
+        "dinov3_vitl16": r"dinov3_vitl16_pretrain_lvd1689m-8aa4cbdd.pth",
+    }
+
+    model_kwargs = {
+        "img_size": 224,
+        "patch_size": 16,
+        "ffn_layer": "mlp",
+        "untie_cls_and_patch_norms": False,
+        "norm_layer": "layernorm",
+        "layerscale_init": 1e-6,
+        "n_storage_tokens": 4,
+        "pos_embed_rope_dtype": "float32",
+    }
+
+    output_dir = "weights_dinov3"
+    os.makedirs(output_dir, exist_ok=True)
+    logging.info(f"Output directory set to: '{output_dir}'")
+
+    MODEL_CONFIGS = {}
+    for name, constructor in MODEL_CONSTRUCTORS.items():
+        MODEL_CONFIGS[name] = {
+            "constructor": constructor,
+            "weight_filename": MODEL_WEIGHTS_PATHS[name],
+            "keras_name": f"dino_{name}",
+            "kwargs": model_kwargs,
+        }
+
+    for model_key, config in MODEL_CONFIGS.items():
+        print("-" * 80)
+        logging.info(f"Processing model: {model_key}")
+
+        # --- Load PyTorch Weights ---
+        # Safely join the weights directory path and the specific filename
+        weight_path = os.path.join(MODELS_WEIGHTS_DIR_PATH, config["weight_filename"])
+
+        if not os.path.isfile(weight_path):
+            logging.error(f"PyTorch weight file not found at: {weight_path}. Skipping.")
+            continue
+
+        logging.info(f"Loading PyTorch state dict from: {weight_path}...")
+        # Map to CPU to avoid GPU memory issues if unnecessary
+        pytorch_state_dict = torch.load(weight_path, map_location=torch.device("cpu"))
+        logging.info("✓ PyTorch weights loaded successfully.")
+
+        # --- Instantiate Keras Model ---
+        logging.info("Instantiating Keras 3 DINOv3 model architecture...")
+        keras_dinov3_model = config["constructor"](
+            name=config["keras_name"], **config["kwargs"]
+        )
+
+        # --- Build Keras Model ---
+        logging.info("Building Keras model to initialize weights...")
+        img_size = config["kwargs"]["img_size"]
+        dummy_input = np.zeros((1, img_size, img_size, 3), dtype="float32")
+        # Call the model in inference mode to ensure all layers are built
+        _ = keras_dinov3_model(dummy_input, training=False)
+        logging.info("✓ Keras model built.")
+
+        # --- Port Weights ---
+        keras_dinov3_model_with_weights = transfer_weights_from_pt_to_keras(
+            pytorch_state_dict, keras_dinov3_model
+        )
+
+        # --- Save Keras Model ---
+        final_keras_model_path = os.path.join(output_dir, f"{model_key}_ported.keras")
+        logging.info(
+            f"Saving final native Keras model to '{final_keras_model_path}'..."
+        )
+        keras_dinov3_model_with_weights.save(final_keras_model_path)
+        logging.info("✓ Save complete.")
+        print("-" * 80 + "\n")
+
+    print("All configured models have been successfully ported and saved.")

--- a/paz/models/foundation/dinov3/utils/__init__.py
+++ b/paz/models/foundation/dinov3/utils/__init__.py
@@ -1,0 +1,1 @@
+from .utils import cat_keep_shapes, uncat_with_shapes, named_apply

--- a/paz/models/foundation/dinov3/utils/utils.py
+++ b/paz/models/foundation/dinov3/utils/utils.py
@@ -1,0 +1,40 @@
+import keras
+import numpy as np
+from typing import List, Tuple, Callable
+
+
+def cat_keep_shapes(
+    x_list: List[keras.KerasTensor],
+) -> Tuple[keras.KerasTensor, List[Tuple[int, ...]], List[int]]:
+    """Flattens and concatenates a list of tensors, preserving original shape info."""
+    shapes = [x.shape for x in x_list]
+
+    num_tokens = [
+        np.prod(x.shape[:-1]).item() if len(x.shape) > 1 else x.shape[0] for x in x_list
+    ]
+    reshaped_tensors = [
+        keras.ops.reshape(x, (n, x.shape[-1])) for x, n in zip(x_list, num_tokens)
+    ]
+    flattened = keras.ops.concatenate(reshaped_tensors, axis=0)
+    return flattened, shapes, num_tokens
+
+
+def uncat_with_shapes(
+    flattened: keras.KerasTensor,
+    shapes: List[Tuple[int, ...]],
+    num_tokens: List[int],
+) -> List[keras.KerasTensor]:
+    """Reverses the cat_keep_shapes operation."""
+    if len(num_tokens) == 1:
+        outputs_splitted = [flattened]
+    else:
+        split_indices = np.cumsum(num_tokens)[:-1].tolist()
+        outputs_splitted = keras.ops.split(flattened, split_indices, axis=0)
+
+    new_feature_dim = flattened.shape[-1]
+    shapes_adjusted = [shape[:-1] + (new_feature_dim,) for shape in shapes]
+
+    outputs_reshaped = [
+        keras.ops.reshape(o, s) for o, s in zip(outputs_splitted, shapes_adjusted)
+    ]
+    return outputs_reshaped

--- a/paz/models/foundation/dinov3/utils/utils.py
+++ b/paz/models/foundation/dinov3/utils/utils.py
@@ -38,3 +38,29 @@ def uncat_with_shapes(
         keras.ops.reshape(o, s) for o, s in zip(outputs_splitted, shapes_adjusted)
     ]
     return outputs_reshaped
+
+
+def named_apply(
+    fn: Callable,
+    module: keras.Layer,
+    name: str = "",
+    depth_first: bool = True,
+    include_root: bool = False,
+) -> keras.Layer:
+    if not depth_first and include_root:
+        fn(module=module, name=name)
+
+    for child_name, child_module in vars(module).items():
+        if isinstance(child_module, keras.Layer):
+            full_child_name = ".".join((name, child_name)) if name else child_name
+            named_apply(
+                fn=fn,
+                module=child_module,
+                name=full_child_name,
+                depth_first=depth_first,
+                include_root=True,
+            )
+    if depth_first and include_root:
+        fn(module=module, name=name)
+
+    return module


### PR DESCRIPTION
### **Title: Feat: Port DINOv3 Foundation Model to Keras 3**

### **Description**

This pull request introduces a complete, native Keras 3 implementation of the DINOv3 foundation model, fully ported from the original PyTorch version. This includes the `ViT-Small`, `ViT-Base`, and `ViT-Large` architectures.

The primary focus of this port is to achieve **numerical equivalence** with the original PyTorch models. To ensure this, a comprehensive testing framework has been built to validate every component, from individual layers to the full end-to-end model.

### **Key Components Added**

* **Core DINOv3 Models (`vision_transformer.py`)**:
    * Adds the main `DinoVisionTransformer` class.
    * Provides constructors for `vit_small`, `vit_base`, and `vit_large`.

* **Modular Keras Layers (`/layers`)**:
    * **Attention**: `SelfAttention` and `CausalSelfAttention`, including logic for applying Rotary Position Embeddings (RoPE).
    * **FFN**: `Mlp` and `SwiGLUFFN` feed-forward network layers.
    * **Embeddings**: `PatchEmbed` for image patching and `RopePositionEmbedding` for RoPE.
    * **Normalization/Scaling**: `RMSNorm` and `LayerScale`.
    * **Blocks**: `SelfAttentionBlock` and `CausalSelfAttentionBlock`, which assemble the above layers into a standard transformer block.
    * `__init__.py` files to correctly expose all new layers and models.

* **Weight Porting Script (`port_dino_weights_from_torch_to_keras.py`)**:
    * A standalone script to load an official PyTorch DINOv3 checkpoint (`.pth`) and save the weights into the native Keras 3 (`.keras`) format.

### **Testing & Verification**

This PR includes a rigorous testing strategy to guarantee the port's correctness:

1.  **Layer-Level Unit Tests**:
    * Every new Keras layer (e.g., `attention.py`, `block.py`, `rms_norm.py`) is paired with an extensive test file (e.g., `attention_test.py`).
    * Each test file imports a **PyTorch reference implementation** of that specific layer.
    * Tests automatically port weights from the PyTorch layer to the Keras layer and assert numerical equivalence using `np.testing.assert_allclose`.

2.  **End-to-End Model Equivalence (`dinov3_test.py`)**:
    * A new test suite validates the *entire* ported Keras model (ViT-S, B, L) against the *entire* reference PyTorch model.
    * It ensures that for a given input, the final output of the Keras model is numerically identical to the PyTorch model's output after loading the ported weights.

3.  **Deep-Dive Block Equivalence**:
    * The end-to-end test includes a "deep-dive" analysis that iterates through *every block* in the model.
    * It compares the output of each internal component (e.g., `norm1`, `attn`, `mlp`) between the Keras and PyTorch implementations, making it easy to isolate any discrepancies.