### PR TITLE
Speed up Gemma4 text demo with parallel prefill

### DIFF
--- a/examples/gemma4/demo_e2b.py
+++ b/examples/gemma4/demo_e2b.py
@@ -10,7 +10,7 @@ import argparse
 import sys
 from pathlib import Path
 
-import jax.numpy as jnp
+import numpy as np
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -19,10 +19,10 @@ if str(ROOT) not in sys.path:
 
 from examples.gemma4.configuration import load_config
 from examples.gemma4.inference import (
-    Gemma4DecoderStep,
+    Gemma4MultimodalDecoderStep,
     Gemma4PerLayerEmbeddingStep,
-    build_empty_cache,
 )
+from examples.gemma4.multimodal_decoding import generate_eager
 from examples.gemma4.tokenizer import Gemma4Tokenizer
 
 WEIGHTS_DIR = Path(__file__).resolve().with_name("weights")
@@ -42,35 +42,21 @@ def build_models(weights_dir):
     embedding_model = Gemma4PerLayerEmbeddingStep(config)
     embedding_model.load_weights(str(weights_dir / "embedding_step.weights.h5"))
     gc.collect()
-    step_model = Gemma4DecoderStep(config)
+    step_model = Gemma4MultimodalDecoderStep(config)
     step_model.load_weights(str(weights_dir / "decoder_step.weights.h5"))
     gc.collect()
     return embedding_model, step_model, config
 
 
 def generate(prompt, models, tokenizer, max_tokens=256):
+    # Parallel prefill (whole prompt in one forward) + eager greedy decode,
+    # mirroring demo_image.py. No vision embeddings on the text-only path.
     embedding_model, step_model, config = models
     token_ids = tokenizer.tokenize_generation_prompt(prompt)
-    stop_ids = set(tokenizer.get_stop_token_ids())
-    max_len = len(token_ids) + max_tokens
-    cache = jnp.array(build_empty_cache(config, max_len))
-    for index in range(len(token_ids) - 1):
-        token = jnp.array([[token_ids[index]]], dtype=jnp.int32)
-        cache_index = jnp.array([index], dtype=jnp.int32)
-        per_layer = embedding_model([token])
-        _, cache = step_model([token, cache, cache_index, per_layer])
-    generated = []
-    token = jnp.array([[token_ids[-1]]], dtype=jnp.int32)
-    cache_index = jnp.array([len(token_ids) - 1], dtype=jnp.int32)
-    for _ in range(max_tokens):
-        per_layer = embedding_model([token])
-        logits, cache = step_model([token, cache, cache_index, per_layer])
-        next_id = int(jnp.argmax(logits[0, 0]))
-        if next_id in stop_ids:
-            break
-        generated.append(next_id)
-        token = jnp.array([[next_id]], dtype=jnp.int32)
-        cache_index = cache_index + 1
+    stop = tokenizer.get_stop_token_ids()[-1]
+    no_vision = np.zeros((0, config.hidden_dim), "float32")
+    generated = generate_eager(step_model, embedding_model, no_vision, config,
+                               token_ids, [], stop, max_tokens)
     return tokenizer.detokenize(generated)
 
 

--- a/examples/gemma4/demo_image.py
+++ b/examples/gemma4/demo_image.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import cv2
 import jax
-import jax.numpy as jnp
 import numpy as np
 from keras import ops
 
@@ -23,9 +22,7 @@ from examples.gemma4.configuration import load_config
 from examples.gemma4.image_converter import preprocess_images
 from examples.gemma4.inference import (Gemma4MultimodalDecoderStep,
                                        Gemma4PerLayerEmbeddingStep)
-from examples.gemma4.inference import build_empty_cache
-from examples.gemma4.multimodal_decoding import (as_token, build_prompt_rows,
-                                                 call_step, trim_to_stop)
+from examples.gemma4.multimodal_decoding import generate_eager
 from examples.gemma4.tokenizer import Gemma4Tokenizer
 from examples.gemma4.vision import VisionEncoderArgs, build_vision_encoder
 
@@ -64,34 +61,6 @@ def build_text(config, weights_dir):
     return step, per_layer
 
 
-def decode_eager(step, per_layer_step, embeddings, config, tokens, indices,
-                 stop, max_tokens):
-    # Eager parallel prefill + Python decode loop, mirroring demo_e2b.generate.
-    # The full-program jit (multimodal_decoding.generate) constant-folds the
-    # multi-GB embedding tables into the executable, which a 31 GB host cannot
-    # afford alongside the resident E2B weights; keras already compiles each
-    # step, so this is equally fast for short captions.
-    embeds, per_layer = build_prompt_rows(
-        step, embeddings, tokens, indices, per_layer_step)
-    length = embeds.shape[1]
-    cache = jnp.asarray(build_empty_cache(config, length + max_tokens))
-    positions = jnp.arange(length, dtype="int32")[None]
-    logits, cache = call_step(step, embeds, cache, 0, positions, per_layer)
-    token = int(jnp.argmax(logits[0, -1]))
-    embedding = step.get_layer("token_embedding")
-    out, index = [token], length
-    while token != stop and len(out) < max_tokens:
-        per_layer = None if per_layer_step is None else per_layer_step(
-            as_token(token))
-        logits, cache = call_step(
-            step, embedding(as_token(token)), cache, index,
-            jnp.array([[index]], dtype="int32"), per_layer)
-        token = int(jnp.argmax(logits[0, -1]))
-        out.append(token)
-        index += 1
-    return trim_to_stop(out, stop)
-
-
 def build_prompt(tokenizer, num_image_tokens, question):
     head = tokenizer.tokenize("<|turn>user\n")[1:]
     tail = tokenizer.tokenize("{}<turn|>\n<|turn>model\n".format(question))[1:]
@@ -114,8 +83,8 @@ def caption(image_path, question, max_tokens, weights_dir=WEIGHTS):
     tokenizer = Gemma4Tokenizer(weights_dir / "tokenizer.json", add_bos=True)
     tokens, indices = build_prompt(tokenizer, len(embeddings), question)
     stop = tokenizer.get_stop_token_ids()[-1]
-    generated = decode_eager(step, per_layer, embeddings, config, tokens,
-                             indices, stop, max_tokens)
+    generated = generate_eager(step, per_layer, embeddings, config, tokens,
+                               indices, stop, max_tokens)
     return tokenizer.detokenize(generated)
 
 

--- a/examples/gemma4/multimodal_decoding.py
+++ b/examples/gemma4/multimodal_decoding.py
@@ -65,6 +65,44 @@ def generate(step_model, per_layer_step, vision_embeddings, config,
         select_greedy_token)
 
 
+def generate_eager(step_model, per_layer_step, vision_embeddings, config,
+                   prompt_ids, vision_indices, stop_id, max_tokens):
+    """Eager parallel prefill + Python greedy decode loop.
+
+    Prefills the whole prompt in ONE forward, then decodes token-by-token. The
+    full-program jit in `generate` constant-folds the multi-GB embedding tables
+    into the executable, which a modest host cannot afford alongside the
+    resident weights; keras compiles each step, so this is equally fast for
+    short outputs while staying within budget on the real E2B/E4B weights.
+    """
+    embeds, per_layer = build_prompt_rows(
+        step_model, vision_embeddings, prompt_ids, vision_indices,
+        per_layer_step)
+    length = embeds.shape[1]
+    cache = jnp.asarray(build_empty_cache(config, length + max_tokens))
+    positions = jnp.arange(length, dtype="int32")[None]
+    logits, cache = call_step(step_model, embeds, cache, 0, positions,
+                              per_layer)
+    token = int(jnp.argmax(logits[0, -1]))
+    embedding = step_model.get_layer("token_embedding")
+    out, index = [token], length
+    while token != stop_id and len(out) < max_tokens:
+        per_layer = decode_per_layer(per_layer_step, token)
+        logits, cache = call_step(
+            step_model, embedding(as_token(token)), cache, index,
+            jnp.array([[index]], dtype="int32"), per_layer)
+        token = int(jnp.argmax(logits[0, -1]))
+        out.append(token)
+        index += 1
+    return trim_to_stop(out, stop_id)
+
+
+def decode_per_layer(per_layer_step, token):
+    if per_layer_step is None:
+        return None
+    return per_layer_step(as_token(token))
+
+
 def generate_sample(step_model, per_layer_step, vision_embeddings, config,
                     prompt_ids, vision_indices, stop_id, max_tokens, key,
                     sampling):

--- a/examples/gemma4/multimodal_decoding.py
+++ b/examples/gemma4/multimodal_decoding.py
@@ -9,7 +9,7 @@ Gemma4MultimodalDecoderStep, which takes a precomputed input embedding and the
 query positions.
 """
 import jax
-import jax.numpy as jnp
+import jax.numpy as jp
 import numpy as np
 from keras import ops
 
@@ -18,7 +18,7 @@ from .sampling import sample_logits
 
 
 def as_token(token):
-    return jnp.array([[int(token)]], dtype="int32")
+    return jp.array([[int(token)]], dtype="int32")
 
 
 def build_prompt_rows(step_model, vision_embeddings, prompt_ids,
@@ -28,15 +28,15 @@ def build_prompt_rows(step_model, vision_embeddings, prompt_ids,
     embeds, per_layers = [], []
     for index, token in enumerate(prompt_ids):
         if index in image_position:
-            embeds.append(jnp.asarray(vision_embeddings[image_position[index]]))
+            embeds.append(jp.asarray(vision_embeddings[image_position[index]]))
             per_layers.append(per_layer_row(per_layer_step, 0))
         else:
             embeds.append(embedding(as_token(token))[0, 0])
             per_layers.append(per_layer_row(per_layer_step, token))
-    input_embeddings = jnp.stack(embeds)[None]
+    input_embeddings = jp.stack(embeds)[None]
     per_layer = None
     if per_layer_step is not None:
-        per_layer = jnp.stack(per_layers)[None]
+        per_layer = jp.stack(per_layers)[None]
     return input_embeddings, per_layer
 
 
@@ -49,7 +49,7 @@ def per_layer_row(per_layer_step, token):
 
 
 def call_step(step_model, embeds, cache, start, positions, per_layer):
-    index = jnp.reshape(jnp.asarray(start, dtype="int32"), (1,))
+    index = jp.reshape(jp.asarray(start, dtype="int32"), (1,))
     inputs = [embeds, cache, index, positions]
     if per_layer is not None:
         inputs.append(per_layer)
@@ -79,19 +79,19 @@ def generate_eager(step_model, per_layer_step, vision_embeddings, config,
         step_model, vision_embeddings, prompt_ids, vision_indices,
         per_layer_step)
     length = embeds.shape[1]
-    cache = jnp.asarray(build_empty_cache(config, length + max_tokens))
-    positions = jnp.arange(length, dtype="int32")[None]
+    cache = jp.asarray(build_empty_cache(config, length + max_tokens))
+    positions = jp.arange(length, dtype="int32")[None]
     logits, cache = call_step(step_model, embeds, cache, 0, positions,
                               per_layer)
-    token = int(jnp.argmax(logits[0, -1]))
+    token = int(jp.argmax(logits[0, -1]))
     embedding = step_model.get_layer("token_embedding")
     out, index = [token], length
     while token != stop_id and len(out) < max_tokens:
         per_layer = decode_per_layer(per_layer_step, token)
         logits, cache = call_step(
             step_model, embedding(as_token(token)), cache, index,
-            jnp.array([[index]], dtype="int32"), per_layer)
-        token = int(jnp.argmax(logits[0, -1]))
+            jp.array([[index]], dtype="int32"), per_layer)
+        token = int(jp.argmax(logits[0, -1]))
         out.append(token)
         index += 1
     return trim_to_stop(out, stop_id)
@@ -113,7 +113,7 @@ def generate_sample(step_model, per_layer_step, vision_embeddings, config,
 
 
 def select_greedy_token(logits, key):
-    return jnp.argmax(logits[0]).astype("int32")
+    return jp.argmax(logits[0]).astype("int32")
 
 
 def build_token_sampler(sampling):
@@ -128,8 +128,8 @@ def run_cached_generate(step_model, per_layer_step, vision_embeddings, config,
         per_layer_step)
     length = embeds.shape[1]
     max_length = length + max_tokens
-    cache = jnp.asarray(build_empty_cache(config, max_length))
-    positions = jnp.arange(length, dtype="int32")[None]
+    cache = jp.asarray(build_empty_cache(config, max_length))
+    positions = jp.arange(length, dtype="int32")[None]
     logits, cache = call_step(
         step_model, embeds, cache, 0, positions, per_layer)
     key, first_key = jax.random.split(key)
@@ -140,8 +140,8 @@ def run_cached_generate(step_model, per_layer_step, vision_embeddings, config,
         snapshot_variables(step_model),
         snapshot_variables(step_model.get_layer("token_embedding")),
         snapshot_variables(per_layer_step))
-    buffer, count = decode(cache, first, jnp.array(length, "int32"),
-                           jnp.array(stop_id, "int32"), key, variables)
+    buffer, count = decode(cache, first, jp.array(length, "int32"),
+                           jp.array(stop_id, "int32"), key, variables)
     generated = ops.convert_to_numpy(buffer[:int(count)]).tolist()
     return trim_to_stop(generated, stop_id)
 
@@ -174,8 +174,8 @@ def build_decode_loop(step_model, per_layer_step, max_length, max_tokens,
 
     @jax.jit
     def decode(cache, first_token, start_index, stop_id, key, variables):
-        buffer = jnp.zeros((max_tokens,), dtype="int32").at[0].set(first_token)
-        count = jnp.array(1, dtype="int32")
+        buffer = jp.zeros((max_tokens,), dtype="int32").at[0].set(first_token)
+        count = jp.array(1, dtype="int32")
         state = (buffer, first_token, start_index, cache, count,
                  first_token == stop_id, key)
         cont = build_should_continue(max_tokens, max_length)
@@ -200,10 +200,10 @@ def build_decode_step(step_model, embedding, per_layer_step, stop_id, select,
 
     def step(state):
         buffer, token, index, cache, count, _, key = state
-        token2d = jnp.reshape(token, (1, 1))
-        positions = jnp.reshape(index, (1, 1)).astype("int32")
+        token2d = jp.reshape(token, (1, 1))
+        positions = jp.reshape(index, (1, 1)).astype("int32")
         embeds = stateless_forward(embedding, embedding_vars, token2d)
-        inputs = [embeds, cache, jnp.reshape(index, (1,)).astype("int32"),
+        inputs = [embeds, cache, jp.reshape(index, (1,)).astype("int32"),
                   positions]
         if per_layer_vars is not None:
             inputs.append(
@@ -257,12 +257,12 @@ def run_batch_decode(step_model, per_layer_step, config, prompts, key, select,
     All rows share query positions, so the cached attention broadcasts across
     the batch. Returns one stop-trimmed token list per row.
     """
-    prompts = jnp.asarray(prompts, dtype="int32")
+    prompts = jp.asarray(prompts, dtype="int32")
     batch, length = prompts.shape
     embeds, per_layer = build_text_batch_rows(
         step_model, per_layer_step, prompts)
-    cache = jnp.asarray(build_empty_cache(config, length + max_tokens, batch))
-    positions = jnp.arange(length, dtype="int32")[None]
+    cache = jp.asarray(build_empty_cache(config, length + max_tokens, batch))
+    positions = jp.arange(length, dtype="int32")[None]
     logits, cache = call_step(
         step_model, embeds, cache, 0, positions, per_layer)
     key, token = pick_token(select, logits[:, -1], key)
@@ -274,7 +274,7 @@ def run_batch_decode(step_model, per_layer_step, config, prompts, key, select,
         per_layer = batch_per_layer(per_layer_step, token2d)
         logits, cache = call_step(
             step_model, embedding(token2d), cache, index,
-            jnp.full((1, 1), index, dtype="int32"), per_layer)
+            jp.full((1, 1), index, dtype="int32"), per_layer)
         key, token = pick_token(select, logits[:, -1], key)
         collected.append(token)
         finished = finished | (np.asarray(token) == stop_id)
@@ -307,7 +307,7 @@ def prefill_logits(step_model, per_layer_step, vision_embeddings, config,
         step_model, vision_embeddings, prompt_ids, vision_indices,
         per_layer_step)
     length = embeds.shape[1]
-    cache = jnp.asarray(build_empty_cache(config, length))
-    positions = jnp.arange(length, dtype="int32")[None]
+    cache = jp.asarray(build_empty_cache(config, length))
+    positions = jp.arange(length, dtype="int32")[None]
     logits, _ = call_step(step_model, embeds, cache, 0, positions, per_layer)
     return logits

--- a/examples/gemma4/multimodal_decoding_test.py
+++ b/examples/gemma4/multimodal_decoding_test.py
@@ -79,21 +79,21 @@ def test_cached_multimodal_matches_full_sequence():
 
 def reference_decode(step, per_layer_step, image, config, prompt_ids,
                      vision_indices, stop_id, max_tokens):
-    import jax.numpy as jnp
+    import jax.numpy as jp
     embeds, per_layer = build_prompt_rows(
         step, image, prompt_ids, vision_indices, per_layer_step)
     length = embeds.shape[1]
-    cache = jnp.asarray(build_empty_cache(config, length + max_tokens))
-    positions = jnp.arange(length, dtype="int32")[None]
+    cache = jp.asarray(build_empty_cache(config, length + max_tokens))
+    positions = jp.arange(length, dtype="int32")[None]
     logits, cache = call_step(step, embeds, cache, 0, positions, per_layer)
-    token = int(jnp.argmax(logits[0, -1]))
+    token = int(jp.argmax(logits[0, -1]))
     embedding = step.get_layer("token_embedding")
     out, index = [token], length
     while token != stop_id and len(out) < max_tokens:
-        positions = jnp.array([[index]], dtype="int32")
+        positions = jp.array([[index]], dtype="int32")
         logits, cache = call_step(
             step, embedding(as_token(token)), cache, index, positions, None)
-        token = int(jnp.argmax(logits[0, -1]))
+        token = int(jp.argmax(logits[0, -1]))
         out.append(token)
         index += 1
     return trim_to_stop(out, stop_id)

--- a/examples/gemma4/multimodal_decoding_test.py
+++ b/examples/gemma4/multimodal_decoding_test.py
@@ -13,10 +13,10 @@ import jax
 
 from .multimodal import build_multimodal_backbone
 from .inference import Gemma4MultimodalDecoderStep, build_empty_cache
-from .multimodal_decoding import (prefill_logits, generate, generate_sample,
-                                  generate_batch, generate_batch_greedy,
-                                  build_prompt_rows, call_step, trim_to_stop,
-                                  as_token)
+from .multimodal_decoding import (prefill_logits, generate, generate_eager,
+                                  generate_sample, generate_batch,
+                                  generate_batch_greedy, build_prompt_rows,
+                                  call_step, trim_to_stop, as_token)
 from .sampling import SamplingArgs
 
 TEXT = build_text_backbone_args(num_layers=2, sliding_window_pattern=2)
@@ -135,6 +135,16 @@ def test_generate_batch_greedy_matches_single_sequence():
     rows = generate_batch_greedy(step, None, TEXT, prompts, stop, 6)
     assert rows[0] == single
     assert rows[1] == single and rows[2] == single
+
+
+def test_generate_eager_matches_jitted_greedy():
+    step = build_text_step()
+    prompt = [2, 5, 9, 11, 7]
+    stop = int(TEXT.vocabulary_size - 1)
+    nov = np.zeros((0, TEXT.hidden_dim), "float32")
+    jitted = generate(step, None, nov, TEXT, prompt, [], stop, 6)
+    eager = generate_eager(step, None, nov, TEXT, prompt, [], stop, 6)
+    assert eager == jitted
 
 
 def test_generate_sample_peaked_matches_greedy_and_is_seeded():


### PR DESCRIPTION
## What

`demo_e2b` (text) prefilled the prompt **token-by-token** — one cached forward per position, with per-step cost growing as the KV cache fills. This switches it to the **parallel-prefill** path already used (and validated) by `demo_image`: the whole prompt goes through in **one** forward via `Gemma4MultimodalDecoderStep`, then decode proceeds eagerly token-by-token.

## How

- Promote `demo_image`'s local `decode_eager` into `multimodal_decoding.generate_eager` (eager parallel prefill + greedy decode) so both demos share one implementation.
- Point `demo_e2b.generate` at `generate_eager` (text-only: no vision embeddings).
- `demo_image` now imports the shared `generate_eager` and drops its private copy.

The eager decode loop is deliberate: the full-program `jit` in `generate` constant-folds the multi-GB embedding tables into the compiled executable and exhausts host memory on the real E2B/E4B weights. keras compiles each step, so eager is just as fast for short outputs while staying within budget.

## Compatibility

`demo_e2b` now loads `decoder_step.weights.h5` into `Gemma4MultimodalDecoderStep` instead of `Gemma4DecoderStep`. `demo_image` already does exactly this with the real weights; I also verified the cross-load + a `generate_eager` run with PLE enabled on a synthetic config.

## Tests

- New `test_generate_eager_matches_jitted_greedy` asserts the eager path is bit-identical to the jitted greedy `generate`.
- `multimodal_decoding_test`, `decoding_test`, `sampling_test`: 15 passed.
- Full `examples/gemma4/` suite: 31 passed, 3 skipped. The 6 failures present are pre-existing and environmental (missing `test_data/gemma4_test_tokenizer.json` fixture in this checkout) — they touch `tokenizer.py`/`demo_test.py` assets, not this change.