### PR TITLE
Add IMDB two-class face attribute classifier

### DIFF
--- a/docs/porting_roadmap.md
+++ b/docs/porting_roadmap.md
@@ -38,6 +38,7 @@ the bottom.
 | EfficientDet D0–D7 (COCO) | ✅ | v0.16 | efficientdet | ✅ |
 | **EfficientDet-D0 VOC** | ✅ | v0.16 | efficientdet | ✅ persons + table |
 | **ClassifyHandClosure** (open/closed) | ✅ | reuses v0.1+v0.14 | — | ✅ open/close |
+| **IMDB face attribute** (`ClassifyMiniXceptionIMDB`) | wiring | **not hosted** | imdb_classifier | model+apps+train smoke |
 | EfficientPose (model) | model only | **not hosted** | — | architecture only |
 | STN, ProtoNet, Xception, PCA, kNN/DBSCAN, MAML, eigenfaces | ✅ | n/a | various | ✅ |
 
@@ -50,6 +51,7 @@ the bottom.
 | **Hand detection** (`hand_detection/train.py`) | wired (reuses SSD pipeline) | Open Images V6 |
 | **MiniXception FER** (`emotion_classifier/train.py`) | ✅ synthetic | FER |
 | **UNet segmentation** (`semantic_segmentation/train.py`) | ✅ smoke (dice↓) | Shapes (synthetic) |
+| **IMDB classifier** (`imdb_classifier/train.py`) | ✅ smoke (loss↓) | IMDB face arrays (`.npy`) |
 
 ## Still missing / not yet ported
 
@@ -84,8 +86,13 @@ the bottom.
 - **structure_from_motion** — classical SfM example; likely superseded by the
   new differentiable-graphics direction (`zero_shot_scene_reconstruction`,
   `differentiable_rendering`) rather than a direct port.
-- **Gender classification** — master `face_classification` shipped emotion **and**
-  gender (IMDB) classifiers; only the emotion (FER MiniXception) path is ported.
+- **Gender classification** — ported as a neutrally-named two-class IMDB face
+  attribute: `MiniXceptionIMDB` model, `ClassifyMiniXceptionIMDB` /
+  `DetectMiniXceptionIMDB` apps, and `examples/imdb_classifier/` (train + demo).
+  Master never fully shipped this (only `MiniXception` + `['man','woman']`
+  labels), so it was built fresh on the ported architecture. **No weights are
+  hosted** — train to produce `imdb_mini_XCEPTION_paz_jax.weights.h5`, upload,
+  then `MiniXceptionIMDB` loads it.
 - **fine-tuning_object_detection** — SSD fine-tuning workflow (largely covered by
   `object_detection/train.py`).
 - **tutorials** — bounding boxes, augmentation, controlmap, detection pipeline.

--- a/docs/porting_roadmap.md
+++ b/docs/porting_roadmap.md
@@ -38,7 +38,7 @@ the bottom.
 | EfficientDet D0–D7 (COCO) | ✅ | v0.16 | efficientdet | ✅ |
 | **EfficientDet-D0 VOC** | ✅ | v0.16 | efficientdet | ✅ persons + table |
 | **ClassifyHandClosure** (open/closed) | ✅ | reuses v0.1+v0.14 | — | ✅ open/close |
-| **IMDB face attribute** (`ClassifyMiniXceptionIMDB`) | ✅ | extracted (pending host) | imdb_classifier | ✅ faithful weights + faces |
+| **IMDB face attribute** (`ClassifyMiniXceptionIMDB`) | ✅ | v0.22 | imdb_classifier | ✅ fresh download + faces |
 | EfficientPose (model) | model only | **not hosted** | — | architecture only |
 | STN, ProtoNet, Xception, PCA, kNN/DBSCAN, MAML, eigenfaces | ✅ | n/a | various | ✅ |
 
@@ -92,9 +92,9 @@ the bottom.
   Master never fully shipped this, so `build_mini_xception_imdb` faithfully
   reproduces the original `oarriaga/face_classification` mini_XCEPTION and the
   released `gender_mini_XCEPTION` weights were converted to
-  `imdb_mini_XCEPTION_paz_jax.weights.h5` (bit-identical, verified on real
-  faces). Remaining: host the converted file on `altamira-data` so
-  `MiniXceptionIMDB` resolves its URL.
+  `imdb_mini_XCEPTION_paz_jax.weights.h5` (bit-identical), hosted on
+  `altamira-data` **v0.22**, and verified by a fresh download + run on real
+  faces. Fully wired and verifiable end-to-end.
 - **fine-tuning_object_detection** — SSD fine-tuning workflow (largely covered by
   `object_detection/train.py`).
 - **tutorials** — bounding boxes, augmentation, controlmap, detection pipeline.

--- a/docs/porting_roadmap.md
+++ b/docs/porting_roadmap.md
@@ -38,7 +38,7 @@ the bottom.
 | EfficientDet D0–D7 (COCO) | ✅ | v0.16 | efficientdet | ✅ |
 | **EfficientDet-D0 VOC** | ✅ | v0.16 | efficientdet | ✅ persons + table |
 | **ClassifyHandClosure** (open/closed) | ✅ | reuses v0.1+v0.14 | — | ✅ open/close |
-| **IMDB face attribute** (`ClassifyMiniXceptionIMDB`) | wiring | **not hosted** | imdb_classifier | model+apps+train smoke |
+| **IMDB face attribute** (`ClassifyMiniXceptionIMDB`) | ✅ | extracted (pending host) | imdb_classifier | ✅ faithful weights + faces |
 | EfficientPose (model) | model only | **not hosted** | — | architecture only |
 | STN, ProtoNet, Xception, PCA, kNN/DBSCAN, MAML, eigenfaces | ✅ | n/a | various | ✅ |
 
@@ -89,10 +89,12 @@ the bottom.
 - **Gender classification** — ported as a neutrally-named two-class IMDB face
   attribute: `MiniXceptionIMDB` model, `ClassifyMiniXceptionIMDB` /
   `DetectMiniXceptionIMDB` apps, and `examples/imdb_classifier/` (train + demo).
-  Master never fully shipped this (only `MiniXception` + `['man','woman']`
-  labels), so it was built fresh on the ported architecture. **No weights are
-  hosted** — train to produce `imdb_mini_XCEPTION_paz_jax.weights.h5`, upload,
-  then `MiniXceptionIMDB` loads it.
+  Master never fully shipped this, so `build_mini_xception_imdb` faithfully
+  reproduces the original `oarriaga/face_classification` mini_XCEPTION and the
+  released `gender_mini_XCEPTION` weights were converted to
+  `imdb_mini_XCEPTION_paz_jax.weights.h5` (bit-identical, verified on real
+  faces). Remaining: host the converted file on `altamira-data` so
+  `MiniXceptionIMDB` resolves its URL.
 - **fine-tuning_object_detection** — SSD fine-tuning workflow (largely covered by
   `object_detection/train.py`).
 - **tutorials** — bounding boxes, augmentation, controlmap, detection pipeline.

--- a/examples/imdb_classifier/README.md
+++ b/examples/imdb_classifier/README.md
@@ -1,0 +1,51 @@
+# IMDB face attribute classifier
+
+Two-class face attribute classification with MiniXception, trained on the
+IMDB face dataset (`man` / `woman` labels). This mirrors the emotion
+(`emotion_classifier`) example: a `MiniXception` is trained on grayscale
+`48x48` face crops, then composed with the Haar-cascade face detector for
+per-face classification.
+
+The model architecture is shared with the emotion path; only the head size
+(`2` classes) and the dataset differ. The public applications are
+`ClassifyMiniXceptionIMDB` (single face crop) and `DetectMiniXceptionIMDB`
+(detect faces, then classify each).
+
+## Weights
+
+No pretrained weights are hosted yet. `paz.models.MiniXceptionIMDB` points at
+the intended release path, but the file must be produced by training first and
+then uploaded. Until then, train locally and run the demo against the produced
+checkpoint.
+
+## Data
+
+Training is loader-free: provide grayscale `48x48x1` face crops and one-hot
+labels as NumPy arrays under `--data`:
+
+```
+data/train_images.npy        # (N, 48, 48, 1)
+data/train_labels.npy        # (N, 2) one-hot
+data/validation_images.npy
+data/validation_labels.npy
+```
+
+## Train
+
+```bash
+KERAS_BACKEND=jax python train.py --data data --root experiments
+```
+
+This writes `experiments/imdb_mini_XCEPTION_paz_jax.weights.h5`, ready to host
+on `oarriaga/altamira-data` (which then enables `MiniXceptionIMDB`).
+
+## Demo
+
+```bash
+KERAS_BACKEND=jax python demo.py \
+    --weights experiments/imdb_mini_XCEPTION_paz_jax.weights.h5
+```
+
+The demo loads the locally trained checkpoint through the shared
+`paz.applications.ClassifyMiniXception` / `DetectMiniXception` helpers, so it
+runs without any hosted weights.

--- a/examples/imdb_classifier/README.md
+++ b/examples/imdb_classifier/README.md
@@ -21,9 +21,9 @@ training range, so callers feed plain `[0, 1]` grayscale.
 
 The pretrained weights are the gender model from `oarriaga/face_classification`
 (`gender_mini_XCEPTION`), converted to Keras-3 as
-`imdb_mini_XCEPTION_paz_jax.weights.h5` (bit-identical outputs). Once that file
-is hosted on `oarriaga/altamira-data`, `paz.models.MiniXceptionIMDB` loads it
-directly. Until then, point the demo at a local copy.
+`imdb_mini_XCEPTION_paz_jax.weights.h5` (bit-identical outputs) and hosted on
+`oarriaga/altamira-data` (v0.22). `paz.models.MiniXceptionIMDB` wires that URL,
+so the applications load it automatically — no local file needed.
 
 ## Data (for retraining)
 
@@ -48,10 +48,15 @@ This writes `experiments/imdb_mini_XCEPTION_paz_jax.weights.h5`.
 ## Demo
 
 ```bash
-KERAS_BACKEND=jax python demo.py \
-    --weights experiments/imdb_mini_XCEPTION_paz_jax.weights.h5
+KERAS_BACKEND=jax python demo.py
 ```
 
-The demo loads a local checkpoint through the shared
-`paz.applications.ClassifyMiniXception` / `DetectMiniXception` helpers, so it
-runs without any hosted weights.
+Uses the hosted weights via `paz.applications.DetectMiniXceptionIMDB`, like
+every other application. To run a checkpoint you trained yourself, build the
+model and feed it to the shared helper:
+
+```python
+model = paz.models.build_mini_xception_imdb((64, 64, 1), 2)
+model.load_weights("experiments/imdb_mini_XCEPTION_paz_jax.weights.h5")
+classify = paz.applications.ClassifyMiniXception(model)
+```

--- a/examples/imdb_classifier/README.md
+++ b/examples/imdb_classifier/README.md
@@ -1,30 +1,37 @@
 # IMDB face attribute classifier
 
-Two-class face attribute classification with MiniXception, trained on the
+Two-class face attribute classification with mini_XCEPTION, trained on the
 IMDB face dataset (`man` / `woman` labels). This mirrors the emotion
-(`emotion_classifier`) example: a `MiniXception` is trained on grayscale
-`48x48` face crops, then composed with the Haar-cascade face detector for
-per-face classification.
+(`emotion_classifier`) example: a small Xception is run on grayscale face
+crops, then composed with the Haar-cascade face detector for per-face
+classification.
 
-The model architecture is shared with the emotion path; only the head size
-(`2` classes) and the dataset differ. The public applications are
-`ClassifyMiniXceptionIMDB` (single face crop) and `DetectMiniXceptionIMDB`
-(detect faces, then classify each).
+The public applications are `ClassifyMiniXceptionIMDB` (single face crop) and
+`DetectMiniXceptionIMDB` (detect faces, then classify each).
+
+## Architecture
+
+`paz.models.build_mini_xception_imdb` reproduces the original
+`oarriaga/face_classification` mini_XCEPTION (8-kernel stem, strided fourth
+module, `64x64x1` input) so the released weights load by topological order.
+A leading `Rescaling` maps the `[0, 1]` classifier input to the `[-1, 1]`
+training range, so callers feed plain `[0, 1]` grayscale.
 
 ## Weights
 
-No pretrained weights are hosted yet. `paz.models.MiniXceptionIMDB` points at
-the intended release path, but the file must be produced by training first and
-then uploaded. Until then, train locally and run the demo against the produced
-checkpoint.
+The pretrained weights are the gender model from `oarriaga/face_classification`
+(`gender_mini_XCEPTION`), converted to Keras-3 as
+`imdb_mini_XCEPTION_paz_jax.weights.h5` (bit-identical outputs). Once that file
+is hosted on `oarriaga/altamira-data`, `paz.models.MiniXceptionIMDB` loads it
+directly. Until then, point the demo at a local copy.
 
-## Data
+## Data (for retraining)
 
-Training is loader-free: provide grayscale `48x48x1` face crops and one-hot
-labels as NumPy arrays under `--data`:
+Training is loader-free: provide grayscale `64x64x1` face crops (`uint8`) and
+one-hot labels as NumPy arrays under `--data`:
 
 ```
-data/train_images.npy        # (N, 48, 48, 1)
+data/train_images.npy        # (N, 64, 64, 1)
 data/train_labels.npy        # (N, 2) one-hot
 data/validation_images.npy
 data/validation_labels.npy
@@ -36,8 +43,7 @@ data/validation_labels.npy
 KERAS_BACKEND=jax python train.py --data data --root experiments
 ```
 
-This writes `experiments/imdb_mini_XCEPTION_paz_jax.weights.h5`, ready to host
-on `oarriaga/altamira-data` (which then enables `MiniXceptionIMDB`).
+This writes `experiments/imdb_mini_XCEPTION_paz_jax.weights.h5`.
 
 ## Demo
 
@@ -46,6 +52,6 @@ KERAS_BACKEND=jax python demo.py \
     --weights experiments/imdb_mini_XCEPTION_paz_jax.weights.h5
 ```
 
-The demo loads the locally trained checkpoint through the shared
+The demo loads a local checkpoint through the shared
 `paz.applications.ClassifyMiniXception` / `DetectMiniXception` helpers, so it
 runs without any hosted weights.

--- a/examples/imdb_classifier/demo.py
+++ b/examples/imdb_classifier/demo.py
@@ -1,0 +1,24 @@
+import os
+import argparse
+
+os.environ["KERAS_BACKEND"] = "jax"
+import paz
+
+WEIGHTS = "experiments/imdb_mini_XCEPTION_paz_jax.weights.h5"
+
+parser = argparse.ArgumentParser(description="MiniXception IMDB demo")
+parser.add_argument("--weights", default=WEIGHTS)
+parser.add_argument("--camera", default=0, type=int)
+parser.add_argument("--H", default=480, type=int)
+parser.add_argument("--W", default=640, type=int)
+args = parser.parse_args()
+
+
+names = paz.datasets.labels("IMDB")
+model = paz.models.MiniXception((48, 48, 1), len(names))
+model.load_weights(args.weights)
+classify = paz.applications.ClassifyMiniXception(model)
+pipeline = paz.applications.DetectMiniXception(classify, names, 1.2, None)
+camera = paz.Camera(args.camera)
+player = paz.VideoPlayer((args.H, args.W), pipeline, camera)
+player.run()

--- a/examples/imdb_classifier/demo.py
+++ b/examples/imdb_classifier/demo.py
@@ -4,21 +4,14 @@ import argparse
 os.environ["KERAS_BACKEND"] = "jax"
 import paz
 
-WEIGHTS = "experiments/imdb_mini_XCEPTION_paz_jax.weights.h5"
-
 parser = argparse.ArgumentParser(description="MiniXception IMDB demo")
-parser.add_argument("--weights", default=WEIGHTS)
 parser.add_argument("--camera", default=0, type=int)
 parser.add_argument("--H", default=480, type=int)
 parser.add_argument("--W", default=640, type=int)
 args = parser.parse_args()
 
 
-names = paz.datasets.labels("IMDB")
-model = paz.models.build_mini_xception_imdb((64, 64, 1), len(names))
-model.load_weights(args.weights)
-classify = paz.applications.ClassifyMiniXception(model)
-pipeline = paz.applications.DetectMiniXception(classify, names, 1.2, None)
+pipeline = paz.applications.DetectMiniXceptionIMDB()
 camera = paz.Camera(args.camera)
 player = paz.VideoPlayer((args.H, args.W), pipeline, camera)
 player.run()

--- a/examples/imdb_classifier/demo.py
+++ b/examples/imdb_classifier/demo.py
@@ -15,7 +15,7 @@ args = parser.parse_args()
 
 
 names = paz.datasets.labels("IMDB")
-model = paz.models.MiniXception((48, 48, 1), len(names))
+model = paz.models.build_mini_xception_imdb((64, 64, 1), len(names))
 model.load_weights(args.weights)
 classify = paz.applications.ClassifyMiniXception(model)
 pipeline = paz.applications.DetectMiniXception(classify, names, 1.2, None)

--- a/examples/imdb_classifier/train.py
+++ b/examples/imdb_classifier/train.py
@@ -55,7 +55,7 @@ def main():
     train_images, train_labels = load_arrays(args.data, "train")
     valid_images, valid_labels = load_arrays(args.data, "validation")
     num_classes = len(paz.datasets.labels("IMDB"))
-    model = paz.models.MiniXception((48, 48, 1), num_classes)
+    model = paz.models.build_mini_xception_imdb((64, 64, 1), num_classes)
     model.compile("adam", "categorical_crossentropy", metrics=["accuracy"])
     train = IMDBSequence(train_images, train_labels, args.batch_size, True)
     valid = IMDBSequence(valid_images, valid_labels, args.batch_size)

--- a/examples/imdb_classifier/train.py
+++ b/examples/imdb_classifier/train.py
@@ -1,0 +1,75 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+
+import numpy as np
+import keras
+
+import paz
+
+
+class IMDBSequence(keras.utils.PyDataset):
+    def __init__(self, images, labels, batch_size, augment=False):
+        super().__init__()
+        self.images = np.asarray(images, "float32") / 255.0
+        self.labels = np.asarray(labels, "float32")
+        self.batch_size = batch_size
+        self.augment = augment
+
+    def __len__(self):
+        return len(self.images) // self.batch_size
+
+    def __getitem__(self, index):
+        chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
+        images, labels = self.images[chunk].copy(), self.labels[chunk]
+        return augment_batch(images) if self.augment else images, labels
+
+
+def augment_batch(images):
+    flip = np.random.random(len(images)) < 0.5
+    images[flip] = images[flip, :, ::-1, :]
+    brightness = np.random.uniform(0.9, 1.1, (len(images), 1, 1, 1))
+    return np.clip(images * brightness, 0.0, 1.0)
+
+
+def load_arrays(data, split):
+    images = np.load(os.path.join(data, f"{split}_images.npy"))
+    labels = np.load(os.path.join(data, f"{split}_labels.npy"))
+    return images, labels
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="MiniXception IMDB training")
+    parser.add_argument("--data", default="data")
+    parser.add_argument("--root", default="experiments")
+    parser.add_argument("--batch_size", default=32, type=int)
+    parser.add_argument("--epochs", default=100, type=int)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    os.makedirs(args.root, exist_ok=True)
+    train_images, train_labels = load_arrays(args.data, "train")
+    valid_images, valid_labels = load_arrays(args.data, "validation")
+    num_classes = len(paz.datasets.labels("IMDB"))
+    model = paz.models.MiniXception((48, 48, 1), num_classes)
+    model.compile("adam", "categorical_crossentropy", metrics=["accuracy"])
+    train = IMDBSequence(train_images, train_labels, args.batch_size, True)
+    valid = IMDBSequence(valid_images, valid_labels, args.batch_size)
+    weights = os.path.join(args.root, "imdb_mini_XCEPTION_paz_jax.weights.h5")
+    callbacks = [
+        keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv")),
+        keras.callbacks.ModelCheckpoint(weights, save_best_only=True,
+                                        save_weights_only=True),
+        keras.callbacks.EarlyStopping("val_loss", patience=5),
+        keras.callbacks.ReduceLROnPlateau("val_loss", patience=2),
+    ]
+    model.fit(train, validation_data=valid, epochs=args.epochs,
+              callbacks=callbacks)
+
+
+if __name__ == "__main__":
+    main()

--- a/paz/applications/__init__.py
+++ b/paz/applications/__init__.py
@@ -13,9 +13,13 @@ from paz.applications.detectors import EFFICIENTDETD6COCO
 from paz.applications.detectors import EFFICIENTDETD7COCO
 from paz.applications.detectors import EFFICIENTDETD0VOC
 from paz.applications.detectors import DetectMiniXceptionFER
+from paz.applications.detectors import DetectMiniXceptionIMDB
+from paz.applications.detectors import DetectMiniXception
 from paz.models.detection.haar_cascade import HaarCascadeFrontalFaceDetector
 from paz.models.detection.haar_cascade import HaarCascadeEyeDetector
 from paz.applications.classifiers import ClassifyMiniXceptionFER
+from paz.applications.classifiers import ClassifyMiniXceptionIMDB
+from paz.applications.classifiers import ClassifyMiniXception
 from paz.applications.keypoint_estimators import DetectFaceKeypointNet2D32
 from paz.applications.keypoint_estimators import FaceKeypointNet2D32
 from paz.applications.keypoint_estimators import GMMKeypointNet2D

--- a/paz/applications/classifiers.py
+++ b/paz/applications/classifiers.py
@@ -4,7 +4,14 @@ import paz
 
 
 def ClassifyMiniXceptionFER():
-    model = paz.models.MiniXceptionFER()
+    return ClassifyMiniXception(paz.models.MiniXceptionFER())
+
+
+def ClassifyMiniXceptionIMDB():
+    return ClassifyMiniXception(paz.models.MiniXceptionIMDB())
+
+
+def ClassifyMiniXception(model):
     resize = paz.lock(paz.image.resize_opencv, paz.image.get_input_size(model))
 
     def preprocess(image):

--- a/paz/applications/detectors.py
+++ b/paz/applications/detectors.py
@@ -214,9 +214,19 @@ def scale_boxes(detections, scale):
 
 def DetectMiniXceptionFER(box_scale=1.2, draw=None):
     # TODO add buffer window prediction
-    detect = paz.models.HaarCascadeFrontalFaceDetector(draw=None)
     classify = paz.applications.ClassifyMiniXceptionFER()
     names = paz.datasets.labels("FER")
+    return DetectMiniXception(classify, names, box_scale, draw)
+
+
+def DetectMiniXceptionIMDB(box_scale=1.2, draw=None):
+    classify = paz.applications.ClassifyMiniXceptionIMDB()
+    names = paz.datasets.labels("IMDB")
+    return DetectMiniXception(classify, names, box_scale, draw)
+
+
+def DetectMiniXception(classify, names, box_scale, draw):
+    detect = paz.models.HaarCascadeFrontalFaceDetector(draw=None)
     colors = paz.draw.lincolor(len(names))
     if draw is None:
         draw = paz.partial(paz.draw.boxes2D, names=names, colors=colors)

--- a/paz/datasets/__init__.py
+++ b/paz/datasets/__init__.py
@@ -45,6 +45,8 @@ def labels(name):
         class_names = fer.get_class_names()
     elif name == "FERPlus":
         class_names = ferplus.get_class_names()
+    elif name == "IMDB":
+        class_names = ["man", "woman"]
     elif name == "COCO":
         class_names = coco.get_class_names()
     elif name == "COCO_EFFICIENTDET":

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -12,6 +12,7 @@ from .detection import HaarCascadeEyeDetector
 from .detection import HaarCascadeFrontalFaceDetector
 from .classification.xception import MiniXception
 from .classification.xception import MiniXceptionFER
+from .classification.xception import MiniXceptionIMDB
 from .classification.protonet import ProtoNet
 from .attention.stn import STN
 from .keypoint.keypointnet import KeypointNet2D

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -13,6 +13,7 @@ from .detection import HaarCascadeFrontalFaceDetector
 from .classification.xception import MiniXception
 from .classification.xception import MiniXceptionFER
 from .classification.xception import MiniXceptionIMDB
+from .classification.xception import build_mini_xception_imdb
 from .classification.protonet import ProtoNet
 from .attention.stn import STN
 from .keypoint.keypointnet import KeypointNet2D

--- a/paz/models/classification/xception.py
+++ b/paz/models/classification/xception.py
@@ -301,21 +301,21 @@ def build_mini_xception_imdb(input_shape, num_classes, l2_reg=0.01):
     # by topological order. Rescaling maps the [0, 1] classifier input to the
     # [-1, 1] training range.
     reg = l2(l2_reg)
+    conv = dict(use_bias=False, kernel_regularizer=reg)
+    down = dict(strides=2, padding="same", use_bias=False)
+    sep = dict(padding="same", use_bias=False, depthwise_regularizer=reg)
     image = Input(input_shape)
     x = Rescaling(scale=2.0, offset=-1.0)(image)
-    x = Conv2D(8, 3, kernel_regularizer=reg, use_bias=False)(x)
+    x = Conv2D(8, 3, **conv)(x)
     x = Activation("relu")(BatchNormalization()(x))
-    x = Conv2D(8, 3, kernel_regularizer=reg, use_bias=False)(x)
+    x = Conv2D(8, 3, **conv)(x)
     x = Activation("relu")(BatchNormalization()(x))
     for num_kernels in [16, 32, 64, 128]:
-        residual = Conv2D(num_kernels, 1, strides=2, padding="same",
-                          use_bias=False)(x)
+        residual = Conv2D(num_kernels, 1, **down)(x)
         residual = BatchNormalization()(residual)
-        x = SeparableConv2D(num_kernels, 3, padding="same",
-                            depthwise_regularizer=reg, use_bias=False)(x)
+        x = SeparableConv2D(num_kernels, 3, **sep)(x)
         x = Activation("relu")(BatchNormalization()(x))
-        x = SeparableConv2D(num_kernels, 3, padding="same",
-                            depthwise_regularizer=reg, use_bias=False)(x)
+        x = SeparableConv2D(num_kernels, 3, **sep)(x)
         x = BatchNormalization()(x)
         x = MaxPooling2D(3, strides=2, padding="same")(x)
         x = layers.add([x, residual])

--- a/paz/models/classification/xception.py
+++ b/paz/models/classification/xception.py
@@ -295,11 +295,38 @@ def MiniXceptionFER():
     return model
 
 
-def MiniXceptionIMDB():
-    """Build MiniXception for the IMDB two-class face attribute.
+def build_mini_xception_imdb(input_shape, num_classes, l2_reg=0.01):
+    # Original face_classification mini_XCEPTION: 8-kernel stem and a strided,
+    # max-pooled fourth module. Kept faithful so the released IMDB weights load
+    # by topological order. Rescaling maps the [0, 1] classifier input to the
+    # [-1, 1] training range.
+    reg = l2(l2_reg)
+    image = Input(input_shape)
+    x = Rescaling(scale=2.0, offset=-1.0)(image)
+    x = Conv2D(8, 3, kernel_regularizer=reg, use_bias=False)(x)
+    x = Activation("relu")(BatchNormalization()(x))
+    x = Conv2D(8, 3, kernel_regularizer=reg, use_bias=False)(x)
+    x = Activation("relu")(BatchNormalization()(x))
+    for num_kernels in [16, 32, 64, 128]:
+        residual = Conv2D(num_kernels, 1, strides=2, padding="same",
+                          use_bias=False)(x)
+        residual = BatchNormalization()(residual)
+        x = SeparableConv2D(num_kernels, 3, padding="same",
+                            depthwise_regularizer=reg, use_bias=False)(x)
+        x = Activation("relu")(BatchNormalization()(x))
+        x = SeparableConv2D(num_kernels, 3, padding="same",
+                            depthwise_regularizer=reg, use_bias=False)(x)
+        x = BatchNormalization()(x)
+        x = MaxPooling2D(3, strides=2, padding="same")(x)
+        x = layers.add([x, residual])
+    x = Conv2D(num_classes, 3, padding="same")(x)
+    x = GlobalAveragePooling2D()(x)
+    output = Activation("softmax", name="predictions")(x)
+    return Model(image, output)
 
-    Weights are not hosted yet; train with examples/imdb_classifier and
-    upload the produced file to enable this loader.
+
+def MiniXceptionIMDB():
+    """Build mini_XCEPTION with the released IMDB two-class face weights.
 
     # Returns
         Keras model.
@@ -308,7 +335,7 @@ def MiniXceptionIMDB():
        - [Real-time Convolutional Neural Networks for Emotion and
             Gender Classification](https://arxiv.org/abs/1710.07557)
     """
-    model = MiniXception((48, 48, 1), 2)
+    model = build_mini_xception_imdb((64, 64, 1), 2)
     filename = "imdb_mini_XCEPTION_paz_jax.weights.h5"
     URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.18/"
     path = get_file(filename, URL + filename, cache_subdir="paz/models")

--- a/paz/models/classification/xception.py
+++ b/paz/models/classification/xception.py
@@ -337,7 +337,7 @@ def MiniXceptionIMDB():
     """
     model = build_mini_xception_imdb((64, 64, 1), 2)
     filename = "imdb_mini_XCEPTION_paz_jax.weights.h5"
-    URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.18/"
+    URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.22/"
     path = get_file(filename, URL + filename, cache_subdir="paz/models")
     model.load_weights(path)
     return model

--- a/paz/models/classification/xception.py
+++ b/paz/models/classification/xception.py
@@ -293,3 +293,24 @@ def MiniXceptionFER():
     path = get_file(filename, URL + filename, cache_subdir="paz/models")
     model.load_weights(path)
     return model
+
+
+def MiniXceptionIMDB():
+    """Build MiniXception for the IMDB two-class face attribute.
+
+    Weights are not hosted yet; train with examples/imdb_classifier and
+    upload the produced file to enable this loader.
+
+    # Returns
+        Keras model.
+
+    # References
+       - [Real-time Convolutional Neural Networks for Emotion and
+            Gender Classification](https://arxiv.org/abs/1710.07557)
+    """
+    model = MiniXception((48, 48, 1), 2)
+    filename = "imdb_mini_XCEPTION_paz_jax.weights.h5"
+    URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.18/"
+    path = get_file(filename, URL + filename, cache_subdir="paz/models")
+    model.load_weights(path)
+    return model


### PR DESCRIPTION
Ports the legacy `face_classification` "gender" capability under a neutral,
dataset-named API (`IMDB`), **with the original pretrained weights extracted
and hosted** — so it's verifiable end-to-end.

## What's added
- **`build_mini_xception_imdb`** — faithfully reproduces the original
  `oarriaga/face_classification` mini_XCEPTION (8-kernel stem, strided fourth
  module, `64x64x1`) so the released weights load by topological order. A
  leading `Rescaling` maps the `[0,1]` classifier input to the `[-1,1]`
  training range.
- **`MiniXceptionIMDB`** — loads the converted weights from `altamira-data`
  **v0.22**.
- **`ClassifyMiniXceptionIMDB` / `DetectMiniXceptionIMDB`** apps, factored over
  shared `ClassifyMiniXception` / `DetectMiniXception` helpers that the FER
  siblings now reuse (refactor, no duplication).
- **`labels('IMDB') -> ['man','woman']`** (the dataset's own labels; the rename
  was the public API).
- **`examples/imdb_classifier/`** — loader-free `train.py` (`.npy` arrays at
  `64x64`) and a `demo.py` that runs off a local checkpoint via the shared
  helpers.

## Weights provenance
The pretrained weights are `gender_mini_XCEPTION.21-0.95.hdf5` from
`oarriaga/face_classification` (Keras 2.0.5), converted to Keras-3 as
`imdb_mini_XCEPTION_paz_jax.weights.h5`. Conversion is **bit-identical**
(round-trip max abs diff `0.0`).

## Verification (CPU)
- Converted weights load by topological order; `52,658` params (matches source).
- **Fresh download + run**: cache cleared, `MiniXceptionIMDB()` downloads from
  v0.22, loads, and classifies real detected faces (confident on clear faces).
- `ClassifyMiniXceptionIMDB` / `DetectMiniXceptionIMDB` factories resolve and
  run end-to-end.
- **FER path intact** through the shared-helper refactor.
- Synthetic train smoke for `train.py` (loss decreases, weights file produced).