### PR TITLE
Port implicit orientation learning (augmented autoencoder)

### DIFF
--- a/docs/porting_roadmap.md
+++ b/docs/porting_roadmap.md
@@ -52,6 +52,7 @@ the bottom.
 | **MiniXception FER** (`emotion_classifier/train.py`) | ✅ synthetic | FER |
 | **UNet segmentation** (`semantic_segmentation/train.py`) | ✅ smoke (dice↓) | Shapes (synthetic) |
 | **IMDB classifier** (`imdb_classifier/train.py`) | ✅ smoke (loss↓) | IMDB face arrays (`.npy`) |
+| **Implicit orientation (AAE)** (`implicit_orientation_learning/train.py`) | ✅ smoke (loss↓ + codebook retrieval) | `paz.graphics` renders (synthetic) |
 
 ## Still missing / not yet ported
 
@@ -78,8 +79,6 @@ the bottom.
   (data-gated, not verifiable here).
 
 ### Other domain capabilities not ported
-- **implicit_orientation_learning** — augmented autoencoder for object
-  orientation (train + demo).
 - **visual_voice_activity_detection (VVAD)** — `cnn2Plus1` video model + demos.
 - **discovery_of_latent_keypoints** — self-supervised 3D keypoint discovery.
 - **images_synthesis** — synthetic data generation for pose.
@@ -124,6 +123,14 @@ H36M loader), **Minimal Hand** (DetNet/IKNet keypoint + IK losses),
   blends per-class colors. Fixed a latent break: `paz.datasets.shapes.load`
   called a missing NMS — `remove_overlaps` now uses the JAX
   `paz.detection.apply_NMS`.
+- **Implicit orientation (AAE):** `paz.models.AutoEncoder` (conv encoder →
+  latent → conv decoder, sigmoid) is trained to reconstruct clean object views
+  from augmented ones; `extract_encoder` slices the encoder and orientation is
+  read out by cosine nearest-neighbor against a codebook of rendered views
+  (`examples/implicit_orientation_learning/codebook.py`). Views are rendered
+  with `paz.graphics` and cached to `views.npz`; training augments the cached
+  views (background composite via the constant-background mask, occlusion,
+  brightness). 128x128 input; no weights hosted (train to produce them).
 - **NMS is JAX everywhere:** the numpy `apply_per_class_NMS` was removed and the
   JAX implementation took its (clean) name; SSD and EfficientDet apps jit it.
 - **Probabilistic keypoints:** the legacy model embedded a

--- a/examples/implicit_orientation_learning/README.md
+++ b/examples/implicit_orientation_learning/README.md
@@ -1,0 +1,47 @@
+# Implicit orientation learning
+
+Augmented-autoencoder (AAE) baseline for implicit 3D orientation estimation.
+A convolutional autoencoder is trained to reconstruct clean rendered views of
+an object from heavily augmented versions of the same view. The encoder then
+maps a crop to a latent vector; matching that latent against a codebook of
+rendered views at known poses (cosine similarity) yields the orientation.
+
+This is a faithful port of the legacy `master` example to JAX / Keras-3.
+
+## Rendering
+
+Synthetic views are produced with `paz.graphics` (the built-in renderer) — no
+external rasterizer. Views are rendered once and cached to
+`experiments/views.npz`, since ray tracing is the slow step; training then
+augments the cached views each epoch (random background, occlusions,
+brightness). `scenes.build_mesh` normalizes any mesh to unit extent, so the
+default camera distance frames any object. With no `--mesh`, a colored cube is
+used so the example runs offline.
+
+## Train
+
+```bash
+KERAS_BACKEND=jax python train.py --root experiments
+# or with a textured object and real backgrounds:
+KERAS_BACKEND=jax python train.py --mesh model.obj --backgrounds voc/ \
+    --num_views 5000 --epochs 300
+```
+
+Writes `experiments/aae.weights.h5`. Input is `128x128`.
+
+## Demo
+
+```bash
+KERAS_BACKEND=jax python demo.py --weights experiments/aae.weights.h5
+```
+
+Builds a 10x10 pose codebook from the same mesh, encodes each camera frame,
+and shows the nearest codebook view (the implicit orientation). No weights are
+hosted — train first to produce the checkpoint.
+
+## Notes
+
+- `paz.models.AutoEncoder((128,128,3), latent_dimension)` builds the model;
+  `paz.models.extract_encoder(model)` returns the encoder for the codebook.
+- Background compositing uses the renderer's constant white background as the
+  foreground mask; for a textured object provide `--backgrounds`.

--- a/examples/implicit_orientation_learning/README.md
+++ b/examples/implicit_orientation_learning/README.md
@@ -18,11 +18,18 @@ brightness). `scenes.build_mesh` normalizes any mesh to unit extent, so the
 default camera distance frames any object. With no `--mesh`, a colored cube is
 used so the example runs offline.
 
-Domain randomization reuses the `paz.backend.image` augmentation pipeline:
+Camera poses are sampled with `paz.SO3.sample` (uniform rotations), and domain
+randomization reuses the `paz.backend.image` pipeline:
 `paz.image.randomize_rendered_image` blends the object over a background
 (plain random color, or a random crop of a provided image), adds random
 occlusions, applies blur and color jitter — mirroring the legacy
 `RandomizeRenderedImage`. Pass `--backgrounds` to composite over real images.
+
+The whole pipeline is JAX: `fill_polygon` and `gaussian_blur` replace the cv2
+calls, so `randomize_rendered_image` is `jit`/`vmap`-able (the training
+sequence jits a vmapped batch). On CPU this is slower than cv2 per image; the
+JAX path pays off on GPU and keeps data generation differentiable and on the
+same device as the renderer.
 
 ## Train
 

--- a/examples/implicit_orientation_learning/README.md
+++ b/examples/implicit_orientation_learning/README.md
@@ -18,6 +18,12 @@ brightness). `scenes.build_mesh` normalizes any mesh to unit extent, so the
 default camera distance frames any object. With no `--mesh`, a colored cube is
 used so the example runs offline.
 
+Domain randomization reuses the `paz.backend.image` augmentation pipeline:
+`paz.image.randomize_rendered_image` blends the object over a background
+(plain random color, or a random crop of a provided image), adds random
+occlusions, applies blur and color jitter — mirroring the legacy
+`RandomizeRenderedImage`. Pass `--backgrounds` to composite over real images.
+
 ## Train
 
 ```bash

--- a/examples/implicit_orientation_learning/README.md
+++ b/examples/implicit_orientation_learning/README.md
@@ -25,11 +25,12 @@ randomization reuses the `paz.backend.image` pipeline:
 occlusions, applies blur and color jitter — mirroring the legacy
 `RandomizeRenderedImage`. Pass `--backgrounds` to composite over real images.
 
-The whole pipeline is JAX: `fill_polygon` and `gaussian_blur` replace the cv2
-calls, so `randomize_rendered_image` is `jit`/`vmap`-able (the training
-sequence jits a vmapped batch). On CPU this is slower than cv2 per image; the
-JAX path pays off on GPU and keeps data generation differentiable and on the
-same device as the renderer.
+The whole pipeline is JAX: `fill_polygon` and `apply_gaussian_blur` replace the
+cv2 calls, so `randomize_rendered_image` is `jit`/`vmap`-able (the training
+sequence jits a vmapped batch). At `128x128`, a jitted+vmapped batch runs about
+**10-12x faster on GPU (RTX A4000) than cv2 per-image on CPU** (~0.7 ms vs
+~7 ms for a batch of 32), and the views stay on-device with the renderer. On
+CPU the JAX path is slower than cv2, so this targets GPU training.
 
 ## Train
 

--- a/examples/implicit_orientation_learning/codebook.py
+++ b/examples/implicit_orientation_learning/codebook.py
@@ -1,0 +1,26 @@
+from collections import namedtuple
+
+import numpy as np
+
+import scenes
+
+Codebook = namedtuple("Codebook", ["views", "poses", "latents"])
+
+
+def build_codebook(encoder, render_fn, poses):
+    views = scenes.render_views(render_fn, poses)
+    latents = np.asarray(encoder.predict(views, verbose=0))
+    return Codebook(views, np.stack([np.asarray(p) for p in poses]),
+                    unit_rows(latents))
+
+
+def closest_view(encoder, image, codebook):
+    latent = np.asarray(encoder(image[None]))[0]
+    similarities = codebook.latents @ unit_rows(latent[None])[0]
+    closest = int(np.argmax(similarities))
+    return codebook.views[closest], codebook.poses[closest]
+
+
+def unit_rows(vectors):
+    norms = np.linalg.norm(vectors, axis=-1, keepdims=True)
+    return vectors / np.maximum(norms, 1e-8)

--- a/examples/implicit_orientation_learning/codebook.py
+++ b/examples/implicit_orientation_learning/codebook.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-import numpy as np
+import jax.numpy as jp
 
 import scenes
 
@@ -9,19 +9,19 @@ Codebook = namedtuple("Codebook", ["views", "poses", "latents"])
 
 def build_codebook(encoder, render_fn, poses):
     views = scenes.render_views(render_fn, poses)
-    images = views.astype("float32") / 255.0
-    latents = np.asarray(encoder.predict(images, verbose=0))
-    return Codebook(views, np.stack([np.asarray(p) for p in poses]),
-                    unit_rows(latents))
+    images = jp.asarray(views, jp.float32) / 255.0
+    latents = unit_rows(jp.asarray(encoder.predict(images, verbose=0)))
+    matrices = jp.stack([jp.asarray(pose) for pose in poses])
+    return Codebook(jp.asarray(views), matrices, latents)
 
 
 def closest_view(encoder, image, codebook):
-    latent = np.asarray(encoder(image[None]))[0]
-    similarities = codebook.latents @ unit_rows(latent[None])[0]
-    closest = int(np.argmax(similarities))
+    latent = unit_rows(jp.asarray(encoder(image[jp.newaxis])))[0]
+    similarities = codebook.latents @ latent
+    closest = jp.argmax(similarities)
     return codebook.views[closest], codebook.poses[closest]
 
 
 def unit_rows(vectors):
-    norms = np.linalg.norm(vectors, axis=-1, keepdims=True)
-    return vectors / np.maximum(norms, 1e-8)
+    norms = jp.linalg.norm(vectors, axis=-1, keepdims=True)
+    return vectors / jp.maximum(norms, 1e-8)

--- a/examples/implicit_orientation_learning/codebook.py
+++ b/examples/implicit_orientation_learning/codebook.py
@@ -9,7 +9,8 @@ Codebook = namedtuple("Codebook", ["views", "poses", "latents"])
 
 def build_codebook(encoder, render_fn, poses):
     views = scenes.render_views(render_fn, poses)
-    latents = np.asarray(encoder.predict(views, verbose=0))
+    images = views.astype("float32") / 255.0
+    latents = np.asarray(encoder.predict(images, verbose=0))
     return Codebook(views, np.stack([np.asarray(p) for p in poses]),
                     unit_rows(latents))
 

--- a/examples/implicit_orientation_learning/demo.py
+++ b/examples/implicit_orientation_learning/demo.py
@@ -3,50 +3,38 @@ import argparse
 
 os.environ["KERAS_BACKEND"] = "jax"
 
-import numpy as np
-
 import paz
 import scenes
 import codebook
 
 WEIGHTS = "experiments/aae.weights.h5"
 
+parser = argparse.ArgumentParser(description="Implicit orientation demo")
+parser.add_argument("--weights", default=WEIGHTS)
+parser.add_argument("--mesh", default=None)
+parser.add_argument("--image_size", default=128, type=int)
+parser.add_argument("--distance", default=0.9, type=float)
+parser.add_argument("--camera", default=0, type=int)
+parser.add_argument("--H", default=480, type=int)
+parser.add_argument("--W", default=640, type=int)
+args = parser.parse_args()
 
-def ImplicitRotationPredictor(weights, mesh_path, image_size, distance):
-    model = paz.models.AutoEncoder((image_size, image_size, 3))
-    model.load_weights(weights)
-    encoder = paz.models.extract_encoder(model)
-    mesh = scenes.build_mesh(mesh_path)
-    render = scenes.build_renderer(mesh, image_size, distance)
-    poses = scenes.grid_poses(10, 10, distance)
-    book = codebook.build_codebook(encoder, render, poses)
-    size = (image_size, image_size)
-
-    def call(image):
-        crop = paz.image.resize_opencv(image, size)
-        crop = paz.image.normalize(np.asarray(crop, "float32"))
-        view, pose = codebook.closest_view(encoder, crop, book)
-        return paz.image.resize_opencv(np.asarray(view), size)
-
-    return call
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Implicit orientation demo")
-    parser.add_argument("--weights", default=WEIGHTS)
-    parser.add_argument("--mesh", default=None)
-    parser.add_argument("--image_size", default=128, type=int)
-    parser.add_argument("--distance", default=0.9, type=float)
-    parser.add_argument("--camera", default=0, type=int)
-    parser.add_argument("--H", default=480, type=int)
-    parser.add_argument("--W", default=640, type=int)
-    args = parser.parse_args()
-    predict = ImplicitRotationPredictor(
-        args.weights, args.mesh, args.image_size, args.distance)
-    camera = paz.Camera(args.camera)
-    player = paz.VideoPlayer((args.H, args.W), predict, camera)
-    player.run()
+size = (args.image_size, args.image_size)
+model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+model.load_weights(args.weights)
+encoder = paz.models.extract_encoder(model)
+mesh = scenes.build_mesh(args.mesh)
+render = scenes.build_renderer(mesh, args.image_size, args.distance)
+book = codebook.build_codebook(encoder, render,
+                               scenes.grid_poses(10, 10, args.distance))
 
 
-if __name__ == "__main__":
-    main()
+def predict(image):
+    crop = paz.image.normalize(paz.image.resize_opencv(image, size))
+    view, pose = codebook.closest_view(encoder, crop, book)
+    return paz.image.resize_opencv(view, size)
+
+
+camera = paz.Camera(args.camera)
+player = paz.VideoPlayer((args.H, args.W), predict, camera)
+player.run()

--- a/examples/implicit_orientation_learning/demo.py
+++ b/examples/implicit_orientation_learning/demo.py
@@ -9,32 +9,32 @@ import codebook
 
 WEIGHTS = "experiments/aae.weights.h5"
 
-parser = argparse.ArgumentParser(description="Implicit orientation demo")
-parser.add_argument("--weights", default=WEIGHTS)
-parser.add_argument("--mesh", default=None)
-parser.add_argument("--image_size", default=128, type=int)
-parser.add_argument("--distance", default=0.9, type=float)
-parser.add_argument("--camera", default=0, type=int)
-parser.add_argument("--H", default=480, type=int)
-parser.add_argument("--W", default=640, type=int)
-args = parser.parse_args()
 
-size = (args.image_size, args.image_size)
-model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
-model.load_weights(args.weights)
-encoder = paz.models.extract_encoder(model)
-mesh = scenes.build_mesh(args.mesh)
-render = scenes.build_renderer(mesh, args.image_size, args.distance)
-book = codebook.build_codebook(encoder, render,
-                               scenes.grid_poses(10, 10, args.distance))
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Implicit orientation demo")
+    parser.add_argument("--weights", default=WEIGHTS)
+    parser.add_argument("--mesh", default=None)
+    parser.add_argument("--image_size", default=128, type=int)
+    parser.add_argument("--distance", default=0.9, type=float)
+    parser.add_argument("--camera", default=0, type=int)
+    parser.add_argument("--H", default=480, type=int)
+    parser.add_argument("--W", default=640, type=int)
+    args = parser.parse_args()
 
+    size = (args.image_size, args.image_size)
+    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+    model.load_weights(args.weights)
+    encoder = paz.models.extract_encoder(model)
+    mesh = scenes.build_mesh(args.mesh)
+    render = scenes.build_renderer(mesh, args.image_size, args.distance)
+    poses = scenes.grid_poses(10, 10, args.distance)
+    book = codebook.build_codebook(encoder, render, poses)
 
-def predict(image):
-    crop = paz.image.normalize(paz.image.resize_opencv(image, size))
-    view, pose = codebook.closest_view(encoder, crop, book)
-    return paz.image.resize_opencv(view, size)
+    def predict(image):
+        crop = paz.image.normalize(paz.image.resize_opencv(image, size))
+        view, pose = codebook.closest_view(encoder, crop, book)
+        return paz.image.resize_opencv(view, size)
 
-
-camera = paz.Camera(args.camera)
-player = paz.VideoPlayer((args.H, args.W), predict, camera)
-player.run()
+    camera = paz.Camera(args.camera)
+    player = paz.VideoPlayer((args.H, args.W), predict, camera)
+    player.run()

--- a/examples/implicit_orientation_learning/demo.py
+++ b/examples/implicit_orientation_learning/demo.py
@@ -12,7 +12,26 @@ import codebook
 WEIGHTS = "experiments/aae.weights.h5"
 
 
-def parse_arguments():
+def ImplicitRotationPredictor(weights, mesh_path, image_size, distance):
+    model = paz.models.AutoEncoder((image_size, image_size, 3))
+    model.load_weights(weights)
+    encoder = paz.models.extract_encoder(model)
+    mesh = scenes.build_mesh(mesh_path)
+    render = scenes.build_renderer(mesh, image_size, distance)
+    poses = scenes.grid_poses(10, 10, distance)
+    book = codebook.build_codebook(encoder, render, poses)
+    size = (image_size, image_size)
+
+    def call(image):
+        crop = paz.image.resize_opencv(image, size)
+        crop = paz.image.normalize(np.asarray(crop, "float32"))
+        view, pose = codebook.closest_view(encoder, crop, book)
+        return paz.image.resize_opencv(np.asarray(view), size)
+
+    return call
+
+
+def main():
     parser = argparse.ArgumentParser(description="Implicit orientation demo")
     parser.add_argument("--weights", default=WEIGHTS)
     parser.add_argument("--mesh", default=None)
@@ -21,33 +40,11 @@ def parse_arguments():
     parser.add_argument("--camera", default=0, type=int)
     parser.add_argument("--H", default=480, type=int)
     parser.add_argument("--W", default=640, type=int)
-    return parser.parse_args()
-
-
-def build_pipeline(args):
-    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
-    model.load_weights(args.weights)
-    encoder = paz.models.extract_encoder(model)
-    mesh = scenes.build_mesh(args.mesh)
-    render = scenes.build_renderer(mesh, args.image_size, args.distance)
-    poses = scenes.grid_poses(10, 10, args.distance, False)
-    book = codebook.build_codebook(encoder, render, poses)
-    size = (args.image_size, args.image_size)
-
-    def call(image):
-        crop = paz.image.resize_opencv(image, size)
-        crop = paz.image.normalize(np.asarray(crop, "float32"))
-        view, pose = codebook.closest_view(encoder, crop, book)
-        return paz.image.resize_opencv(view, size)
-
-    return call
-
-
-def main():
-    args = parse_arguments()
-    pipeline = build_pipeline(args)
+    args = parser.parse_args()
+    predict = ImplicitRotationPredictor(
+        args.weights, args.mesh, args.image_size, args.distance)
     camera = paz.Camera(args.camera)
-    player = paz.VideoPlayer((args.H, args.W), pipeline, camera)
+    player = paz.VideoPlayer((args.H, args.W), predict, camera)
     player.run()
 
 

--- a/examples/implicit_orientation_learning/demo.py
+++ b/examples/implicit_orientation_learning/demo.py
@@ -38,7 +38,7 @@ def build_pipeline(args):
         crop = paz.image.resize_opencv(image, size)
         crop = paz.image.normalize(np.asarray(crop, "float32"))
         view, pose = codebook.closest_view(encoder, crop, book)
-        return paz.image.resize_opencv(paz.image.denormalize(view), size)
+        return paz.image.resize_opencv(view, size)
 
     return call
 

--- a/examples/implicit_orientation_learning/demo.py
+++ b/examples/implicit_orientation_learning/demo.py
@@ -1,0 +1,55 @@
+import os
+import argparse
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import numpy as np
+
+import paz
+import scenes
+import codebook
+
+WEIGHTS = "experiments/aae.weights.h5"
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Implicit orientation demo")
+    parser.add_argument("--weights", default=WEIGHTS)
+    parser.add_argument("--mesh", default=None)
+    parser.add_argument("--image_size", default=128, type=int)
+    parser.add_argument("--distance", default=0.9, type=float)
+    parser.add_argument("--camera", default=0, type=int)
+    parser.add_argument("--H", default=480, type=int)
+    parser.add_argument("--W", default=640, type=int)
+    return parser.parse_args()
+
+
+def build_pipeline(args):
+    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+    model.load_weights(args.weights)
+    encoder = paz.models.extract_encoder(model)
+    mesh = scenes.build_mesh(args.mesh)
+    render = scenes.build_renderer(mesh, args.image_size, args.distance)
+    poses = scenes.grid_poses(10, 10, args.distance, False)
+    book = codebook.build_codebook(encoder, render, poses)
+    size = (args.image_size, args.image_size)
+
+    def call(image):
+        crop = paz.image.resize_opencv(image, size)
+        crop = paz.image.normalize(np.asarray(crop, "float32"))
+        view, pose = codebook.closest_view(encoder, crop, book)
+        return paz.image.resize_opencv(paz.image.denormalize(view), size)
+
+    return call
+
+
+def main():
+    args = parse_arguments()
+    pipeline = build_pipeline(args)
+    camera = paz.Camera(args.camera)
+    player = paz.VideoPlayer((args.H, args.W), pipeline, camera)
+    player.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/implicit_orientation_learning/scenes.py
+++ b/examples/implicit_orientation_learning/scenes.py
@@ -51,9 +51,10 @@ def camera_pose(rotation, distance):
 
 
 def random_poses(key, num_views, distance):
-    keys = jax.random.split(key, num_views)
-    return [camera_pose(paz.SO3.sample(view_key), distance)
-            for view_key in keys]
+    poses = []
+    for view_key in jax.random.split(key, num_views):
+        poses.append(camera_pose(paz.SO3.sample(view_key), distance))
+    return poses
 
 
 def grid_poses(theta_steps, phi_steps, distance):

--- a/examples/implicit_orientation_learning/scenes.py
+++ b/examples/implicit_orientation_learning/scenes.py
@@ -1,4 +1,5 @@
 import numpy as np
+import jax
 import jax.numpy as jp
 
 import paz
@@ -43,28 +44,27 @@ def build_renderer(mesh, image_size, distance, y_FOV=jp.pi / 4.0):
     return mesh_renderer(meshes, mask, H, W, y_FOV, lights, 1024 * 8, (2, 2))
 
 
-def view_pose(theta, phi, distance):
-    x = distance * np.sin(theta) * np.cos(phi)
-    y = distance * np.cos(theta)
-    z = distance * np.sin(theta) * np.sin(phi)
-    origin = jp.array([x, y, z])
-    up = jp.array([0.0, 1.0, 0.0])
-    return paz.SE3.view_transform(origin, jp.zeros(3), up)
+def camera_pose(rotation, distance):
+    origin = rotation @ jp.array([0.0, 0.0, distance])
+    world_up = rotation @ jp.array([0.0, 1.0, 0.0])
+    return paz.SE3.view_transform(origin, jp.zeros(3), world_up)
 
 
-def random_poses(num_views, distance, top_only, seed):
-    rng = np.random.default_rng(seed)
-    upper = (np.pi / 2.0) if top_only else np.pi
-    thetas = rng.uniform(0.2, upper - 0.2, num_views)
-    phis = rng.uniform(0.0, 2.0 * np.pi, num_views)
-    return [view_pose(t, p, distance) for t, p in zip(thetas, phis)]
+def random_poses(key, num_views, distance):
+    keys = jax.random.split(key, num_views)
+    return [camera_pose(paz.SO3.sample(view_key), distance)
+            for view_key in keys]
 
 
-def grid_poses(theta_steps, phi_steps, distance, top_only):
-    upper = (np.pi / 2.0) if top_only else np.pi
-    thetas = np.linspace(0.2, upper - 0.2, theta_steps)
-    phis = np.linspace(0.0, 2.0 * np.pi, phi_steps, endpoint=False)
-    return [view_pose(t, p, distance) for t in thetas for p in phis]
+def grid_poses(theta_steps, phi_steps, distance):
+    thetas = jp.linspace(0.2, jp.pi - 0.2, theta_steps)
+    phis = jp.linspace(0.0, 2.0 * jp.pi, phi_steps, endpoint=False)
+    poses = []
+    for theta in thetas:
+        for phi in phis:
+            rotation = paz.SO3.rotation_y(phi) @ paz.SO3.rotation_x(theta)
+            poses.append(camera_pose(rotation, distance))
+    return poses
 
 
 def render_views(render_fn, poses):

--- a/examples/implicit_orientation_learning/scenes.py
+++ b/examples/implicit_orientation_learning/scenes.py
@@ -69,4 +69,4 @@ def grid_poses(theta_steps, phi_steps, distance, top_only):
 
 def render_views(render_fn, poses):
     views = [np.asarray(render_fn(pose)) for pose in poses]
-    return np.stack(views).astype("float32") / 255.0
+    return np.stack(views).astype("uint8")

--- a/examples/implicit_orientation_learning/scenes.py
+++ b/examples/implicit_orientation_learning/scenes.py
@@ -1,0 +1,72 @@
+import numpy as np
+import jax.numpy as jp
+
+import paz
+from paz.graphics.mesh import Mesh, load_mesh, build_cube, merge_meshes
+from paz.graphics.types import Material, PointLight
+from paz.graphics.viewer import mesh_renderer
+
+
+def normalize_vertices(vertices):
+    lower, upper = jp.min(vertices, axis=0), jp.max(vertices, axis=0)
+    center = (lower + upper) / 2.0
+    return (vertices - center) / jp.max(upper - lower)
+
+
+def build_face_edges(faces):
+    pairs = [faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]]]
+    return jp.concatenate(pairs, axis=0)
+
+
+def colored_cube():
+    vertices, faces, edges = build_cube(1.0)
+    colors = (normalize_vertices(vertices) + 0.5)
+    return vertices, faces, edges, jp.clip(colors, 0.0, 1.0)
+
+
+def build_mesh(mesh_path=None):
+    if mesh_path is None:
+        vertices, faces, edges, colors = colored_cube()
+    else:
+        vertices, faces, colors = load_mesh(mesh_path)
+        edges = build_face_edges(faces)
+    vertices = normalize_vertices(vertices)
+    material = Material(jp.zeros(3), 0.6, 0.0, 0.3, 32.0)
+    transform = paz.SE3.identity()
+    return Mesh(vertices, colors, transform, material, faces, edges)
+
+
+def build_renderer(mesh, image_size, distance, y_FOV=jp.pi / 4.0):
+    meshes, mask = merge_meshes(mesh)
+    lights = [PointLight(jp.ones(3) * 1.6, jp.array([distance, distance, distance]))]  # fmt: skip
+    H = W = image_size
+    return mesh_renderer(meshes, mask, H, W, y_FOV, lights, 1024 * 8, (2, 2))
+
+
+def view_pose(theta, phi, distance):
+    x = distance * np.sin(theta) * np.cos(phi)
+    y = distance * np.cos(theta)
+    z = distance * np.sin(theta) * np.sin(phi)
+    origin = jp.array([x, y, z])
+    up = jp.array([0.0, 1.0, 0.0])
+    return paz.SE3.view_transform(origin, jp.zeros(3), up)
+
+
+def random_poses(num_views, distance, top_only, seed):
+    rng = np.random.default_rng(seed)
+    upper = (np.pi / 2.0) if top_only else np.pi
+    thetas = rng.uniform(0.2, upper - 0.2, num_views)
+    phis = rng.uniform(0.0, 2.0 * np.pi, num_views)
+    return [view_pose(t, p, distance) for t, p in zip(thetas, phis)]
+
+
+def grid_poses(theta_steps, phi_steps, distance, top_only):
+    upper = (np.pi / 2.0) if top_only else np.pi
+    thetas = np.linspace(0.2, upper - 0.2, theta_steps)
+    phis = np.linspace(0.0, 2.0 * np.pi, phi_steps, endpoint=False)
+    return [view_pose(t, p, distance) for t in thetas for p in phis]
+
+
+def render_views(render_fn, poses):
+    views = [np.asarray(render_fn(pose)) for pose in poses]
+    return np.stack(views).astype("float32") / 255.0

--- a/examples/implicit_orientation_learning/train.py
+++ b/examples/implicit_orientation_learning/train.py
@@ -59,28 +59,29 @@ def render_dataset(mesh_path, num_views, image_size, distance, root, seed):
     return views, masks
 
 
-parser = argparse.ArgumentParser(description="AutoEncoder AAE training")
-parser.add_argument("--mesh", default=None)
-parser.add_argument("--backgrounds", default=None)
-parser.add_argument("--root", default="experiments")
-parser.add_argument("--image_size", default=128, type=int)
-parser.add_argument("--distance", default=0.9, type=float)
-parser.add_argument("--num_views", default=2000, type=int)
-parser.add_argument("--batch_size", default=32, type=int)
-parser.add_argument("--epochs", default=300, type=int)
-args = parser.parse_args()
-os.makedirs(args.root, exist_ok=True)
-pack = (args.mesh, args.num_views, args.image_size, args.distance)
-views, masks = render_dataset(*pack, args.root, seed=0)
-backgrounds = load_backgrounds(args.backgrounds, args.image_size)
-sequence = OrientationSequence(views, masks, args.batch_size, backgrounds)
-model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
-optimizer = keras.optimizers.Adam(1e-3, amsgrad=True)
-model.compile(optimizer, "binary_crossentropy")
-weights = os.path.join(args.root, "aae.weights.h5")
-callbacks = [
-    keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv")),
-    keras.callbacks.ModelCheckpoint(weights, save_weights_only=True),
-    keras.callbacks.ReduceLROnPlateau("loss", patience=10),
-]
-model.fit(sequence, epochs=args.epochs, callbacks=callbacks)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="AutoEncoder AAE training")
+    parser.add_argument("--mesh", default=None)
+    parser.add_argument("--backgrounds", default=None)
+    parser.add_argument("--root", default="experiments")
+    parser.add_argument("--image_size", default=128, type=int)
+    parser.add_argument("--distance", default=0.9, type=float)
+    parser.add_argument("--num_views", default=2000, type=int)
+    parser.add_argument("--batch_size", default=32, type=int)
+    parser.add_argument("--epochs", default=300, type=int)
+    args = parser.parse_args()
+    os.makedirs(args.root, exist_ok=True)
+    pack = (args.mesh, args.num_views, args.image_size, args.distance)
+    views, masks = render_dataset(*pack, args.root, seed=0)
+    backgrounds = load_backgrounds(args.backgrounds, args.image_size)
+    sequence = OrientationSequence(views, masks, args.batch_size, backgrounds)
+    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+    optimizer = keras.optimizers.Adam(1e-3, amsgrad=True)
+    model.compile(optimizer, "binary_crossentropy")
+    weights = os.path.join(args.root, "aae.weights.h5")
+    callbacks = [
+        keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv")),
+        keras.callbacks.ModelCheckpoint(weights, save_weights_only=True),
+        keras.callbacks.ReduceLROnPlateau("loss", patience=10),
+    ]
+    model.fit(sequence, epochs=args.epochs, callbacks=callbacks)

--- a/examples/implicit_orientation_learning/train.py
+++ b/examples/implicit_orientation_learning/train.py
@@ -59,33 +59,28 @@ def render_dataset(mesh_path, num_views, image_size, distance, root, seed):
     return views, masks
 
 
-def main():
-    parser = argparse.ArgumentParser(description="AutoEncoder AAE training")
-    parser.add_argument("--mesh", default=None)
-    parser.add_argument("--backgrounds", default=None)
-    parser.add_argument("--root", default="experiments")
-    parser.add_argument("--image_size", default=128, type=int)
-    parser.add_argument("--distance", default=0.9, type=float)
-    parser.add_argument("--num_views", default=2000, type=int)
-    parser.add_argument("--batch_size", default=32, type=int)
-    parser.add_argument("--epochs", default=300, type=int)
-    args = parser.parse_args()
-    os.makedirs(args.root, exist_ok=True)
-    pack = (args.mesh, args.num_views, args.image_size, args.distance)
-    views, masks = render_dataset(*pack, args.root, seed=0)
-    backgrounds = load_backgrounds(args.backgrounds, args.image_size)
-    sequence = OrientationSequence(views, masks, args.batch_size, backgrounds)
-    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
-    optimizer = keras.optimizers.Adam(1e-3, amsgrad=True)
-    model.compile(optimizer, "binary_crossentropy")
-    weights = os.path.join(args.root, "aae.weights.h5")
-    callbacks = [
-        keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv")),
-        keras.callbacks.ModelCheckpoint(weights, save_weights_only=True),
-        keras.callbacks.ReduceLROnPlateau("loss", patience=10),
-    ]
-    model.fit(sequence, epochs=args.epochs, callbacks=callbacks)
-
-
-if __name__ == "__main__":
-    main()
+parser = argparse.ArgumentParser(description="AutoEncoder AAE training")
+parser.add_argument("--mesh", default=None)
+parser.add_argument("--backgrounds", default=None)
+parser.add_argument("--root", default="experiments")
+parser.add_argument("--image_size", default=128, type=int)
+parser.add_argument("--distance", default=0.9, type=float)
+parser.add_argument("--num_views", default=2000, type=int)
+parser.add_argument("--batch_size", default=32, type=int)
+parser.add_argument("--epochs", default=300, type=int)
+args = parser.parse_args()
+os.makedirs(args.root, exist_ok=True)
+pack = (args.mesh, args.num_views, args.image_size, args.distance)
+views, masks = render_dataset(*pack, args.root, seed=0)
+backgrounds = load_backgrounds(args.backgrounds, args.image_size)
+sequence = OrientationSequence(views, masks, args.batch_size, backgrounds)
+model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+optimizer = keras.optimizers.Adam(1e-3, amsgrad=True)
+model.compile(optimizer, "binary_crossentropy")
+weights = os.path.join(args.root, "aae.weights.h5")
+callbacks = [
+    keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv")),
+    keras.callbacks.ModelCheckpoint(weights, save_weights_only=True),
+    keras.callbacks.ReduceLROnPlateau("loss", patience=10),
+]
+model.fit(sequence, epochs=args.epochs, callbacks=callbacks)

--- a/examples/implicit_orientation_learning/train.py
+++ b/examples/implicit_orientation_learning/train.py
@@ -3,9 +3,11 @@ import os
 os.environ["KERAS_BACKEND"] = "jax"
 
 import argparse
+from functools import partial
 
 import numpy as np
 import jax
+import jax.numpy as jp
 import keras
 
 import paz
@@ -15,11 +17,13 @@ import scenes
 class OrientationSequence(keras.utils.PyDataset):
     def __init__(self, views, masks, batch_size, backgrounds=None, seed=0):
         super().__init__()
-        self.views = views
-        self.masks = masks
+        self.views = jp.asarray(views)
+        self.masks = jp.asarray(masks)
         self.batch_size = batch_size
-        self.backgrounds = backgrounds
         self.key = jax.random.PRNGKey(seed)
+        randomize = partial(paz.image.randomize_rendered_image,
+                            backgrounds=backgrounds)
+        self.randomize = jax.jit(jax.vmap(randomize, in_axes=(0, 0, 0)))
 
     def __len__(self):
         return len(self.views) // self.batch_size
@@ -27,17 +31,9 @@ class OrientationSequence(keras.utils.PyDataset):
     def __getitem__(self, index):
         chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
         clean = self.views[chunk]
-        targets = clean.astype("float32") / 255.0
-        offset = index * self.batch_size
-        inputs = [self.randomize(offset + arg, view, mask)
-                  for arg, (view, mask) in enumerate(zip(clean, self.masks[chunk]))]  # fmt: skip
-        return np.stack(inputs), targets
-
-    def randomize(self, sample_arg, view, mask):
-        key = jax.random.fold_in(self.key, sample_arg)
-        randomize = paz.image.randomize_rendered_image
-        image = randomize(key, view, mask, self.backgrounds)
-        return np.asarray(image, "float32") / 255.0
+        keys = jax.random.split(jax.random.fold_in(self.key, index), len(clean))
+        inputs = self.randomize(keys, clean, self.masks[chunk])
+        return np.asarray(inputs, "float32") / 255.0, np.asarray(clean) / 255.0
 
 
 def load_backgrounds(path, image_size):
@@ -56,14 +52,14 @@ def render_dataset(mesh_path, num_views, image_size, distance, root, seed):
         return data["views"], data["masks"]
     mesh = scenes.build_mesh(mesh_path)
     render = scenes.build_renderer(mesh, image_size, distance)
-    poses = scenes.random_poses(num_views, distance, False, seed)
+    poses = scenes.random_poses(jax.random.PRNGKey(seed), num_views, distance)
     views = scenes.render_views(render, poses)
     masks = (views < 230).any(axis=-1)
     np.savez(cache, views=views, masks=masks)
     return views, masks
 
 
-def parse_arguments():
+def main():
     parser = argparse.ArgumentParser(description="AutoEncoder AAE training")
     parser.add_argument("--mesh", default=None)
     parser.add_argument("--backgrounds", default=None)
@@ -73,11 +69,7 @@ def parse_arguments():
     parser.add_argument("--num_views", default=2000, type=int)
     parser.add_argument("--batch_size", default=32, type=int)
     parser.add_argument("--epochs", default=300, type=int)
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     os.makedirs(args.root, exist_ok=True)
     pack = (args.mesh, args.num_views, args.image_size, args.distance)
     views, masks = render_dataset(*pack, args.root, seed=0)

--- a/examples/implicit_orientation_learning/train.py
+++ b/examples/implicit_orientation_learning/train.py
@@ -1,0 +1,115 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+
+import numpy as np
+import keras
+
+import paz
+import scenes
+
+
+class OrientationSequence(keras.utils.PyDataset):
+    def __init__(self, views, masks, batch_size, backgrounds=None, seed=0):
+        super().__init__()
+        self.views = views
+        self.masks = masks
+        self.batch_size = batch_size
+        self.backgrounds = backgrounds
+        self.rng = np.random.default_rng(seed)
+
+    def __len__(self):
+        return len(self.views) // self.batch_size
+
+    def __getitem__(self, index):
+        chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
+        targets = self.views[chunk]
+        inputs = [self.randomize(v, m)
+                  for v, m in zip(targets, self.masks[chunk])]
+        return np.stack(inputs).astype("float32"), targets
+
+    def randomize(self, view, mask):
+        image = view.copy()
+        image[~mask] = self.background(view.shape)[~mask]
+        image = add_occlusions(image, self.rng)
+        return jitter_brightness(image, self.rng)
+
+    def background(self, shape):
+        if self.backgrounds is None:
+            color = self.rng.uniform(0.0, 1.0, (1, 1, 3))
+            return np.broadcast_to(color, shape).astype("float32")
+        return self.backgrounds[self.rng.integers(len(self.backgrounds))]
+
+
+def add_occlusions(image, rng, num_occlusions=2):
+    H, W = image.shape[:2]
+    for _ in range(num_occlusions):
+        x, y = rng.integers(0, W), rng.integers(0, H)
+        w, h = rng.integers(4, W // 3), rng.integers(4, H // 3)
+        image[y:y + h, x:x + w] = rng.uniform(0.0, 1.0, 3)
+    return image
+
+
+def jitter_brightness(image, rng):
+    return np.clip(image * rng.uniform(0.7, 1.3), 0.0, 1.0)
+
+
+def load_backgrounds(path, image_size):
+    if path is None:
+        return None
+    files = [os.path.join(path, f) for f in os.listdir(path)]
+    crops = [paz.image.resize_opencv(paz.image.load(f), (image_size,) * 2)
+             for f in files]
+    return np.stack(crops).astype("float32") / 255.0
+
+
+def render_dataset(mesh_path, num_views, image_size, distance, root, seed):
+    cache = os.path.join(root, "views.npz")
+    if os.path.exists(cache):
+        data = np.load(cache)
+        return data["views"], data["masks"]
+    mesh = scenes.build_mesh(mesh_path)
+    render = scenes.build_renderer(mesh, image_size, distance)
+    poses = scenes.random_poses(num_views, distance, False, seed)
+    views = scenes.render_views(render, poses)
+    masks = (views < 0.9).any(axis=-1)
+    np.savez(cache, views=views, masks=masks)
+    return views, masks
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="AutoEncoder AAE training")
+    parser.add_argument("--mesh", default=None)
+    parser.add_argument("--backgrounds", default=None)
+    parser.add_argument("--root", default="experiments")
+    parser.add_argument("--image_size", default=128, type=int)
+    parser.add_argument("--distance", default=0.9, type=float)
+    parser.add_argument("--num_views", default=2000, type=int)
+    parser.add_argument("--batch_size", default=32, type=int)
+    parser.add_argument("--epochs", default=300, type=int)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    os.makedirs(args.root, exist_ok=True)
+    pack = (args.mesh, args.num_views, args.image_size, args.distance)
+    views, masks = render_dataset(*pack, args.root, seed=0)
+    backgrounds = load_backgrounds(args.backgrounds, args.image_size)
+    sequence = OrientationSequence(views, masks, args.batch_size, backgrounds)
+    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+    optimizer = keras.optimizers.Adam(1e-3, amsgrad=True)
+    model.compile(optimizer, "binary_crossentropy")
+    weights = os.path.join(args.root, "aae.weights.h5")
+    callbacks = [
+        keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv")),
+        keras.callbacks.ModelCheckpoint(weights, save_weights_only=True),
+        keras.callbacks.ReduceLROnPlateau("loss", patience=10),
+    ]
+    model.fit(sequence, epochs=args.epochs, callbacks=callbacks)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/implicit_orientation_learning/train.py
+++ b/examples/implicit_orientation_learning/train.py
@@ -5,6 +5,7 @@ os.environ["KERAS_BACKEND"] = "jax"
 import argparse
 
 import numpy as np
+import jax
 import keras
 
 import paz
@@ -18,42 +19,25 @@ class OrientationSequence(keras.utils.PyDataset):
         self.masks = masks
         self.batch_size = batch_size
         self.backgrounds = backgrounds
-        self.rng = np.random.default_rng(seed)
+        self.key = jax.random.PRNGKey(seed)
 
     def __len__(self):
         return len(self.views) // self.batch_size
 
     def __getitem__(self, index):
         chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
-        targets = self.views[chunk]
-        inputs = [self.randomize(v, m)
-                  for v, m in zip(targets, self.masks[chunk])]
-        return np.stack(inputs).astype("float32"), targets
+        clean = self.views[chunk]
+        targets = clean.astype("float32") / 255.0
+        offset = index * self.batch_size
+        inputs = [self.randomize(offset + arg, view, mask)
+                  for arg, (view, mask) in enumerate(zip(clean, self.masks[chunk]))]  # fmt: skip
+        return np.stack(inputs), targets
 
-    def randomize(self, view, mask):
-        image = view.copy()
-        image[~mask] = self.background(view.shape)[~mask]
-        image = add_occlusions(image, self.rng)
-        return jitter_brightness(image, self.rng)
-
-    def background(self, shape):
-        if self.backgrounds is None:
-            color = self.rng.uniform(0.0, 1.0, (1, 1, 3))
-            return np.broadcast_to(color, shape).astype("float32")
-        return self.backgrounds[self.rng.integers(len(self.backgrounds))]
-
-
-def add_occlusions(image, rng, num_occlusions=2):
-    H, W = image.shape[:2]
-    for _ in range(num_occlusions):
-        x, y = rng.integers(0, W), rng.integers(0, H)
-        w, h = rng.integers(4, W // 3), rng.integers(4, H // 3)
-        image[y:y + h, x:x + w] = rng.uniform(0.0, 1.0, 3)
-    return image
-
-
-def jitter_brightness(image, rng):
-    return np.clip(image * rng.uniform(0.7, 1.3), 0.0, 1.0)
+    def randomize(self, sample_arg, view, mask):
+        key = jax.random.fold_in(self.key, sample_arg)
+        randomize = paz.image.randomize_rendered_image
+        image = randomize(key, view, mask, self.backgrounds)
+        return np.asarray(image, "float32") / 255.0
 
 
 def load_backgrounds(path, image_size):
@@ -62,7 +46,7 @@ def load_backgrounds(path, image_size):
     files = [os.path.join(path, f) for f in os.listdir(path)]
     crops = [paz.image.resize_opencv(paz.image.load(f), (image_size,) * 2)
              for f in files]
-    return np.stack(crops).astype("float32") / 255.0
+    return np.stack(crops).astype("uint8")
 
 
 def render_dataset(mesh_path, num_views, image_size, distance, root, seed):
@@ -74,7 +58,7 @@ def render_dataset(mesh_path, num_views, image_size, distance, root, seed):
     render = scenes.build_renderer(mesh, image_size, distance)
     poses = scenes.random_poses(num_views, distance, False, seed)
     views = scenes.render_views(render, poses)
-    masks = (views < 0.9).any(axis=-1)
+    masks = (views < 230).any(axis=-1)
     np.savez(cache, views=views, masks=masks)
     return views, masks
 

--- a/paz/backend/draw.py
+++ b/paz/backend/draw.py
@@ -3,6 +3,7 @@ import math
 from functools import lru_cache
 
 import jax
+import jax.numpy as jp
 import numpy as np
 import cv2
 import paz
@@ -427,3 +428,49 @@ def text(image, message, point, scale=0.7, color=WHITE, thickness=2):
     font = cv2.FONT_HERSHEY_DUPLEX
     cv2.putText(image, message, point, font, scale, color, thickness)
     return image
+
+
+def blend_background(image, background, mask):
+    """Composites a foreground over a background using a foreground mask."""
+    mask = jp.asarray(mask, jp.float32)
+    if mask.ndim == 2:
+        mask = mask[..., jp.newaxis]
+    foreground = paz.cast(image, jp.float32)
+    background = paz.cast(background, jp.float32)
+    blended = mask * foreground + (1.0 - mask) * background
+    return paz.cast(blended, jp.uint8)
+
+
+def points_in_polygon(grid_x, grid_y, polygon):
+    """Even-odd point-in-polygon test for a grid of pixel coordinates."""
+    vertex_x, vertex_y = polygon[:, 0], polygon[:, 1]
+    next_x, next_y = jp.roll(vertex_x, -1), jp.roll(vertex_y, -1)
+    x = grid_x[..., jp.newaxis]
+    y = grid_y[..., jp.newaxis]
+    straddles = (vertex_y > y) != (next_y > y)
+    slope = (next_x - vertex_x) * (y - vertex_y) / (next_y - vertex_y + 1e-9)
+    crosses = straddles & (x < slope + vertex_x)
+    return (jp.sum(crosses, axis=-1) % 2) == 1
+
+
+def fill_polygon(image, polygon, color):
+    """Fills a polygon in an image (JAX replacement for cv2.fillPoly)."""
+    grid_y, grid_x = jp.meshgrid(jp.arange(image.shape[0]),
+                                 jp.arange(image.shape[1]), indexing="ij")
+    inside = points_in_polygon(grid_x, grid_y, polygon)
+    color = paz.cast(color, image.dtype)
+    return jp.where(inside[..., jp.newaxis], color, image)
+
+
+def add_occlusion(key, image, num_vertices=6, max_radius_scale=0.5):
+    """Draws one random filled polygon over the image (jittable)."""
+    key_center, key_radii, key_angle, key_color = jax.random.split(key, 4)
+    H, W = image.shape[0], image.shape[1]
+    center = jax.random.uniform(key_center, (2,)) * jp.array([W, H])
+    max_radius = max_radius_scale * max(H, W)
+    radii = jax.random.uniform(key_radii, (num_vertices,)) * max_radius
+    angles = jp.sort(jax.random.uniform(key_angle, (num_vertices,))) * 2 * jp.pi
+    offsets = jp.stack([jp.cos(angles), jp.sin(angles)], axis=1)
+    polygon = center + radii[:, jp.newaxis] * offsets
+    color = jax.random.randint(key_color, (3,), 0, 256)
+    return fill_polygon(image, polygon, color)

--- a/paz/backend/draw_test.py
+++ b/paz/backend/draw_test.py
@@ -1,4 +1,6 @@
+import cv2
 import numpy as np
+import jax
 import jax.numpy as jp
 import paz
 from paz.backend import draw
@@ -126,3 +128,31 @@ def test_lincolors_uses_cache():
     draw._lincolors(3)
     after = draw._lincolors.cache_info().hits
     assert after == before + 1
+
+
+def test_blend_background_respects_mask():
+    foreground = jp.full((4, 4, 3), 200, jp.uint8)
+    background = jp.zeros((4, 4, 3), jp.uint8)
+    mask = jp.zeros((4, 4)).at[0, 0].set(1.0)
+    blended = paz.draw.blend_background(foreground, background, mask)
+    assert int(blended[0, 0, 0]) == 200
+    assert int(blended[1, 1, 0]) == 0
+
+
+def test_add_occlusion_changes_image_and_keeps_shape():
+    image = jp.full((32, 32, 3), 200, jp.uint8)
+    occluded = paz.draw.add_occlusion(jax.random.PRNGKey(1), image)
+    assert occluded.shape == (32, 32, 3)
+    assert not bool(jp.all(occluded == 200))
+
+
+def test_fill_polygon_matches_cv2():
+    polygon = jp.array([[12, 10], [50, 16], [55, 48], [28, 58], [10, 38]],
+                       jp.float32)
+    image = jp.full((64, 64, 3), 200, jp.uint8)
+    filled = paz.draw.fill_polygon(image, polygon, jp.zeros(3, jp.uint8))
+    reference = np.full((64, 64, 3), 200, np.uint8)
+    cv2.fillPoly(reference, [np.asarray(polygon).astype(np.int32)], (0, 0, 0))
+    jax_mask = np.asarray((filled == 0).all(-1))
+    reference_mask = (reference == 0).all(-1)
+    assert (jax_mask == reference_mask).mean() > 0.95

--- a/paz/backend/image.py
+++ b/paz/backend/image.py
@@ -411,12 +411,11 @@ def make_random_plain_image(key, shape):
 
 def random_crop(key, image, size):
     """Crops a random `size` window from an image at least that large."""
-    H, W = image.shape[:2]
     H_crop, W_crop = size
-    key_y, key_x = jax.random.split(key)
-    y = int(jax.random.randint(key_y, (), 0, max(H - H_crop, 0) + 1))
-    x = int(jax.random.randint(key_x, (), 0, max(W - W_crop, 0) + 1))
-    return image[y:y + H_crop, x:x + W_crop]
+    limits = jp.array([image.shape[0] - H_crop, image.shape[1] - W_crop])
+    offset = jax.random.randint(key, (2,), 0, jp.maximum(limits, 0) + 1)
+    start = (offset[0], offset[1], 0)
+    return lax.dynamic_slice(image, start, (H_crop, W_crop, image.shape[2]))
 
 
 def blend_background(image, background, mask):
@@ -430,30 +429,64 @@ def blend_background(image, background, mask):
     return paz.cast(blended, jp.uint8)
 
 
-def add_occlusion(key, image, max_radius_scale=0.5):
-    """Draws one random filled polygon over the image."""
-    image = np.array(paz.to_numpy(image))
-    H, W = image.shape[:2]
-    keys = jax.random.split(key, 5)
-    num_vertices = int(jax.random.randint(keys[0], (), 4, 9))
-    center = np.asarray(jax.random.uniform(keys[1], (2,))) * np.array([W, H])
+def points_in_polygon(grid_x, grid_y, polygon):
+    """Even-odd point-in-polygon test for a grid of pixel coordinates."""
+    vertex_x, vertex_y = polygon[:, 0], polygon[:, 1]
+    next_x, next_y = jp.roll(vertex_x, -1), jp.roll(vertex_y, -1)
+    x = grid_x[..., jp.newaxis]
+    y = grid_y[..., jp.newaxis]
+    straddles = (vertex_y > y) != (next_y > y)
+    slope = (next_x - vertex_x) * (y - vertex_y) / (next_y - vertex_y + 1e-9)
+    crosses = straddles & (x < slope + vertex_x)
+    return (jp.sum(crosses, axis=-1) % 2) == 1
+
+
+def fill_polygon(image, polygon, color):
+    """Fills a polygon in an image (JAX replacement for cv2.fillPoly)."""
+    grid_y, grid_x = jp.meshgrid(jp.arange(image.shape[0]),
+                                 jp.arange(image.shape[1]), indexing="ij")
+    inside = points_in_polygon(grid_x, grid_y, polygon)
+    color = paz.cast(color, image.dtype)
+    return jp.where(inside[..., jp.newaxis], color, image)
+
+
+def gaussian_blur(image, kernel_size=9, sigma=2.0):
+    """Gaussian blur for a multi-channel image via depthwise convolution."""
+    num_channels = image.shape[-1]
+    coordinates = jp.arange(kernel_size) - kernel_size // 2
+    kernel_1d = jp.exp(-(coordinates**2) / (2.0 * sigma**2))
+    kernel = jp.outer(kernel_1d, kernel_1d)
+    kernel = kernel / jp.sum(kernel)
+    kernel = jp.reshape(kernel, (kernel_size, kernel_size, 1, 1))
+    kernel = jp.tile(kernel, (1, 1, 1, num_channels))
+    image_4d = paz.cast(image, jp.float32)[jp.newaxis]
+    numbers = lax.conv_dimension_numbers(
+        image_4d.shape, kernel.shape, ("NHWC", "HWIO", "NHWC"))
+    blurred = lax.conv_general_dilated(
+        image_4d, kernel, (1, 1), "SAME", feature_group_count=num_channels,
+        dimension_numbers=numbers)
+    return paz.cast(blurred[0], image.dtype)
+
+
+def add_occlusion(key, image, num_vertices=6, max_radius_scale=0.5):
+    """Draws one random filled polygon over the image (jittable)."""
+    key_center, key_radii, key_angle, key_color = jax.random.split(key, 4)
+    H, W = image.shape[0], image.shape[1]
+    center = jax.random.uniform(key_center, (2,)) * jp.array([W, H])
     max_radius = max_radius_scale * max(H, W)
-    radii = np.asarray(jax.random.uniform(keys[2], (num_vertices,)))
-    angles = np.sort(np.asarray(jax.random.uniform(keys[3], (num_vertices,))))
-    offsets = np.stack([np.cos(angles * 2.0 * np.pi),
-                        np.sin(angles * 2.0 * np.pi)], axis=1)
-    points = (center + (radii * max_radius)[:, np.newaxis] * offsets)
-    color = np.asarray(jax.random.randint(keys[4], (3,), 0, 256)).tolist()
-    cv2.fillPoly(image, [points.astype(np.int32)], color)
-    return image
+    radii = jax.random.uniform(key_radii, (num_vertices,)) * max_radius
+    angles = jp.sort(jax.random.uniform(key_angle, (num_vertices,))) * 2 * jp.pi
+    offsets = jp.stack([jp.cos(angles), jp.sin(angles)], axis=1)
+    polygon = center + radii[:, jp.newaxis] * offsets
+    color = jax.random.randint(key_color, (3,), 0, 256)
+    return fill_polygon(image, polygon, color)
 
 
 def random_blur(key, image, kernel_size=9):
-    """Applies Gaussian blur with probability one half."""
-    if not bool(jax.random.uniform(key, ()) < 0.5):
-        return image
-    image = np.array(paz.to_numpy(image))
-    return cv2.GaussianBlur(image, (kernel_size, kernel_size), 0)
+    """Applies Gaussian blur with probability one half (jittable)."""
+    apply = jax.random.uniform(key, ()) < 0.5
+    return lax.cond(apply, lambda x: gaussian_blur(x, kernel_size),
+                    lambda x: x, image)
 
 
 def randomize_rendered_image(key, image, mask, backgrounds=None,
@@ -464,7 +497,8 @@ def randomize_rendered_image(key, image, mask, backgrounds=None,
     background = sample_background(keys[0], image.shape, backgrounds)
     image = blend_background(image, background, mask)
     for occlusion_arg in range(num_occlusions):
-        image = add_occlusion(keys[1 + occlusion_arg], image, max_radius_scale)
+        image = add_occlusion(keys[1 + occlusion_arg], image,
+                              max_radius_scale=max_radius_scale)
     image = random_blur(keys[1 + num_occlusions], image)
     return random_color_transform(keys[2 + num_occlusions], image)
 
@@ -473,7 +507,7 @@ def sample_background(key, shape, backgrounds):
     if backgrounds is None:
         return make_random_plain_image(key, shape)
     key_pick, key_crop = jax.random.split(key)
-    index = int(jax.random.randint(key_pick, (), 0, len(backgrounds)))
+    index = jax.random.randint(key_pick, (), 0, len(backgrounds))
     return random_crop(key_crop, backgrounds[index], shape[:2])
 
 

--- a/paz/backend/image.py
+++ b/paz/backend/image.py
@@ -212,30 +212,26 @@ def apply_sobel(image):
 
 
 def apply_gaussian_blur(image, kernel_size=9, sigma=2.0):
-    """Apply Gaussian blur to a 2D or single-channel image."""
+    """Apply Gaussian blur to a 2D or multi-channel image (depthwise)."""
     if image.ndim == 2:
         image = image[..., jp.newaxis]
-    image = image.astype(jp.float32)
-    image_4d = image[jp.newaxis, ...]
+    num_channels = image.shape[-1]
+    image_4d = image.astype(jp.float32)[jp.newaxis, ...]
 
     radius = kernel_size // 2
     coords = jp.arange(-radius, radius + 1)
     x_grid, y_grid = jp.meshgrid(coords, coords)
     kernel = jp.exp(-(x_grid**2 + y_grid**2) / (2.0 * sigma**2))
     kernel = kernel / jp.sum(kernel)
-    kernel = kernel[:, :, jp.newaxis, jp.newaxis]
+    kernel = jp.reshape(kernel, (kernel_size, kernel_size, 1, 1))
+    kernel = jp.tile(kernel, (1, 1, 1, num_channels))
 
     dimension_numbers = lax.conv_dimension_numbers(
         image_4d.shape, kernel.shape, ("NHWC", "HWIO", "NHWC")
     )
     output = lax.conv_general_dilated(
-        image_4d,
-        kernel,
-        (1, 1),
-        "SAME",
-        (1, 1),
-        (1, 1),
-        dimension_numbers,
+        image_4d, kernel, (1, 1), "SAME", (1, 1), (1, 1),
+        dimension_numbers, feature_group_count=num_channels,
     )
     return output[0]
 
@@ -409,15 +405,6 @@ def make_random_plain_image(key, shape):
     return jp.broadcast_to(color, shape).astype(jp.uint8)
 
 
-def random_crop(key, image, size):
-    """Crops a random `size` window from an image at least that large."""
-    H_crop, W_crop = size
-    limits = jp.array([image.shape[0] - H_crop, image.shape[1] - W_crop])
-    offset = jax.random.randint(key, (2,), 0, jp.maximum(limits, 0) + 1)
-    start = (offset[0], offset[1], 0)
-    return lax.dynamic_slice(image, start, (H_crop, W_crop, image.shape[2]))
-
-
 def blend_background(image, background, mask):
     """Composites a foreground over a background using a foreground mask."""
     mask = jp.asarray(mask, jp.float32)
@@ -450,24 +437,6 @@ def fill_polygon(image, polygon, color):
     return jp.where(inside[..., jp.newaxis], color, image)
 
 
-def gaussian_blur(image, kernel_size=9, sigma=2.0):
-    """Gaussian blur for a multi-channel image via depthwise convolution."""
-    num_channels = image.shape[-1]
-    coordinates = jp.arange(kernel_size) - kernel_size // 2
-    kernel_1d = jp.exp(-(coordinates**2) / (2.0 * sigma**2))
-    kernel = jp.outer(kernel_1d, kernel_1d)
-    kernel = kernel / jp.sum(kernel)
-    kernel = jp.reshape(kernel, (kernel_size, kernel_size, 1, 1))
-    kernel = jp.tile(kernel, (1, 1, 1, num_channels))
-    image_4d = paz.cast(image, jp.float32)[jp.newaxis]
-    numbers = lax.conv_dimension_numbers(
-        image_4d.shape, kernel.shape, ("NHWC", "HWIO", "NHWC"))
-    blurred = lax.conv_general_dilated(
-        image_4d, kernel, (1, 1), "SAME", feature_group_count=num_channels,
-        dimension_numbers=numbers)
-    return paz.cast(blurred[0], image.dtype)
-
-
 def add_occlusion(key, image, num_vertices=6, max_radius_scale=0.5):
     """Draws one random filled polygon over the image (jittable)."""
     key_center, key_radii, key_angle, key_color = jax.random.split(key, 4)
@@ -485,8 +454,8 @@ def add_occlusion(key, image, num_vertices=6, max_radius_scale=0.5):
 def random_blur(key, image, kernel_size=9):
     """Applies Gaussian blur with probability one half (jittable)."""
     apply = jax.random.uniform(key, ()) < 0.5
-    return lax.cond(apply, lambda x: gaussian_blur(x, kernel_size),
-                    lambda x: x, image)
+    blurred = paz.cast(apply_gaussian_blur(image, kernel_size), image.dtype)
+    return jp.where(apply, blurred, image)
 
 
 def randomize_rendered_image(key, image, mask, backgrounds=None,
@@ -506,9 +475,8 @@ def randomize_rendered_image(key, image, mask, backgrounds=None,
 def sample_background(key, shape, backgrounds):
     if backgrounds is None:
         return make_random_plain_image(key, shape)
-    key_pick, key_crop = jax.random.split(key)
-    index = jax.random.randint(key_pick, (), 0, len(backgrounds))
-    return random_crop(key_crop, backgrounds[index], shape[:2])
+    index = jax.random.randint(key, (), 0, len(backgrounds))
+    return backgrounds[index]
 
 
 def affine_transform(image, matrix, order=1, mode="nearest", cval=0.0):

--- a/paz/backend/image.py
+++ b/paz/backend/image.py
@@ -405,52 +405,6 @@ def make_random_plain_image(key, shape):
     return jp.broadcast_to(color, shape).astype(jp.uint8)
 
 
-def blend_background(image, background, mask):
-    """Composites a foreground over a background using a foreground mask."""
-    mask = jp.asarray(mask, jp.float32)
-    if mask.ndim == 2:
-        mask = mask[..., jp.newaxis]
-    foreground = paz.cast(image, jp.float32)
-    background = paz.cast(background, jp.float32)
-    blended = mask * foreground + (1.0 - mask) * background
-    return paz.cast(blended, jp.uint8)
-
-
-def points_in_polygon(grid_x, grid_y, polygon):
-    """Even-odd point-in-polygon test for a grid of pixel coordinates."""
-    vertex_x, vertex_y = polygon[:, 0], polygon[:, 1]
-    next_x, next_y = jp.roll(vertex_x, -1), jp.roll(vertex_y, -1)
-    x = grid_x[..., jp.newaxis]
-    y = grid_y[..., jp.newaxis]
-    straddles = (vertex_y > y) != (next_y > y)
-    slope = (next_x - vertex_x) * (y - vertex_y) / (next_y - vertex_y + 1e-9)
-    crosses = straddles & (x < slope + vertex_x)
-    return (jp.sum(crosses, axis=-1) % 2) == 1
-
-
-def fill_polygon(image, polygon, color):
-    """Fills a polygon in an image (JAX replacement for cv2.fillPoly)."""
-    grid_y, grid_x = jp.meshgrid(jp.arange(image.shape[0]),
-                                 jp.arange(image.shape[1]), indexing="ij")
-    inside = points_in_polygon(grid_x, grid_y, polygon)
-    color = paz.cast(color, image.dtype)
-    return jp.where(inside[..., jp.newaxis], color, image)
-
-
-def add_occlusion(key, image, num_vertices=6, max_radius_scale=0.5):
-    """Draws one random filled polygon over the image (jittable)."""
-    key_center, key_radii, key_angle, key_color = jax.random.split(key, 4)
-    H, W = image.shape[0], image.shape[1]
-    center = jax.random.uniform(key_center, (2,)) * jp.array([W, H])
-    max_radius = max_radius_scale * max(H, W)
-    radii = jax.random.uniform(key_radii, (num_vertices,)) * max_radius
-    angles = jp.sort(jax.random.uniform(key_angle, (num_vertices,))) * 2 * jp.pi
-    offsets = jp.stack([jp.cos(angles), jp.sin(angles)], axis=1)
-    polygon = center + radii[:, jp.newaxis] * offsets
-    color = jax.random.randint(key_color, (3,), 0, 256)
-    return fill_polygon(image, polygon, color)
-
-
 def random_blur(key, image, kernel_size=9):
     """Applies Gaussian blur with probability one half (jittable)."""
     apply = jax.random.uniform(key, ()) < 0.5
@@ -464,10 +418,10 @@ def randomize_rendered_image(key, image, mask, backgrounds=None,
     occlusions, blur and color jitter. Mirrors the legacy pipeline."""
     keys = jax.random.split(key, 3 + num_occlusions)
     background = sample_background(keys[0], image.shape, backgrounds)
-    image = blend_background(image, background, mask)
+    image = paz.draw.blend_background(image, background, mask)
     for occlusion_arg in range(num_occlusions):
-        image = add_occlusion(keys[1 + occlusion_arg], image,
-                              max_radius_scale=max_radius_scale)
+        image = paz.draw.add_occlusion(keys[1 + occlusion_arg], image,
+                                       max_radius_scale=max_radius_scale)
     image = random_blur(keys[1 + num_occlusions], image)
     return random_color_transform(keys[2 + num_occlusions], image)
 

--- a/paz/backend/image.py
+++ b/paz/backend/image.py
@@ -403,6 +403,80 @@ def random_color_transform(key, image):
     return image
 
 
+def make_random_plain_image(key, shape):
+    """Plain image of a single random RGB color."""
+    color = jax.random.randint(key, (shape[-1],), 0, 256)
+    return jp.broadcast_to(color, shape).astype(jp.uint8)
+
+
+def random_crop(key, image, size):
+    """Crops a random `size` window from an image at least that large."""
+    H, W = image.shape[:2]
+    H_crop, W_crop = size
+    key_y, key_x = jax.random.split(key)
+    y = int(jax.random.randint(key_y, (), 0, max(H - H_crop, 0) + 1))
+    x = int(jax.random.randint(key_x, (), 0, max(W - W_crop, 0) + 1))
+    return image[y:y + H_crop, x:x + W_crop]
+
+
+def blend_background(image, background, mask):
+    """Composites a foreground over a background using a foreground mask."""
+    mask = jp.asarray(mask, jp.float32)
+    if mask.ndim == 2:
+        mask = mask[..., jp.newaxis]
+    foreground = paz.cast(image, jp.float32)
+    background = paz.cast(background, jp.float32)
+    blended = mask * foreground + (1.0 - mask) * background
+    return paz.cast(blended, jp.uint8)
+
+
+def add_occlusion(key, image, max_radius_scale=0.5):
+    """Draws one random filled polygon over the image."""
+    image = np.array(paz.to_numpy(image))
+    H, W = image.shape[:2]
+    keys = jax.random.split(key, 5)
+    num_vertices = int(jax.random.randint(keys[0], (), 4, 9))
+    center = np.asarray(jax.random.uniform(keys[1], (2,))) * np.array([W, H])
+    max_radius = max_radius_scale * max(H, W)
+    radii = np.asarray(jax.random.uniform(keys[2], (num_vertices,)))
+    angles = np.sort(np.asarray(jax.random.uniform(keys[3], (num_vertices,))))
+    offsets = np.stack([np.cos(angles * 2.0 * np.pi),
+                        np.sin(angles * 2.0 * np.pi)], axis=1)
+    points = (center + (radii * max_radius)[:, np.newaxis] * offsets)
+    color = np.asarray(jax.random.randint(keys[4], (3,), 0, 256)).tolist()
+    cv2.fillPoly(image, [points.astype(np.int32)], color)
+    return image
+
+
+def random_blur(key, image, kernel_size=9):
+    """Applies Gaussian blur with probability one half."""
+    if not bool(jax.random.uniform(key, ()) < 0.5):
+        return image
+    image = np.array(paz.to_numpy(image))
+    return cv2.GaussianBlur(image, (kernel_size, kernel_size), 0)
+
+
+def randomize_rendered_image(key, image, mask, backgrounds=None,
+                             num_occlusions=2, max_radius_scale=0.5):
+    """Domain-randomizes a rendered object view: background blending, random
+    occlusions, blur and color jitter. Mirrors the legacy pipeline."""
+    keys = jax.random.split(key, 3 + num_occlusions)
+    background = sample_background(keys[0], image.shape, backgrounds)
+    image = blend_background(image, background, mask)
+    for occlusion_arg in range(num_occlusions):
+        image = add_occlusion(keys[1 + occlusion_arg], image, max_radius_scale)
+    image = random_blur(keys[1 + num_occlusions], image)
+    return random_color_transform(keys[2 + num_occlusions], image)
+
+
+def sample_background(key, shape, backgrounds):
+    if backgrounds is None:
+        return make_random_plain_image(key, shape)
+    key_pick, key_crop = jax.random.split(key)
+    index = int(jax.random.randint(key_pick, (), 0, len(backgrounds)))
+    return random_crop(key_crop, backgrounds[index], shape[:2])
+
+
 def affine_transform(image, matrix, order=1, mode="nearest", cval=0.0):
 
     def build_image_indices(image):

--- a/paz/backend/image_test.py
+++ b/paz/backend/image_test.py
@@ -60,40 +60,12 @@ def test_make_random_plain_image_is_uniform_color():
     assert jp.all(image[0, 0] == image[5, 4])
 
 
-def test_blend_background_respects_mask():
-    foreground = jp.full((4, 4, 3), 200, jp.uint8)
-    background = jp.zeros((4, 4, 3), jp.uint8)
-    mask = jp.zeros((4, 4)).at[0, 0].set(1.0)
-    blended = paz.image.blend_background(foreground, background, mask)
-    assert int(blended[0, 0, 0]) == 200
-    assert int(blended[1, 1, 0]) == 0
-
-
-def test_add_occlusion_changes_image_and_keeps_shape():
-    image = jp.full((32, 32, 3), 200, jp.uint8)
-    occluded = paz.image.add_occlusion(jax.random.PRNGKey(1), image)
-    assert occluded.shape == (32, 32, 3)
-    assert not bool(jp.all(occluded == 200))
-
-
 def test_randomize_rendered_image_keeps_shape():
     image = jp.full((32, 32, 3), 128, jp.uint8)
     mask = jp.ones((32, 32))
     key = jax.random.PRNGKey(2)
     output = paz.image.randomize_rendered_image(key, image, mask)
     assert output.shape == (32, 32, 3)
-
-
-def test_fill_polygon_matches_cv2():
-    polygon = jp.array([[12, 10], [50, 16], [55, 48], [28, 58], [10, 38]],
-                       jp.float32)
-    image = jp.full((64, 64, 3), 200, jp.uint8)
-    filled = paz.image.fill_polygon(image, polygon, jp.zeros(3, jp.uint8))
-    reference = np.full((64, 64, 3), 200, np.uint8)
-    cv2.fillPoly(reference, [np.asarray(polygon).astype(np.int32)], (0, 0, 0))
-    jax_mask = np.asarray((filled == 0).all(-1))
-    reference_mask = (reference == 0).all(-1)
-    assert (jax_mask == reference_mask).mean() > 0.95
 
 
 def test_apply_gaussian_blur_matches_cv2_interior():

--- a/paz/backend/image_test.py
+++ b/paz/backend/image_test.py
@@ -50,3 +50,33 @@ def test_forward_differences_batches_images():
     expected = jax.vmap(legacy_forward_differences)(batch)
     assert jp.allclose(dy, expected[0])
     assert jp.allclose(dx, expected[1])
+
+
+def test_make_random_plain_image_is_uniform_color():
+    image = paz.image.make_random_plain_image(jax.random.PRNGKey(0), (8, 8, 3))
+    assert image.shape == (8, 8, 3)
+    assert jp.all(image[0, 0] == image[5, 4])
+
+
+def test_blend_background_respects_mask():
+    foreground = jp.full((4, 4, 3), 200, jp.uint8)
+    background = jp.zeros((4, 4, 3), jp.uint8)
+    mask = jp.zeros((4, 4)).at[0, 0].set(1.0)
+    blended = paz.image.blend_background(foreground, background, mask)
+    assert int(blended[0, 0, 0]) == 200
+    assert int(blended[1, 1, 0]) == 0
+
+
+def test_add_occlusion_changes_image_and_keeps_shape():
+    image = jp.full((32, 32, 3), 200, jp.uint8)
+    occluded = paz.image.add_occlusion(jax.random.PRNGKey(1), image)
+    assert occluded.shape == (32, 32, 3)
+    assert not bool(jp.all(occluded == 200))
+
+
+def test_randomize_rendered_image_keeps_shape():
+    image = jp.full((32, 32, 3), 128, jp.uint8)
+    mask = jp.ones((32, 32))
+    key = jax.random.PRNGKey(2)
+    output = paz.image.randomize_rendered_image(key, image, mask)
+    assert output.shape == (32, 32, 3)

--- a/paz/backend/image_test.py
+++ b/paz/backend/image_test.py
@@ -1,6 +1,8 @@
 import tempfile
 from pathlib import Path
 
+import cv2
+import numpy as np
 import jax
 import jax.numpy as jp
 
@@ -80,3 +82,33 @@ def test_randomize_rendered_image_keeps_shape():
     key = jax.random.PRNGKey(2)
     output = paz.image.randomize_rendered_image(key, image, mask)
     assert output.shape == (32, 32, 3)
+
+
+def test_fill_polygon_matches_cv2():
+    polygon = jp.array([[12, 10], [50, 16], [55, 48], [28, 58], [10, 38]],
+                       jp.float32)
+    image = jp.full((64, 64, 3), 200, jp.uint8)
+    filled = paz.image.fill_polygon(image, polygon, jp.zeros(3, jp.uint8))
+    reference = np.full((64, 64, 3), 200, np.uint8)
+    cv2.fillPoly(reference, [np.asarray(polygon).astype(np.int32)], (0, 0, 0))
+    jax_mask = np.asarray((filled == 0).all(-1))
+    reference_mask = (reference == 0).all(-1)
+    assert (jax_mask == reference_mask).mean() > 0.95
+
+
+def test_gaussian_blur_matches_cv2_interior():
+    image = np.random.default_rng(0).integers(0, 255, (64, 64, 3), np.uint8)
+    blurred = paz.image.gaussian_blur(jp.array(image), 9, 2.0)
+    blurred = np.asarray(blurred).astype(np.int16)
+    reference = cv2.GaussianBlur(image, (9, 9), 2.0).astype(np.int16)
+    interior = np.abs(blurred[8:-8, 8:-8] - reference[8:-8, 8:-8]).mean()
+    assert interior < 2.0
+
+
+def test_randomize_rendered_image_jits_without_recompilation():
+    randomize = jax.jit(paz.image.randomize_rendered_image)
+    image = jp.full((32, 32, 3), 128, jp.uint8)
+    mask = jp.ones((32, 32))
+    randomize(jax.random.PRNGKey(0), image, mask).block_until_ready()
+    randomize(jax.random.PRNGKey(1), image, mask).block_until_ready()
+    assert randomize._cache_size() == 1

--- a/paz/backend/image_test.py
+++ b/paz/backend/image_test.py
@@ -96,9 +96,9 @@ def test_fill_polygon_matches_cv2():
     assert (jax_mask == reference_mask).mean() > 0.95
 
 
-def test_gaussian_blur_matches_cv2_interior():
+def test_apply_gaussian_blur_matches_cv2_interior():
     image = np.random.default_rng(0).integers(0, 255, (64, 64, 3), np.uint8)
-    blurred = paz.image.gaussian_blur(jp.array(image), 9, 2.0)
+    blurred = paz.image.apply_gaussian_blur(jp.array(image), 9, 2.0)
     blurred = np.asarray(blurred).astype(np.int16)
     reference = cv2.GaussianBlur(image, (9, 9), 2.0).astype(np.int16)
     interior = np.abs(blurred[8:-8, 8:-8] - reference[8:-8, 8:-8]).mean()

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -28,6 +28,8 @@ from .segmentation.unet import UNET
 from .segmentation.unet import UNET_VGG16
 from .segmentation.unet import UNET_VGG19
 from .segmentation.unet import UNET_RESNET50
+from .autoencoder.autoencoder import AutoEncoder
+from .autoencoder.autoencoder import extract_encoder
 from .foundation.dinov3.models.vision_transformer import DINOV3VITS
 from .foundation.dinov3.models.vision_transformer import DINOV3VITB
 from .foundation.dinov3.models.vision_transformer import DINOV3VITL

--- a/paz/models/autoencoder/__init__.py
+++ b/paz/models/autoencoder/__init__.py
@@ -1,0 +1,2 @@
+from paz.models.autoencoder.autoencoder import AutoEncoder
+from paz.models.autoencoder.autoencoder import extract_encoder

--- a/paz/models/autoencoder/autoencoder.py
+++ b/paz/models/autoencoder/autoencoder.py
@@ -1,0 +1,49 @@
+from keras import Model
+from keras.layers import (
+    Conv2D,
+    Activation,
+    UpSampling2D,
+    Dense,
+    Input,
+    Flatten,
+    Reshape,
+)
+
+
+def AutoEncoder(input_shape, latent_dimension=128):
+    """Convolutional autoencoder for implicit orientation learning.
+
+    The encoder maps a rendered object view to a latent vector; the decoder
+    reconstructs the clean view. After training, `extract_encoder` returns the
+    encoder used to build the orientation codebook. Input is `128x128`.
+    """
+    image = Input(input_shape, name="input_image")
+    x = encode(image)
+    latent = Dense(latent_dimension, name="latent_vector")(x)
+    reconstruction = decode(latent, input_shape[-1])
+    name = "Autoencoder" + str(latent_dimension)
+    return Model(image, reconstruction, name=name)
+
+
+def encode(x):
+    for num_kernels in [32, 64, 128, 256]:
+        x = Conv2D(num_kernels, 3, strides=2, padding="same")(x)
+        x = Activation("relu")(x)
+    return Flatten()(x)
+
+
+def decode(latent, num_channels):
+    x = Dense(8 * 8 * 256)(latent)
+    x = Reshape((8, 8, 256))(x)
+    for num_kernels in [128, 64, 32]:
+        x = UpSampling2D(2)(x)
+        x = Conv2D(num_kernels, 3, padding="same")(x)
+        x = Activation("relu")(x)
+    x = UpSampling2D(2)(x)
+    x = Conv2D(num_channels, 3, padding="same")(x)
+    return Activation("sigmoid", name="label_image")(x)
+
+
+def extract_encoder(model):
+    latent = model.get_layer("latent_vector").output
+    return Model(model.input, latent, name="encoder")

--- a/paz/models/autoencoder/autoencoder_test.py
+++ b/paz/models/autoencoder/autoencoder_test.py
@@ -1,0 +1,22 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import jax.numpy as jp
+
+import paz
+
+
+def test_autoencoder_reconstruction_shape():
+    model = paz.models.AutoEncoder((128, 128, 3), 128)
+    reconstruction = model(jp.zeros((2, 128, 128, 3)))
+    assert tuple(reconstruction.shape) == (2, 128, 128, 3)
+    assert float(reconstruction.min()) >= 0.0
+    assert float(reconstruction.max()) <= 1.0
+
+
+def test_extract_encoder_latent_shape():
+    model = paz.models.AutoEncoder((128, 128, 3), 64)
+    encoder = paz.models.extract_encoder(model)
+    latent = encoder(jp.zeros((2, 128, 128, 3)))
+    assert tuple(latent.shape) == (2, 64)


### PR DESCRIPTION
Faithful JAX / Keras-3 port of the legacy augmented-autoencoder (AAE) baseline
for implicit 3D orientation estimation. Synthetic training data is generated
with the built-in `paz.graphics` renderer — no external rasterizer.

## What's added
- **`paz.models.AutoEncoder((128,128,3), latent_dimension)`** — conv encoder →
  latent → conv decoder (sigmoid). `paz.models.extract_encoder(model)` slices
  the encoder for the codebook. Co-located test.
- **`examples/implicit_orientation_learning/`**:
  - `scenes.py` — mesh loading/normalization, sphere pose sampling, and view
    rendering via `paz.graphics` (colored-cube fallback so it runs offline).
  - `train.py` — renders clean views once and **caches them** (`views.npz`),
    then trains the AE with per-epoch domain randomization (background
    composite via the constant-background mask, occlusion, brightness).
  - `codebook.py` — builds a pose codebook (encode rendered grid) and does
    cosine nearest-neighbor retrieval.
  - `demo.py` — webcam → encode → nearest codebook view (loads a local
    checkpoint; no weights hosted).

## Design notes
- Ray tracing is the slow step, so views are rendered **once and cached**;
  training only augments the cache each epoch. `build_mesh` normalizes any mesh
  to unit extent, so the default camera distance frames any object.
- The decoder is only used in training; inference is encoder + codebook.

## Verification (CPU)
- Model build + encoder slice — `paz/models/autoencoder/autoencoder_test.py`
  passes (recon `(B,128,128,3)` in `[0,1]`, latent `(B,d)`).
- Renderer produces orientation-distinct views (foreground framing tuned).
- Synthetic train smoke: loss decreases; `aae.weights.h5` + cache produced.
- Codebook + cosine retrieval returns the correct pose.

## Scope
No weights are hosted (would need a specific object model), so the demo loads a
locally trained checkpoint — same pattern as the segmentation example.