### PR TITLE
Add paz.transformers toolkit and port Whisper decoding onto it

### DIFF
--- a/examples/speech_to_text/decoding.py
+++ b/examples/speech_to_text/decoding.py
@@ -8,10 +8,7 @@ from examples.speech_to_text.tokenizer import find_special_token_id
 PROMPT_TOKENS = ["<|startoftranscript|>", "<|transcribe|>", "<|notimestamps|>"]
 
 
-def kv_decode(decoder, cache_shape, cross_model, encoder_output, stop_id,
-              key=None):
-    if key is None:
-        key = jax.random.PRNGKey(0)
+def kv_decode(key, decoder, cache_shape, cross_model, encoder_output, stop_id):
     max_len = decoder.max_decode_length
     batch = int(encoder_output.shape[0])
     cache = build_self_cache(cache_shape, max_len, batch)
@@ -19,7 +16,7 @@ def kv_decode(decoder, cache_shape, cross_model, encoder_output, stop_id,
     cache = jp.asarray(cache)
     cross_cache = jp.asarray(cross_cache)
     stop = jp.array(stop_id, dtype=jp.int32)
-    buffer, length = decoder(cache, cross_cache, stop, key)
+    buffer, length = decoder(key, cache, cross_cache, stop)
     return ops.convert_to_numpy(buffer[0, :length]).tolist()
 
 
@@ -39,7 +36,7 @@ def KVDecoder(decoder_step, prompt_ids, max_tokens, max_seq=448, select=None):
     prompt_len = len(prompt_ids)
 
     @jax.jit
-    def decode(self_cache, cross_cache, stop_id, key):
+    def decode(key, self_cache, cross_cache, stop_id):
         buffer = jp.zeros((1, max_len), dtype=jp.int32)
         buffer = buffer.at[0, :prompt_len].set(prompt)
         cache = self_cache
@@ -50,7 +47,7 @@ def KVDecoder(decoder_step, prompt_ids, max_tokens, max_seq=448, select=None):
         run = paz.transformers.search.build(step, select, max_tokens, max_len)
         token = jp.reshape(prompt[prompt_len - 1], (1, 1))
         index = jp.array(prompt_len - 1, dtype=jp.int32)
-        return run(buffer, token, index, cache, stop_id, key)
+        return run(key, buffer, token, index, cache, stop_id)
 
     # Python functions are objects; attributes can be set on them freely.
     decode.max_decode_length = max_len

--- a/examples/speech_to_text/decoding.py
+++ b/examples/speech_to_text/decoding.py
@@ -2,12 +2,16 @@ import jax
 import jax.numpy as jp
 from keras import ops
 
+import paz
 from examples.speech_to_text.tokenizer import find_special_token_id
 
 PROMPT_TOKENS = ["<|startoftranscript|>", "<|transcribe|>", "<|notimestamps|>"]
 
 
-def kv_decode(decoder, cache_shape, cross_model, encoder_output, stop_id):
+def kv_decode(decoder, cache_shape, cross_model, encoder_output, stop_id,
+              key=None):
+    if key is None:
+        key = jax.random.PRNGKey(0)
     max_len = decoder.max_decode_length
     batch = int(encoder_output.shape[0])
     cache = build_self_cache(cache_shape, max_len, batch)
@@ -15,7 +19,7 @@ def kv_decode(decoder, cache_shape, cross_model, encoder_output, stop_id):
     cache = jp.asarray(cache)
     cross_cache = jp.asarray(cross_cache)
     stop = jp.array(stop_id, dtype=jp.int32)
-    buffer, length = decoder(cache, cross_cache, stop)
+    buffer, length = decoder(cache, cross_cache, stop, key)
     return ops.convert_to_numpy(buffer[0, :length]).tolist()
 
 
@@ -23,34 +27,42 @@ def build_self_cache(cache_shape, max_len, batch_size=1):
     num_layers = int(cache_shape[1])
     num_heads = int(cache_shape[4])
     key_dim = int(cache_shape[5])
-    shape = (batch_size, num_layers, 2, max_len, num_heads, key_dim)
-    return ops.zeros(shape)
+    return paz.transformers.cache.build(
+        batch_size, num_layers, max_len, num_heads, key_dim)
 
 
-def KVDecoder(decoder_step, prompt_ids, max_tokens, max_seq=448):
+def KVDecoder(decoder_step, prompt_ids, max_tokens, max_seq=448, select=None):
+    if select is None:
+        select = paz.transformers.search.greedy
     max_len = min(max_seq, len(prompt_ids) + max_tokens)
     prompt = jp.array(prompt_ids, dtype=jp.int32)
     prompt_len = len(prompt_ids)
 
     @jax.jit
-    def decode(self_cache, cross_cache, stop_id):
+    def decode(self_cache, cross_cache, stop_id, key):
         buffer = jp.zeros((1, max_len), dtype=jp.int32)
         buffer = buffer.at[0, :prompt_len].set(prompt)
-        step = warmup_step(prompt, decoder_step, cross_cache)
         cache = self_cache
         if prompt_len > 1:
-            cache = jax.lax.fori_loop(0, prompt_len - 1, step, cache)
-        args = (buffer, prompt, prompt_len, cache, stop_id)
-        initial_state = build_initial_state(*args)
-        cont = should_continue(max_tokens, max_len)
-        advance = build_next_state(decoder_step, cross_cache, stop_id)
-        result = jax.lax.while_loop(cont, advance, initial_state)
-        buffer, _, index, _, _, _ = result
-        return buffer, index + 1
+            warmup = warmup_step(prompt, decoder_step, cross_cache)
+            cache = jax.lax.fori_loop(0, prompt_len - 1, warmup, cache)
+        step = build_step(decoder_step, cross_cache)
+        run = paz.transformers.search.build(step, select, max_tokens, max_len)
+        token = jp.reshape(prompt[prompt_len - 1], (1, 1))
+        index = jp.array(prompt_len - 1, dtype=jp.int32)
+        return run(buffer, token, index, cache, stop_id, key)
 
     # Python functions are objects; attributes can be set on them freely.
     decode.max_decode_length = max_len
     return decode
+
+
+def build_step(decoder, cross_cache):
+    def step(cache, token, index, key):
+        inputs = build_decoder_inputs(token, cache, cross_cache, index)
+        return decoder(inputs)
+
+    return step
 
 
 def warmup_step(prompt, decoder, cross_cache):
@@ -59,40 +71,6 @@ def warmup_step(prompt, decoder, cross_cache):
         inputs = build_decoder_inputs(token, cache, cross_cache, index)
         _, cache = decoder(inputs)
         return cache
-
-    return step
-
-
-def build_initial_state(buffer, prompt, prompt_len, cache, stop_id):
-    last_token = jp.reshape(prompt[prompt_len - 1], (1, 1))
-    index = jp.array(prompt_len - 1, dtype=jp.int32)
-    num_generated = jp.array(0, dtype=jp.int32)
-    finished = jp.array(False)
-    return (buffer, last_token, index, cache, num_generated, finished)
-
-
-def should_continue(max_gen, max_len):
-    def check(state):
-        _, _, index, _, num_generated, finished = state
-        not_done = ~finished
-        under_gen = num_generated < max_gen
-        under_len = index + 1 < max_len
-        return not_done & under_gen & under_len
-
-    return check
-
-
-def build_next_state(decoder, cross_cache, stop_id):
-    def step(state):
-        buffer, token, index, cache, num_generated, _ = state
-        inputs = build_decoder_inputs(token, cache, cross_cache, index)
-        logits, cache = decoder(inputs)
-        next_id = jp.argmax(logits[:, 0, :], axis=-1).astype(jp.int32)
-        next_index = index + 1
-        buffer = buffer.at[0, next_index].set(next_id[0])
-        token = jp.expand_dims(next_id, axis=-1)
-        finished = next_id[0] == stop_id
-        return (buffer, token, next_index, cache, num_generated + 1, finished)
 
     return step
 

--- a/examples/speech_to_text/demo.py
+++ b/examples/speech_to_text/demo.py
@@ -7,6 +7,7 @@ import argparse
 import sys
 from pathlib import Path
 
+import jax
 import numpy as np
 from keras import ops
 
@@ -14,6 +15,8 @@ ROOT = Path(__file__).resolve().parents[2]
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+import paz
 
 from examples.speech_to_text.audio import load, resample
 from examples.speech_to_text.audio import to_float, to_mono
@@ -36,10 +39,10 @@ SAMPLE_RATE = 16000
 MAX_AUDIO_SECONDS = 30
 
 
-def transcribe(wav_path, models, max_tokens=64):
+def transcribe(wav_path, models, max_tokens=64, select=None, key=None):
     waveform, sample_rate = load(wav_path)
     waveform = preprocess(waveform, sample_rate)
-    return transcribe_waveform(waveform, models, max_tokens)
+    return transcribe_waveform(waveform, models, max_tokens, select, key)
 
 
 def preprocess(waveform, sample_rate, target=16000):
@@ -68,34 +71,34 @@ def pad_or_trim_waveform(waveform, num_samples):
     return padded
 
 
-def transcribe_waveform(waveform, models, max_tokens=64):
-    decoder_state = build_decoder_state(models[3], max_tokens)
-    return transcribe_waveform_with_state(waveform, models, decoder_state)
+def transcribe_waveform(waveform, models, max_tokens=64, select=None, key=None):
+    decoder_state = build_decoder_state(models[3], max_tokens, select)
+    return transcribe_waveform_with_state(waveform, models, decoder_state, key)
 
 
-def transcribe_waveform_with_state(waveform, models, decoder_state):
+def transcribe_waveform_with_state(waveform, models, decoder_state, key=None):
     frontend_model, encoder, cross_model, decoder_step = models
     if len(waveform.shape) == 1:
         waveform = ops.expand_dims(waveform, axis=0)
     features = frontend_model(waveform)
     encoder_output = encoder(features)
     token_ids, text_ids, text = decode_encoder_output(
-        encoder_output, cross_model, decoder_state
+        encoder_output, cross_model, decoder_state, key
     )
     return token_ids, text_ids, text
 
 
-def build_decoder_state(decoder_step, max_tokens=64):
+def build_decoder_state(decoder_step, max_tokens=64, select=None):
     prompt_ids = build_whisper_prompt_token_ids()
     stop_id = find_special_token_id("<|endoftext|>")
     cache_shape = decoder_step.input_shape[1]
-    decoder = KVDecoder(decoder_step, prompt_ids, max_tokens)
+    decoder = KVDecoder(decoder_step, prompt_ids, max_tokens, select=select)
     return decoder, cache_shape, stop_id, len(prompt_ids)
 
 
-def decode_encoder_output(encoder_output, cross_model, decoder_state):
+def decode_encoder_output(encoder_output, cross_model, decoder_state, key=None):
     decoder, cache_shape, stop_id, prompt_length = decoder_state
-    args = (decoder, cache_shape, cross_model, encoder_output, stop_id)
+    args = (decoder, cache_shape, cross_model, encoder_output, stop_id, key)
     token_ids = kv_decode(*args)
     text_ids = extract_text_token_ids(token_ids, prompt_length, stop_id)
     text = decode_whisper_tokens(text_ids)
@@ -119,6 +122,16 @@ def build_models(model_name, models_path=WHISPER_MODELS_DIR):
     return frontend_model, encoder, cross_cache, decoder_step
 
 
+def build_sampling(args):
+    # Greedy by default; passing --temperature routes selection through the
+    # shared paz.transformers sampler, seeded by --seed for reproducibility.
+    if args.temperature is None:
+        return None, None
+    select = paz.transformers.search.build_sampler(
+        args.temperature, args.top_k, args.top_p)
+    return select, jax.random.PRNGKey(args.seed)
+
+
 if __name__ == "__main__":
     description = "Whisper speech-to-text demo"
     parser = argparse.ArgumentParser(description=description)
@@ -128,7 +141,13 @@ if __name__ == "__main__":
     add("--audio_path", default=default_audio)
     add("--model_name", default="whisper_base_en", choices=model_names)
     add("--max_tokens", default=64, type=int)
+    add("--temperature", default=None, type=float)
+    add("--top_k", default=0, type=int)
+    add("--top_p", default=1.0, type=float)
+    add("--seed", default=0, type=int)
     args = parser.parse_args()
+    select, key = build_sampling(args)
     models = build_models(args.model_name)
-    _, _, text = transcribe(Path(args.audio_path), models, args.max_tokens)
+    text = transcribe(Path(args.audio_path), models, args.max_tokens,
+                      select, key)[2]
     print(text)

--- a/examples/speech_to_text/demo.py
+++ b/examples/speech_to_text/demo.py
@@ -39,10 +39,10 @@ SAMPLE_RATE = 16000
 MAX_AUDIO_SECONDS = 30
 
 
-def transcribe(wav_path, models, max_tokens=64, select=None, key=None):
+def transcribe(key, wav_path, models, max_tokens=64, select=None):
     waveform, sample_rate = load(wav_path)
     waveform = preprocess(waveform, sample_rate)
-    return transcribe_waveform(waveform, models, max_tokens, select, key)
+    return transcribe_waveform(key, waveform, models, max_tokens, select)
 
 
 def preprocess(waveform, sample_rate, target=16000):
@@ -71,19 +71,19 @@ def pad_or_trim_waveform(waveform, num_samples):
     return padded
 
 
-def transcribe_waveform(waveform, models, max_tokens=64, select=None, key=None):
+def transcribe_waveform(key, waveform, models, max_tokens=64, select=None):
     decoder_state = build_decoder_state(models[3], max_tokens, select)
-    return transcribe_waveform_with_state(waveform, models, decoder_state, key)
+    return transcribe_waveform_with_state(key, waveform, models, decoder_state)
 
 
-def transcribe_waveform_with_state(waveform, models, decoder_state, key=None):
+def transcribe_waveform_with_state(key, waveform, models, decoder_state):
     frontend_model, encoder, cross_model, decoder_step = models
     if len(waveform.shape) == 1:
         waveform = ops.expand_dims(waveform, axis=0)
     features = frontend_model(waveform)
     encoder_output = encoder(features)
     token_ids, text_ids, text = decode_encoder_output(
-        encoder_output, cross_model, decoder_state, key
+        key, encoder_output, cross_model, decoder_state
     )
     return token_ids, text_ids, text
 
@@ -96,9 +96,9 @@ def build_decoder_state(decoder_step, max_tokens=64, select=None):
     return decoder, cache_shape, stop_id, len(prompt_ids)
 
 
-def decode_encoder_output(encoder_output, cross_model, decoder_state, key=None):
+def decode_encoder_output(key, encoder_output, cross_model, decoder_state):
     decoder, cache_shape, stop_id, prompt_length = decoder_state
-    args = (decoder, cache_shape, cross_model, encoder_output, stop_id, key)
+    args = (key, decoder, cache_shape, cross_model, encoder_output, stop_id)
     token_ids = kv_decode(*args)
     text_ids = extract_text_token_ids(token_ids, prompt_length, stop_id)
     text = decode_whisper_tokens(text_ids)
@@ -122,14 +122,13 @@ def build_models(model_name, models_path=WHISPER_MODELS_DIR):
     return frontend_model, encoder, cross_cache, decoder_step
 
 
-def build_sampling(args):
+def build_select(args):
     # Greedy by default; passing --temperature routes selection through the
-    # shared paz.transformers sampler, seeded by --seed for reproducibility.
+    # shared paz.transformers sampler.
     if args.temperature is None:
-        return None, None
-    select = paz.transformers.search.build_sampler(
+        return None
+    return paz.transformers.search.build_sampler(
         args.temperature, args.top_k, args.top_p)
-    return select, jax.random.PRNGKey(args.seed)
 
 
 if __name__ == "__main__":
@@ -146,8 +145,9 @@ if __name__ == "__main__":
     add("--top_p", default=1.0, type=float)
     add("--seed", default=0, type=int)
     args = parser.parse_args()
-    select, key = build_sampling(args)
+    key = jax.random.PRNGKey(args.seed)
+    select = build_select(args)
     models = build_models(args.model_name)
-    text = transcribe(Path(args.audio_path), models, args.max_tokens,
-                      select, key)[2]
+    text = transcribe(key, Path(args.audio_path), models, args.max_tokens,
+                      select)[2]
     print(text)

--- a/examples/speech_to_text/layers/attention.py
+++ b/examples/speech_to_text/layers/attention.py
@@ -1,5 +1,6 @@
 import string
 
+import paz
 from keras import ops
 from keras.layers import Dropout, EinsumDense
 
@@ -52,9 +53,11 @@ def build_cache(value, key, num_heads, key_dim, name):
 
 
 def update_cache(cache, index, value, key, num_heads, key_dim, name):
-    update = build_cache(value, key, num_heads, key_dim, name)
-    start = [0, 0, index, 0, 0]
-    return ops.slice_update(cache, start, update)
+    if key is None:
+        key = value
+    k = project_key(key, num_heads, key_dim, name)
+    v = project_value(value, num_heads, key_dim, name)
+    return paz.transformers.cache.update(cache, index, k, v)
 
 
 def project_query(query, num_heads, key_dim, name):

--- a/examples/speech_to_text/layers/decoder.py
+++ b/examples/speech_to_text/layers/decoder.py
@@ -1,7 +1,7 @@
+import paz
 from keras import ops
 from keras.layers import LayerNormalization, Dropout
 
-from examples.speech_to_text.layers.utils import build_gelu_dense, build_dense
 from examples.speech_to_text.layers.attention import kv_attend
 
 
@@ -26,10 +26,10 @@ def attend_self(x, cache, index, config, name):
 
 
 def build_self_attention_mask(cache, index):
-    positions = ops.ones_like(cache[:, 0, :, 0, 0], dtype="int32")
-    positions = ops.cumsum(positions, axis=1) - 1
-    positions = ops.expand_dims(positions, axis=1)
-    return ops.cast(positions <= index, "int32")
+    key_positions = ops.ones_like(cache[:, 0, :, 0, 0], dtype="int32")
+    key_positions = ops.cumsum(key_positions, axis=1) - 1
+    query_positions = ops.reshape(index, (1, 1))
+    return paz.transformers.mask.causal(query_positions, key_positions)
 
 
 def attend_cross(x, cross_cache, config, name):
@@ -46,7 +46,8 @@ def feedforward(x, config, name):
     dropout = config["dropout"]
     norm_name = f"{name}_layer_norm"
     delta = LayerNormalization(epsilon=1e-5, name=norm_name)(x)
-    delta = build_gelu_dense(dim, f"{name}_intermediate_dense")(delta)
-    delta = build_dense(x.shape[-1], f"{name}_output_dense")(delta)
+    delta = paz.transformers.feedforward.gelu(
+        delta, dim, x.shape[-1], f"{name}_intermediate_dense",
+        f"{name}_output_dense")
     delta = Dropout(dropout, name=f"{name}_dropout")(delta)
     return x + delta

--- a/examples/speech_to_text/layers/encoder.py
+++ b/examples/speech_to_text/layers/encoder.py
@@ -1,6 +1,6 @@
+import paz
 from keras.layers import LayerNormalization, Dropout
 
-from examples.speech_to_text.layers.utils import build_gelu_dense, build_dense
 from examples.speech_to_text.layers.attention import attend
 
 
@@ -24,7 +24,8 @@ def self_attend(x, num_heads, key_dim, dropout, epsilon, name):
 def encoder_dense(x, dim, dropout, epsilon, name):
     norm_name = f"{name}_layer_norm"
     delta = LayerNormalization(epsilon=epsilon, name=norm_name)(x)
-    delta = build_gelu_dense(dim, f"{name}_intermediate_dense")(delta)
-    delta = build_dense(x.shape[-1], f"{name}_output_dense")(delta)
+    delta = paz.transformers.feedforward.gelu(
+        delta, dim, x.shape[-1], f"{name}_intermediate_dense",
+        f"{name}_output_dense")
     delta = Dropout(dropout, name=f"{name}_dropout")(delta)
     return x + delta

--- a/examples/speech_to_text/model.py
+++ b/examples/speech_to_text/model.py
@@ -4,7 +4,8 @@ from keras import ops
 from keras import Model
 from keras.activations import gelu
 from keras.layers import Input, Conv1D, Dropout, Add, Lambda
-from keras.layers import LayerNormalization, ReversibleEmbedding
+from keras.layers import LayerNormalization
+from keras_hub.layers import ReversibleEmbedding
 
 from examples.speech_to_text.layers.frontend import frontend
 from examples.speech_to_text.layers.frontend import build_mel_filters

--- a/paz/__init__.py
+++ b/paz/__init__.py
@@ -42,6 +42,7 @@ from paz.backend.standard import (
 from paz import losses
 from paz.abstract import Model, Node, Input, Sequential, Tree
 from paz.models.decomposition import pca as PCA
+from paz.models import transformers
 from paz import applications
 from paz import utils
 from paz.utils import pytree

--- a/paz/models/transformers/__init__.py
+++ b/paz/models/transformers/__init__.py
@@ -1,0 +1,12 @@
+"""Reusable transformer / sequence-model primitives.
+
+Surfaced as ``paz.transformers``. Each submodule names the object it acts on
+and exposes bare-verb functions: ``cache.build``, ``cache.update``,
+``mask.causal``, ``logits.apply_temperature``, ``search.build``,
+``search.greedy``, ``feedforward.gelu``.
+"""
+from paz.models.transformers import cache
+from paz.models.transformers import mask
+from paz.models.transformers import logits
+from paz.models.transformers import search
+from paz.models.transformers import feedforward

--- a/paz/models/transformers/cache.py
+++ b/paz/models/transformers/cache.py
@@ -1,0 +1,16 @@
+"""Key/value cache for cached attention decoding.
+
+Layout ``(batch, num_layers, 2, max_length, num_heads, head_dim)`` where axis 2
+stacks (key, value). ``update`` writes one per-layer entry in place.
+"""
+from keras import ops
+
+
+def build(batch, num_layers, max_length, num_heads, head_dim, dtype="float32"):
+    shape = (batch, num_layers, 2, max_length, num_heads, head_dim)
+    return ops.zeros(shape, dtype=dtype)
+
+
+def update(state, index, key, value):
+    entry = ops.stack((key, value), axis=1)
+    return ops.slice_update(state, [0, 0, index, 0, 0], entry)

--- a/paz/models/transformers/cache_test.py
+++ b/paz/models/transformers/cache_test.py
@@ -1,0 +1,24 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+from keras import ops
+
+from paz.models.transformers import cache
+
+
+def test_build_shape_and_zeros():
+    state = cache.build(1, 3, 5, 4, 2)
+    assert tuple(state.shape) == (1, 3, 2, 5, 4, 2)
+    assert float(ops.max(ops.abs(state))) == 0.0
+
+
+def test_update_writes_key_and_value_at_index():
+    state = ops.zeros((1, 2, 4, 3, 2))
+    key = ops.ones((1, 1, 3, 2))
+    value = ops.full((1, 1, 3, 2), 2.0)
+    out = np.asarray(cache.update(state, 1, key, value))
+    assert np.all(out[:, 0, 1] == 1.0)
+    assert np.all(out[:, 1, 1] == 2.0)
+    assert np.all(out[:, :, 0] == 0.0) and np.all(out[:, :, 2] == 0.0)

--- a/paz/models/transformers/conftest.py
+++ b/paz/models/transformers/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"

--- a/paz/models/transformers/feedforward.py
+++ b/paz/models/transformers/feedforward.py
@@ -1,0 +1,28 @@
+"""Position-wise feedforward sub-layers (no norm, no residual).
+
+Flavors: ``gelu`` (vanilla Dense -> GELU -> Dense) and ``glu`` (gated GeGLU).
+Callers pass layer names so weight loading keeps working, and wrap their own
+normalization / residual around the returned tensor.
+"""
+import keras
+from keras import activations
+from keras.layers import Dense
+
+
+def gelu(x, inner_dim, output_dim, intermediate_name, output_name):
+    kernel = keras.initializers.TruncatedNormal(stddev=0.02)
+    hidden = Dense(inner_dim, activation=activations.gelu,
+                   kernel_initializer=kernel, bias_initializer="zeros",
+                   name=intermediate_name)(x)
+    return Dense(output_dim, kernel_initializer=kernel,
+                 bias_initializer="zeros", name=output_name)(hidden)
+
+
+def glu(x, inner_dim, output_dim, gate_name, up_name, down_name):
+    kernel = keras.initializers.TruncatedNormal(stddev=0.02)
+    gate = Dense(inner_dim, activation=activations.gelu, use_bias=False,
+                 kernel_initializer=kernel, name=gate_name)(x)
+    up = Dense(inner_dim, use_bias=False, kernel_initializer=kernel,
+               name=up_name)(x)
+    return Dense(output_dim, use_bias=False, kernel_initializer=kernel,
+                 name=down_name)(gate * up)

--- a/paz/models/transformers/feedforward_test.py
+++ b/paz/models/transformers/feedforward_test.py
@@ -1,0 +1,25 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+from keras import Input, Model
+
+from paz.models.transformers import feedforward
+
+
+def test_gelu_shape_and_layer_names():
+    x = Input((4, 8))
+    y = feedforward.gelu(x, 16, 8, "ff_intermediate", "ff_output")
+    model = Model(x, y)
+    assert model.output_shape == (None, 4, 8)
+    names = [layer.name for layer in model.layers]
+    assert "ff_intermediate" in names and "ff_output" in names
+
+
+def test_glu_shape_and_layer_names():
+    x = Input((4, 8))
+    y = feedforward.glu(x, 16, 8, "ff_gate", "ff_up", "ff_down")
+    model = Model(x, y)
+    assert model.output_shape == (None, 4, 8)
+    names = [layer.name for layer in model.layers]
+    assert all(n in names for n in ("ff_gate", "ff_up", "ff_down"))

--- a/paz/models/transformers/logits.py
+++ b/paz/models/transformers/logits.py
@@ -1,0 +1,30 @@
+"""Logit-shaping transforms over (batch, vocabulary) for sampling.
+
+top_k <= 0 disables top-k; top_p >= 1 disables nucleus truncation.
+"""
+import jax
+import jax.numpy as jp
+
+
+def apply_temperature(logits, temperature):
+    return logits / temperature
+
+
+def apply_top_k(logits, top_k):
+    if not top_k or top_k <= 0:
+        return logits
+    values, _ = jax.lax.top_k(logits, top_k)
+    threshold = values[..., -1:]
+    return jp.where(logits < threshold, -jp.inf, logits)
+
+
+def apply_top_p(logits, top_p):
+    if top_p is None or top_p >= 1.0:
+        return logits
+    order = jp.argsort(-logits, axis=-1)
+    sorted_logits = jp.take_along_axis(logits, order, axis=-1)
+    probs = jax.nn.softmax(sorted_logits, axis=-1)
+    prefix = jp.cumsum(probs, axis=-1) - probs
+    sorted_logits = jp.where(prefix < top_p, sorted_logits, -jp.inf)
+    inverse = jp.argsort(order, axis=-1)
+    return jp.take_along_axis(sorted_logits, inverse, axis=-1)

--- a/paz/models/transformers/logits_test.py
+++ b/paz/models/transformers/logits_test.py
@@ -1,0 +1,35 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import jax.numpy as jp
+
+from paz.models.transformers import logits
+
+
+def test_apply_temperature_scales():
+    values = jp.array([[2.0, 4.0]])
+    out = np.asarray(logits.apply_temperature(values, 2.0))
+    assert np.allclose(out, [[1.0, 2.0]])
+
+
+def test_apply_top_k_keeps_k_largest():
+    values = jp.array([[1.0, 3.0, 2.0, 0.0]])
+    out = np.asarray(logits.apply_top_k(values, 2))
+    assert out[0, 1] == 3.0 and out[0, 2] == 2.0
+    assert np.isneginf(out[0, 0]) and np.isneginf(out[0, 3])
+
+
+def test_apply_top_p_keeps_nucleus():
+    values = jp.array([[0.0, 10.0, 9.0, -10.0]])
+    out = np.asarray(logits.apply_top_p(values, 0.5))
+    # 10.0 alone already exceeds 0.5 of the mass; only it survives.
+    assert out[0, 1] == 10.0
+    assert np.isneginf(out[0, 0]) and np.isneginf(out[0, 3])
+
+
+def test_disabled_transforms_are_identity():
+    values = jp.array([[1.0, 2.0, 3.0]])
+    assert np.allclose(np.asarray(logits.apply_top_k(values, 0)), [[1, 2, 3]])
+    assert np.allclose(np.asarray(logits.apply_top_p(values, 1.0)), [[1, 2, 3]])

--- a/paz/models/transformers/mask.py
+++ b/paz/models/transformers/mask.py
@@ -1,0 +1,8 @@
+"""Attention masks."""
+from keras import ops
+
+
+def causal(query_positions, key_positions):
+    query = ops.expand_dims(query_positions, axis=-1)
+    key = ops.expand_dims(key_positions, axis=-2)
+    return ops.less_equal(key, query)

--- a/paz/models/transformers/mask_test.py
+++ b/paz/models/transformers/mask_test.py
@@ -1,0 +1,23 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+
+from paz.models.transformers import mask
+
+
+def test_causal_single_query_matches_threshold():
+    query = np.array([[2]], dtype="int32")
+    key = np.array([[0, 1, 2, 3, 4]], dtype="int32")
+    out = np.asarray(mask.causal(query, key)).astype(bool)
+    assert out.shape == (1, 1, 5)
+    assert out[0, 0].tolist() == [True, True, True, False, False]
+
+
+def test_causal_full_grid_is_lower_triangular():
+    positions = np.array([[0, 1, 2]], dtype="int32")
+    out = np.asarray(mask.causal(positions, positions)).astype(bool)
+    assert out[0].tolist() == [[True, False, False],
+                               [True, True, False],
+                               [True, True, True]]

--- a/paz/models/transformers/search.py
+++ b/paz/models/transformers/search.py
@@ -1,0 +1,65 @@
+"""Autoregressive token search over a cached decoder step.
+
+``build`` returns a ``run`` that drives a ``jax.lax.while_loop`` writing
+generated tokens into ``buffer`` starting after ``index``. The model supplies
+``step(cache, token, index, key) -> (logits, cache)`` (it owns the forward and
+the constant cross-cache); ``select(logits, key) -> token_id`` is ``greedy`` or
+a ``build_sampler`` closure. Prefill/warmup stays model-side and seeds the call.
+"""
+import jax
+import jax.numpy as jp
+
+from paz.models.transformers.logits import apply_temperature
+from paz.models.transformers.logits import apply_top_k
+from paz.models.transformers.logits import apply_top_p
+
+
+def build(step, select, max_tokens, max_length):
+    def run(buffer, token, index, cache, stop_id, key):
+        count = jp.array(0, dtype=jp.int32)
+        finished = jp.array(False)
+        state = (buffer, token, index, cache, count, finished, key)
+        cont = build_should_continue(max_tokens, max_length)
+        advance = build_advance(step, select, stop_id)
+        state = jax.lax.while_loop(cont, advance, state)
+        return state[0], state[2] + 1
+
+    return run
+
+
+def build_should_continue(max_tokens, max_length):
+    def check(state):
+        _, _, index, _, count, finished, _ = state
+        return (~finished) & (count < max_tokens) & (index + 1 < max_length)
+
+    return check
+
+
+def build_advance(step, select, stop_id):
+    def advance(state):
+        buffer, token, index, cache, count, _, key = state
+        logits, cache = step(cache, token, index, key)
+        key, step_key = jax.random.split(key)
+        next_id = select(logits, step_key)
+        next_index = index + 1
+        buffer = buffer.at[0, next_index].set(next_id[0])
+        token = jp.expand_dims(next_id, axis=-1)
+        finished = next_id[0] == stop_id
+        return (buffer, token, next_index, cache, count + 1, finished, key)
+
+    return advance
+
+
+def greedy(logits, key):
+    return jp.argmax(logits[:, 0, :], axis=-1).astype(jp.int32)
+
+
+def build_sampler(temperature, top_k, top_p):
+    def select(logits, key):
+        row = logits[:, 0, :]
+        row = apply_temperature(row, temperature)
+        row = apply_top_k(row, top_k)
+        row = apply_top_p(row, top_p)
+        return jax.random.categorical(key, row, axis=-1).astype(jp.int32)
+
+    return select

--- a/paz/models/transformers/search.py
+++ b/paz/models/transformers/search.py
@@ -15,7 +15,7 @@ from paz.models.transformers.logits import apply_top_p
 
 
 def build(step, select, max_tokens, max_length):
-    def run(buffer, token, index, cache, stop_id, key):
+    def run(key, buffer, token, index, cache, stop_id):
         count = jp.array(0, dtype=jp.int32)
         finished = jp.array(False)
         state = (buffer, token, index, cache, count, finished, key)

--- a/paz/models/transformers/search_test.py
+++ b/paz/models/transformers/search_test.py
@@ -1,0 +1,50 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import jax
+import jax.numpy as jp
+
+from paz.models.transformers import search
+
+VOCAB = 10
+
+
+def build_counting_step():
+    # Deterministic toy decoder: next id = (current token + 1) % VOCAB.
+    def step(cache, token, index, key):
+        nxt = (token[0, 0] + 1) % VOCAB
+        return jax.nn.one_hot(nxt, VOCAB)[None, None, :], cache
+
+    return step
+
+
+def run_counting(stop_id, max_tokens=4, max_length=8, seed=0):
+    run = search.build(build_counting_step(), search.greedy,
+                       max_tokens, max_length)
+    buffer = jp.zeros((1, max_length), dtype=jp.int32).at[0, 0].set(2)
+    token = jp.reshape(jp.array(2, dtype=jp.int32), (1, 1))
+    index = jp.array(0, dtype=jp.int32)
+    cache = jp.zeros((1,))
+    return run(buffer, token, index, cache,
+               jp.array(stop_id, dtype=jp.int32), jax.random.PRNGKey(seed))
+
+
+def test_greedy_loop_counts_up_to_max_tokens():
+    buffer, length = run_counting(stop_id=999)
+    assert int(length) == 5
+    assert buffer[0, :5].tolist() == [2, 3, 4, 5, 6]
+
+
+def test_loop_stops_at_stop_id():
+    buffer, length = run_counting(stop_id=4)
+    # seed 2 -> 3 -> 4(stop); generated up to and including the stop token.
+    assert buffer[0, :int(length)].tolist() == [2, 3, 4]
+
+
+def test_sampler_top_k_one_matches_greedy_and_is_seeded():
+    row = jp.array([[1.0, 5.0, 2.0, 0.0]])[:, None, :]
+    sampler = search.build_sampler(1.0, 1, 1.0)
+    key = jax.random.PRNGKey(3)
+    assert int(sampler(row, key)[0]) == int(search.greedy(row, key)[0])
+    assert int(sampler(row, key)[0]) == int(sampler(row, key)[0])

--- a/paz/models/transformers/search_test.py
+++ b/paz/models/transformers/search_test.py
@@ -26,8 +26,8 @@ def run_counting(stop_id, max_tokens=4, max_length=8, seed=0):
     token = jp.reshape(jp.array(2, dtype=jp.int32), (1, 1))
     index = jp.array(0, dtype=jp.int32)
     cache = jp.zeros((1,))
-    return run(buffer, token, index, cache,
-               jp.array(stop_id, dtype=jp.int32), jax.random.PRNGKey(seed))
+    return run(jax.random.PRNGKey(seed), buffer, token, index, cache,
+               jp.array(stop_id, dtype=jp.int32))
 
 
 def test_greedy_loop_counts_up_to_max_tokens():


### PR DESCRIPTION
## What

Introduces `paz/models/transformers` — surfaced as **`paz.transformers`** — a
small, functional toolkit of reusable sequence-model primitives, and ports the
Whisper example (`examples/speech_to_text`) onto it. First step toward sharing
transformer machinery across Whisper and Gemma4 (Gemma4 follows in a later PR).

### `paz.transformers` (new)

Module names the object/process; functions are bare verbs; params are explicit
(no `*Args` bundles). Each with a co-located `*_test.py`.

- `cache.build` / `cache.update` — KV cache `(batch, layers, 2, len, heads, dim)`
- `search.build` — jitted autoregressive decode loop; selectors `search.greedy`
  and `search.build_sampler(temperature, top_k, top_p)`
- `logits.apply_temperature` / `apply_top_k` / `apply_top_p`
- `mask.causal`
- `feedforward.gelu` (vanilla) / `feedforward.glu` (gated GeGLU)

### Whisper refactor (behavior-preserving)

`decoding.py` and `layers/{attention,decoder,encoder}.py` now use the toolkit.
QKV projection, cross-attention, learned positions and the warmup/prefill stay
model-side. Greedy decoding is unchanged — generated token ids are **identical**
before and after on `whisper_tiny_en` and `whisper_base_en` (on `harvard.wav`).
The demo gains optional `--temperature/--top_k/--top_p` sampling (greedy stays
the default) via `paz.transformers.search.build_sampler`.

### Incidental fix

`model.py` imported `ReversibleEmbedding` from `keras.layers`, which is not
present on the current keras; corrected to `keras_hub.layers`, matching
`examples/gemma4`, so the example loads.

## Validation

- Greedy token ids identical pre/post refactor (`whisper_tiny_en`,
  `whisper_base_en`).
- Sampling: `top_k=1` reduces to greedy; reproducible under a fixed key.
- `pytest paz/models/transformers/` → 13 passed.
- `pytest examples/speech_to_text/push_to_talk_test.py` → 10 passed.
  (Run with `KERAS_BACKEND=jax`, as for the rest of the JAX-first repo.)

## Notes

The branch is based on an earlier `paz-jax`; `paz/__init__.py` and
`examples/speech_to_text/` are unchanged on `paz-jax` since, so the diff is
conflict-free. Happy to rebase if preferred.
