### PR TITLE
Inline example entry points under __main__ (no main()/argparse helper)

### DIFF
--- a/examples/action_scores/train_classifier.py
+++ b/examples/action_scores/train_classifier.py
@@ -33,16 +33,12 @@ def find_feature_layer(model):
     return adds[-1]
 
 
-def parse_arguments():
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="FER + action scores")
     parser.add_argument("--root", default="experiments")
     parser.add_argument("--batch_size", default=32, type=int)
     parser.add_argument("--epochs", default=100, type=int)
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     os.makedirs(args.root, exist_ok=True)
     train_images, train_labels = fer.load("train")
     valid_images, valid_labels = fer.load("validation")
@@ -58,7 +54,3 @@ def main():
     log = keras.callbacks.CSVLogger(os.path.join(args.root, "log.csv"))
     model.fit(train, epochs=args.epochs, validation_data=valid,
               callbacks=[log, scores, features])
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/efficientpose/train.py
+++ b/examples/efficientpose/train.py
@@ -155,16 +155,12 @@ class LinemodSequence(keras.utils.PyDataset):
         return np.asarray(resized, "float32") - self.mean, scale
 
 
-def parse_arguments():
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--smoke", action="store_true")
     parser.add_argument("--data_path", default="Linemod_preprocessed/")
     parser.add_argument("--object_id", default="08")
     parser.add_argument("--batch_size", default=1, type=int)
     parser.add_argument("--num_epochs", default=500, type=int)
-    return parser.parse_args()
-
-
-if __name__ == "__main__":
-    args = parse_arguments()
+    args = parser.parse_args()
     smoke_train() if args.smoke else train_linemod(args)

--- a/examples/eigenfaces/demo.py
+++ b/examples/eigenfaces/demo.py
@@ -14,18 +14,6 @@ import eigenfaces
 import paz
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Eigenfaces live demo")
-    parser.add_argument("--camera", default=0, type=int)
-    parser.add_argument("--H", default=480, type=int)
-    parser.add_argument("--W", default=640, type=int)
-    parser.add_argument("--box_scale", default=1.2, type=float)
-    parser.add_argument("--distance_threshold", default=None, type=float)
-    parser.add_argument("--experiments_path", default="experiments")
-    parser.add_argument("--database_path", default="database")
-    return parser.parse_args()
-
-
 def load_state(experiments_path):
     filepath = Path(experiments_path) / "eigenfaces_state.npz"
     if not filepath.exists():
@@ -52,23 +40,10 @@ def build_demo_pipeline(state, face_database, box_scale=1.2, threshold=None):
             weight = eigenfaces.project_single(face, state)
             label = face_database.query(weight, threshold)
             labels.append(label)
-        image_with_boxes = _draw_predictions(image, boxes, labels, color_by_label)
-        return (boxes, labels), image_with_boxes
+        drawn = _draw_predictions(image, boxes, labels, color_by_label)
+        return (boxes, labels), drawn
 
     return call
-
-
-def main():
-    args = parse_args()
-    eigenface_state = load_state(args.experiments_path)
-    face_database = load_database(args.database_path)
-    box_scale = args.box_scale
-    threshold = args.distance_threshold
-    build_args = (eigenface_state, face_database, box_scale, threshold)
-    pipeline = build_demo_pipeline(*build_args)
-    camera = paz.Camera(args.camera)
-    player = paz.VideoPlayer((args.H, args.W), pipeline, camera)
-    player.run()
 
 
 def _build_face_boxes(image, detect_face, box_scale):
@@ -115,4 +90,20 @@ def _cast_box(box):
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Eigenfaces live demo")
+    parser.add_argument("--camera", default=0, type=int)
+    parser.add_argument("--H", default=480, type=int)
+    parser.add_argument("--W", default=640, type=int)
+    parser.add_argument("--box_scale", default=1.2, type=float)
+    parser.add_argument("--distance_threshold", default=None, type=float)
+    parser.add_argument("--experiments_path", default="experiments")
+    parser.add_argument("--database_path", default="database")
+    args = parser.parse_args()
+    eigenface_state = load_state(args.experiments_path)
+    face_database = load_database(args.database_path)
+    build_args = (eigenface_state, face_database, args.box_scale,
+                  args.distance_threshold)
+    pipeline = build_demo_pipeline(*build_args)
+    camera = paz.Camera(args.camera)
+    player = paz.VideoPlayer((args.H, args.W), pipeline, camera)
+    player.run()

--- a/examples/emotion_classifier/train.py
+++ b/examples/emotion_classifier/train.py
@@ -35,16 +35,12 @@ def augment_batch(images):
     return np.clip(images * brightness, 0.0, 1.0)
 
 
-def parse_arguments():
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MiniXception FER training")
     parser.add_argument("--root", default="experiments")
     parser.add_argument("--batch_size", default=32, type=int)
     parser.add_argument("--epochs", default=100, type=int)
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     os.makedirs(args.root, exist_ok=True)
     train_images, train_labels = fer.load("train")
     valid_images, valid_labels = fer.load("validation")
@@ -61,7 +57,3 @@ def main():
     ]
     model.fit(train, validation_data=valid, epochs=args.epochs,
               callbacks=callbacks)
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/hand_detection/train.py
+++ b/examples/hand_detection/train.py
@@ -18,7 +18,14 @@ from generator import Generator
 from pipeline2 import preprocess_batch
 
 
-def parse_arguments():
+def build_generator(args, key, split, batch_args, workers, augment=True):
+    images, detections = OpenImagesV6Hand(args.data_path, split).load_data()
+    pipeline = paz.lock(preprocess_batch, *batch_args, split == "train")
+    return Generator(key, images, detections, args.batch_size, pipeline,
+                     workers, args.max_queue_size)
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="SSD512 hand detection train")
     parser.add_argument("--data_path", default="open-images-v6/")
     parser.add_argument("--root", default="experiments", type=str)
@@ -32,11 +39,7 @@ def parse_arguments():
     parser.add_argument("--num_workers", default="max")
     parser.add_argument("--max_queue_size", default=50, type=int)
     parser.add_argument("--box_variances", nargs="+", default=[0.1, 0.1, 0.2, 0.2])  # fmt: skip
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     root, key = paz.logger.setup(args)
     prior_boxes = paz.models.detection.single_shot_detector.build_prior_boxes("COCO")  # fmt: skip
     num_classes = 1  # foreground hand class; SSD512 adds the background class
@@ -60,14 +63,3 @@ def main():
                      save_best_only=True)]
     model.fit(train, epochs=args.num_epochs, validation_data=valid,
               callbacks=callbacks)
-
-
-def build_generator(args, key, split, batch_args, workers, augment=True):
-    images, detections = OpenImagesV6Hand(args.data_path, split).load_data()
-    pipeline = paz.lock(preprocess_batch, *batch_args, split == "train")
-    return Generator(key, images, detections, args.batch_size, pipeline,
-                     workers, args.max_queue_size)
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/imdb_classifier/train.py
+++ b/examples/imdb_classifier/train.py
@@ -40,17 +40,13 @@ def load_arrays(data, split):
     return images, labels
 
 
-def parse_arguments():
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MiniXception IMDB training")
     parser.add_argument("--data", default="data")
     parser.add_argument("--root", default="experiments")
     parser.add_argument("--batch_size", default=32, type=int)
     parser.add_argument("--epochs", default=100, type=int)
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     os.makedirs(args.root, exist_ok=True)
     train_images, train_labels = load_arrays(args.data, "train")
     valid_images, valid_labels = load_arrays(args.data, "validation")
@@ -69,7 +65,3 @@ def main():
     ]
     model.fit(train, validation_data=valid, epochs=args.epochs,
               callbacks=callbacks)
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/probabilistic_keypoint_estimation/train.py
+++ b/examples/probabilistic_keypoint_estimation/train.py
@@ -36,7 +36,7 @@ def augment_batch(images):
     return np.clip(images * brightness, 0.0, 1.0)
 
 
-def parse_arguments():
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Probabilistic keypoints")
     parser.add_argument("--root", default="dataset")
     parser.add_argument("--save_path", default="experiments")
@@ -44,11 +44,7 @@ def parse_arguments():
     parser.add_argument("--learning_rate", default=0.001, type=float)
     parser.add_argument("--epochs", default=10000, type=int)
     parser.add_argument("--validation_split", default=0.2, type=float)
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     os.makedirs(args.save_path, exist_ok=True)
     images, keypoints = facial_keypoints.load(args.root, "train")
     split = int(len(images) * (1 - args.validation_split))
@@ -70,7 +66,3 @@ def main():
     ]
     model.fit(train, validation_data=valid, epochs=args.epochs,
               callbacks=callbacks)
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/semantic_segmentation/train.py
+++ b/examples/semantic_segmentation/train.py
@@ -29,7 +29,7 @@ class ShapesSequence(keras.utils.PyDataset):
         return self.images[chunk], self.targets[chunk]
 
 
-def parse_arguments():
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="UNet Shapes segmentation")
     parser.add_argument("--save_path", default="experiments")
     parser.add_argument("--image_size", default=128, type=int)
@@ -38,11 +38,7 @@ def parse_arguments():
     parser.add_argument("--learning_rate", default=0.001, type=float)
     parser.add_argument("--epochs", default=100, type=int)
     parser.add_argument("--validation_split", default=0.2, type=float)
-    return parser.parse_args()
-
-
-def main():
-    args = parse_arguments()
+    args = parser.parse_args()
     os.makedirs(args.save_path, exist_ok=True)
     H = W = args.image_size
     num_classes = len(shapes.get_class_names()) + 1
@@ -66,7 +62,3 @@ def main():
     ]
     model.fit(train, validation_data=valid, epochs=args.epochs,
               callbacks=callbacks)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Cluster A of the post-#365 cleanup: apply the example-script convention
(classic `if __name__ == "__main__":` guard with the body inlined — no
`def main()`, no `parse_arguments()`/`parse_args()` helper) across the existing
ports, which predate that convention.

## Files
- `examples/imdb_classifier/train.py`
- `examples/emotion_classifier/train.py`
- `examples/semantic_segmentation/train.py`
- `examples/hand_detection/train.py` (kept `build_generator` as a module fn)
- `examples/action_scores/train_classifier.py`
- `examples/probabilistic_keypoint_estimation/train.py`
- `examples/efficientpose/train.py`
- `examples/eigenfaces/demo.py` (kept its module helpers)

Module-level helper functions/classes are unchanged; only the `main()`/argparse
wrappers were removed and inlined under the guard. No behavior change.

## Verification (CPU)
- All eight files compile; `pyflakes` reports no unused imports.
- `imdb_classifier/train.py` runs end-to-end on synthetic arrays (trains,
  writes `*.weights.h5`).

Scope note: numpy-`augment_batch` reuse (cluster B) and the EfficientDet
numpy postprocess / pose-app cv2 (clusters C/D) are deliberately left for
separate PRs.