### PR TITLE
Reuse JAX backend augmentation in train sequences

### DIFF
--- a/examples/emotion_classifier/train.py
+++ b/examples/emotion_classifier/train.py
@@ -5,34 +5,41 @@ os.environ["KERAS_BACKEND"] = "jax"
 import argparse
 
 import numpy as np
+import jax
+import jax.numpy as jp
 import keras
 
 import paz
 from paz.datasets import fer
 
 
+def augment_face(key, image):
+    key_flip, key_light = jax.random.split(key)
+    image = paz.image.random_flip_left_right(key_flip, image)
+    return paz.image.random_brightness(key_light, image)
+
+
 class FERSequence(keras.utils.PyDataset):
-    def __init__(self, images, labels, batch_size, augment=False):
+    def __init__(self, images, labels, batch_size, augment=False, seed=0):
         super().__init__()
-        self.images = np.asarray(images, "float32") / 255.0
+        self.images = np.asarray(images, "uint8")
         self.labels = np.asarray(labels, "float32")
         self.batch_size = batch_size
         self.augment = augment
+        self.key = jax.random.PRNGKey(seed)
+        self.augment_images = jax.jit(jax.vmap(augment_face))
 
     def __len__(self):
         return len(self.images) // self.batch_size
 
     def __getitem__(self, index):
         chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
-        images, labels = self.images[chunk].copy(), self.labels[chunk]
-        return augment_batch(images) if self.augment else images, labels
-
-
-def augment_batch(images):
-    flip = np.random.random(len(images)) < 0.5
-    images[flip] = images[flip, :, ::-1, :]
-    brightness = np.random.uniform(0.9, 1.1, (len(images), 1, 1, 1))
-    return np.clip(images * brightness, 0.0, 1.0)
+        images = self.images[chunk]
+        if self.augment:
+            key = jax.random.fold_in(self.key, index)
+            keys = jax.random.split(key, len(images))
+            images = self.augment_images(keys, jp.asarray(images))
+        return np.asarray(images, "float32") / 255.0, self.labels[chunk]
 
 
 if __name__ == "__main__":

--- a/examples/imdb_classifier/train.py
+++ b/examples/imdb_classifier/train.py
@@ -5,33 +5,40 @@ os.environ["KERAS_BACKEND"] = "jax"
 import argparse
 
 import numpy as np
+import jax
+import jax.numpy as jp
 import keras
 
 import paz
 
 
+def augment_face(key, image):
+    key_flip, key_light = jax.random.split(key)
+    image = paz.image.random_flip_left_right(key_flip, image)
+    return paz.image.random_brightness(key_light, image)
+
+
 class IMDBSequence(keras.utils.PyDataset):
-    def __init__(self, images, labels, batch_size, augment=False):
+    def __init__(self, images, labels, batch_size, augment=False, seed=0):
         super().__init__()
-        self.images = np.asarray(images, "float32") / 255.0
+        self.images = np.asarray(images, "uint8")
         self.labels = np.asarray(labels, "float32")
         self.batch_size = batch_size
         self.augment = augment
+        self.key = jax.random.PRNGKey(seed)
+        self.augment_images = jax.jit(jax.vmap(augment_face))
 
     def __len__(self):
         return len(self.images) // self.batch_size
 
     def __getitem__(self, index):
         chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
-        images, labels = self.images[chunk].copy(), self.labels[chunk]
-        return augment_batch(images) if self.augment else images, labels
-
-
-def augment_batch(images):
-    flip = np.random.random(len(images)) < 0.5
-    images[flip] = images[flip, :, ::-1, :]
-    brightness = np.random.uniform(0.9, 1.1, (len(images), 1, 1, 1))
-    return np.clip(images * brightness, 0.0, 1.0)
+        images = self.images[chunk]
+        if self.augment:
+            key = jax.random.fold_in(self.key, index)
+            keys = jax.random.split(key, len(images))
+            images = self.augment_images(keys, jp.asarray(images))
+        return np.asarray(images, "float32") / 255.0, self.labels[chunk]
 
 
 def load_arrays(data, split):

--- a/examples/probabilistic_keypoint_estimation/train.py
+++ b/examples/probabilistic_keypoint_estimation/train.py
@@ -5,6 +5,8 @@ os.environ["KERAS_BACKEND"] = "jax"
 import argparse
 
 import numpy as np
+import jax
+import jax.numpy as jp
 import keras
 
 import paz
@@ -12,28 +14,28 @@ import facial_keypoints
 
 
 class KeypointSequence(keras.utils.PyDataset):
-    def __init__(self, images, keypoints, batch_size, augment=False):
+    def __init__(self, images, keypoints, batch_size, augment=False, seed=0):
         super().__init__()
-        self.images = np.asarray(images, "float32") / 255.0
+        self.images = np.asarray(images, "uint8")
         self.keypoints = paz.gaussian_mixture.normalize_points(
             np.asarray(keypoints, "float32"), 96, 96)
         self.batch_size = batch_size
         self.augment = augment
+        self.key = jax.random.PRNGKey(seed)
+        self.augment_images = jax.jit(jax.vmap(paz.image.random_brightness))
 
     def __len__(self):
         return len(self.images) // self.batch_size
 
     def __getitem__(self, index):
         chunk = slice(index * self.batch_size, (index + 1) * self.batch_size)
-        images = self.images[chunk][..., None].copy()
+        images = self.images[chunk][..., None]
         if self.augment:
-            images = augment_batch(images)
+            key = jax.random.fold_in(self.key, index)
+            keys = jax.random.split(key, len(images))
+            images = self.augment_images(keys, jp.asarray(images))
+        images = np.asarray(images, "float32") / 255.0
         return images, np.asarray(self.keypoints[chunk])
-
-
-def augment_batch(images):
-    brightness = np.random.uniform(0.9, 1.1, (len(images), 1, 1, 1))
-    return np.clip(images * brightness, 0.0, 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cluster B of the post-#365 cleanup: stop hand-rolling numpy augmentation in the
example training sequences and reuse the existing key-based JAX backend
augmentation, applied as a jitted `vmap` over the batch.

## Change
- `emotion_classifier` and `imdb_classifier`: `random_flip_left_right` +
  `random_brightness` (a small module-level `augment_face`).
- `probabilistic_keypoint_estimation`: `random_brightness` only — flipping the
  image would invalidate the keypoint targets.

Each sequence now stores `uint8` images, augments on device
(`jax.jit(jax.vmap(...))`), and normalizes to `[0, 1]` at the end — replacing
the duplicated numpy `augment_batch`.

## Verification (CPU)
- All three compile; `pyflakes` clean.
- `imdb_classifier/train.py` runs end-to-end on synthetic arrays.

Remaining clusters (separate PRs): C (EfficientDet numpy postprocess → JAX),
D (`human_pose_estimators` cv2 affine → `paz.image.affine_transform`).