### PR TITLE
JAX-ify EfficientDet postprocess box transforms

### DIFF
--- a/paz/applications/detectors.py
+++ b/paz/applications/detectors.py
@@ -199,17 +199,15 @@ def scaled_resize(image, size):
 
 
 def change_box_coordinates(outputs):
-    outputs = np.asarray(outputs[0])
-    boxes, classes = outputs[:, :4], outputs[:, 4:]
-    s1, s2, s3, s4 = np.split(boxes, 4, axis=1)
-    boxes = np.concatenate([s2, s1, s4, s3], axis=1)
-    return np.concatenate([boxes, classes], axis=1)[np.newaxis]
+    boxes, classes = outputs[0][:, :4], outputs[0][:, 4:]
+    s1, s2, s3, s4 = jp.split(boxes, 4, axis=1)
+    boxes = jp.concatenate([s2, s1, s4, s3], axis=1)
+    return jp.concatenate([boxes, classes], axis=1)[jp.newaxis]
 
 
 def scale_boxes(detections, scale):
-    detections = np.asarray(detections)
     boxes = detections[:, :4] * scale
-    return np.concatenate([boxes, detections[:, 4:]], axis=1)
+    return jp.concatenate([boxes, detections[:, 4:]], axis=1)
 
 
 def DetectMiniXceptionFER(box_scale=1.2, draw=None):


### PR DESCRIPTION
Cluster C of the post-#365 cleanup: the EfficientDet COCO postprocess ran its
box transforms on the host with numpy, unlike the SSD path (whose decode +
per-class NMS are already JAX/jitted).

## Change
`paz/applications/detectors.py`: `change_box_coordinates` and `scale_boxes` now
use `jax.numpy` instead of `numpy`, so the postprocess stays on-device and
jit-friendly. `scaled_resize` keeps `cv2.resize` (legitimate resize I/O per the
guide).

## Verification (CPU)
- `EFFICIENTDETD0COCO` (v0.16 weights) on the dinner scene: 23 detections,
  classes person / dining table / cup / bowl / wine glass / refrigerator, top
  score 0.95 — behavior unchanged.
- lint + `pyflakes` clean.

Remaining: cluster D (`human_pose_estimators` cv2 affine →
`paz.image.affine_transform`).