### PR TITLE
Adopt paz.transformers.cache in Gemma4 KV-cache

### DIFF
--- a/examples/gemma4/inference.py
+++ b/examples/gemma4/inference.py
@@ -1,6 +1,8 @@
 from keras import Model, ops
 from keras.layers import Input
 
+from paz.models.transformers import cache as kv_cache
+
 from .layers.core import apply_tanh_soft_cap
 from .layers.decoder import cached_decoder_block
 from .layers.normalization import build_rms_norm
@@ -175,6 +177,6 @@ def build_cached_decoder_blocks(hidden, cache, index, config,
 def build_empty_cache(config, max_length, batch_size=1):
     num_kv_heads = config.num_key_value_heads
     cache_head_dim = build_cache_head_dim(config)
-    shape = (batch_size, config.num_layers, 2, max_length,
-             num_kv_heads, cache_head_dim)
-    return ops.zeros(shape, dtype=config.dtype)
+    args = (batch_size, config.num_layers, max_length, num_kv_heads,
+            cache_head_dim, config.dtype)
+    return kv_cache.build(*args)

--- a/examples/gemma4/layers/attention.py
+++ b/examples/gemma4/layers/attention.py
@@ -2,6 +2,7 @@ from keras import ops
 from keras.layers import Dropout, EinsumDense, Softmax
 
 from paz.layers import MergeDims, SplitDim
+from paz.models.transformers import cache as kv_cache
 from paz.models.transformers.embeddings import rotary
 
 from .core import apply_tanh_soft_cap
@@ -54,7 +55,7 @@ def cached_attend(x, cache, index, head_dim, num_query_heads, num_kv_heads,
         if head_dim < cache_head_dim:
             key = pad_to_cache_dim(key, cache_head_dim - head_dim)
             value = pad_to_cache_dim(value, cache_head_dim - head_dim)
-        updated_cache = update_kv_cache(cache, index, key, value, dtype)
+        updated_cache = kv_cache.update(cache, index, key, value)
         kv_src = updated_cache
     full_key, full_value = ops.split(kv_src, 2, axis=1)
     full_key = ops.squeeze(full_key, axis=1)
@@ -98,18 +99,6 @@ def query_positions(index, positions):
 def build_cache_positions(index, positions):
     transposed = ops.transpose(query_positions(index, positions))
     return ops.cast(transposed, "float32")
-
-
-def update_kv_cache(cache, index, key_update, value_update, dtype=None):
-    key_cache = cache[:, 0, ...]
-    value_cache = cache[:, 1, ...]
-    if dtype is not None:
-        key_cache = ops.cast(key_cache, dtype)
-        value_cache = ops.cast(value_cache, dtype)
-    start = [0, index, 0, 0]
-    key_cache = ops.slice_update(key_cache, start, key_update)
-    value_cache = ops.slice_update(value_cache, start, value_update)
-    return ops.stack((key_cache, value_cache), axis=1)
 
 
 def project_query(x, num_heads, head_dim, epsilon, dtype, name):


### PR DESCRIPTION
## What

Phase-1 PR 3 of the `paz.transformers` rollout (after #366 Whisper, #371
Gemma4 rotary/RMSNorm/logits). Gemma4's KV-cache now uses the shared
`paz.transformers.cache`:

- `build_empty_cache` delegates to `paz.transformers.cache.build` (identical
  6-D layout `(batch, num_layers, 2, max_length, num_kv_heads, head_dim)`).
- Cached attention's write uses `paz.transformers.cache.update` instead of a
  local `update_kv_cache`, which is removed.

## Why it's bit-for-bit

The shared `cache.update` stacks `(key, value)` and `slice_update`s at
`[0, 0, index, 0, 0]`; Gemma4's old code split `cache[:, 0]` / `cache[:, 1]`,
updated each at `[0, index, 0, 0]`, then re-stacked — same result. The old
`dtype` cast was a no-op: the cache is built as `config.dtype` and K/V are
already cast to `config.dtype` before the write, so it is dropped.

## Validation

- gemma4 oracle identical: `pytest examples/gemma4/{inference,decoding,multimodal_decoding,model,causal_lm}_test.py` → 21 passed.
- Whisper + toolkit unaffected: `pytest paz/models/transformers/ examples/speech_to_text/push_to_talk_test.py` → 26 passed.
- `KERAS_BACKEND=jax`, pyflakes clean, all lines <= 80.

## Phase-1 roadmap

- #366 toolkit core + Whisper — merged
- #371 Gemma4 rotary / RMSNorm / logits — merged
- **this PR** — Gemma4 KV-cache
- next: stateless decode helpers -> `paz.backend.standard`
- then: decode-loop unification onto `paz.transformers.search` (the larger one)
