### PR TITLE
Relocate stateless decode helpers to paz.backend.standard

### DIFF
--- a/examples/gemma4/multimodal_decoding.py
+++ b/examples/gemma4/multimodal_decoding.py
@@ -13,6 +13,8 @@ import jax.numpy as jp
 import numpy as np
 from keras import ops
 
+from paz import call_stateless, snapshot_variables
+
 from .inference import build_empty_cache
 from .sampling import sample_logits
 
@@ -146,22 +148,6 @@ def run_cached_generate(step_model, per_layer_step, vision_embeddings, config,
     return trim_to_stop(generated, stop_id)
 
 
-def snapshot_variables(model):
-    if model is None:
-        return None
-    train = [variable.value for variable in model.trainable_variables]
-    nontrain = [variable.value for variable in model.non_trainable_variables]
-    return train, nontrain
-
-
-def stateless_forward(model, variables, *inputs):
-    # Run the model from variables passed as inputs, so jax.jit treats the
-    # weights as arguments instead of constant-folding the multi-GB embedding
-    # tables into the compiled executable (which would exhaust host memory).
-    output, _ = model.stateless_call(variables[0], variables[1], *inputs)
-    return output
-
-
 def trim_to_stop(tokens, stop_id):
     if stop_id in tokens:
         tokens = tokens[:tokens.index(stop_id)]
@@ -202,13 +188,13 @@ def build_decode_step(step_model, embedding, per_layer_step, stop_id, select,
         buffer, token, index, cache, count, _, key = state
         token2d = jp.reshape(token, (1, 1))
         positions = jp.reshape(index, (1, 1)).astype("int32")
-        embeds = stateless_forward(embedding, embedding_vars, token2d)
+        embeds = call_stateless(embedding, embedding_vars, token2d)
         inputs = [embeds, cache, jp.reshape(index, (1,)).astype("int32"),
                   positions]
         if per_layer_vars is not None:
             inputs.append(
-                stateless_forward(per_layer_step, per_layer_vars, token2d))
-        logits, cache = stateless_forward(step_model, step_vars, inputs)
+                call_stateless(per_layer_step, per_layer_vars, token2d))
+        logits, cache = call_stateless(step_model, step_vars, inputs)
         key, step_key = jax.random.split(key)
         next_id = select(logits[:, 0, :], step_key)
         buffer = buffer.at[count].set(next_id)

--- a/paz/__init__.py
+++ b/paz/__init__.py
@@ -38,6 +38,8 @@ from paz.backend.standard import (
     to_jax,
     to_numpy,
     NamedTuple,
+    snapshot_variables,
+    call_stateless,
 )
 from paz import losses
 from paz.abstract import Model, Node, Input, Sequential, Tree

--- a/paz/backend/standard.py
+++ b/paz/backend/standard.py
@@ -59,6 +59,22 @@ def as_numpy_array(function):
     return wrapper
 
 
+def snapshot_variables(model):
+    if model is None:
+        return None
+    train = [variable.value for variable in model.trainable_variables]
+    nontrain = [variable.value for variable in model.non_trainable_variables]
+    return train, nontrain
+
+
+def call_stateless(model, variables, *inputs):
+    # Run a Keras model from variables passed as inputs so jax.jit treats the
+    # weights as arguments instead of constant-folding large tables into the
+    # compiled executable (which would exhaust host memory).
+    output, _ = model.stateless_call(variables[0], variables[1], *inputs)
+    return output
+
+
 def str_to_bool(value):
     if isinstance(value, bool):
         result = value


### PR DESCRIPTION
## What

Phase-1 PR 4 of the `paz.transformers` rollout. Move the stateless decode
helpers out of the Gemma4 example into the library:

- `snapshot_variables(model)` and `call_stateless(model, variables, *inputs)`
  (renamed from `stateless_forward`) now live in `paz.backend.standard`,
  re-exported as `paz.snapshot_variables` / `paz.call_stateless` alongside
  `lock`, `to_jax`, etc.
- Gemma4's `multimodal_decoding.py` imports them from `paz` instead of keeping
  local copies.

## Why

These are generic "run a Keras model statelessly under `jax.jit` with weights
passed as arguments (so large tables aren't constant-folded into the
executable)" plumbing — usable by any jitted model, not a transformer concept.
They don't import keras (they only call `model.stateless_call` /
`model.*_variables`), so they sit naturally next to the other
`paz.backend.standard` utilities.

## Validation

- gemma4 jitted decode unchanged: `pytest examples/gemma4/{multimodal_decoding,decoding,sampling}_test.py` → 15 passed.
- `import paz; paz.call_stateless` / `paz.snapshot_variables` resolve.
- `KERAS_BACKEND=jax`, lines <= 80, pyflakes clean on changed code.

## Phase-1 roadmap

- #366 toolkit core + Whisper — merged
- #371 Gemma4 rotary / RMSNorm / logits — merged
- #372 Gemma4 KV-cache — merged
- **this PR** — stateless decode helpers -> paz.backend.standard
- next (last of phase 1): decode-loop unification onto `paz.transformers.search`
  (the larger one; will be split or deferred if it risks gemma4's validated
  jitted generation).
