### PR TITLE
Adopt paz.transformers.search in Gemma4 text decoding

### DIFF
--- a/examples/gemma4/decoding.py
+++ b/examples/gemma4/decoding.py
@@ -2,25 +2,27 @@ import jax
 import jax.numpy as jp
 from keras import ops
 
+from paz.models.transformers import search
+
 from .inference import build_empty_cache
-from .sampling import sample_logits
 
 
-def kv_decode(
-    step_model, config, prompt_ids, stop_id, max_tokens, max_seq=4096
-):
+def kv_decode(step_model, config, prompt_ids, stop_id, max_tokens,
+              max_seq=4096):
     """Single-sequence jitted greedy decoding (text, no per-layer input)."""
-    return run_kv_decode(step_model, config, prompt_ids, stop_id, max_tokens,
-                         jax.random.PRNGKey(0), select_greedy, max_seq)
+    args = (step_model, config, prompt_ids, stop_id, max_tokens,
+            jax.random.PRNGKey(0), search.greedy, max_seq)
+    return run_kv_decode(*args)
 
 
-def kv_sample(
-    step_model, config, prompt_ids, stop_id, max_tokens, key, sampling,
-    max_seq=4096
-):
+def kv_sample(step_model, config, prompt_ids, stop_id, max_tokens, key,
+              sampling, max_seq=4096):
     """Single-sequence jitted sampling decoding seeded by `key`."""
-    return run_kv_decode(step_model, config, prompt_ids, stop_id, max_tokens,
-                         key, build_sampler(sampling), max_seq)
+    select = search.build_sampler(
+        sampling.temperature, sampling.top_k, sampling.top_p)
+    args = (step_model, config, prompt_ids, stop_id, max_tokens, key, select,
+            max_seq)
+    return run_kv_decode(*args)
 
 
 def run_kv_decode(step_model, config, prompt_ids, stop_id, max_tokens, key,
@@ -32,14 +34,6 @@ def run_kv_decode(step_model, config, prompt_ids, stop_id, max_tokens, key,
     return ops.convert_to_numpy(buffer[0, :length]).tolist()
 
 
-def select_greedy(logits, key):
-    return jp.argmax(logits, axis=-1).astype(jp.int32)
-
-
-def build_sampler(sampling):
-    return lambda logits, key: sample_logits(logits, key, sampling)
-
-
 def KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq=4096):
     max_len = min(max_seq, len(prompt_ids) + max_tokens)
     prompt = jp.array(prompt_ids, dtype=jp.int32)
@@ -49,19 +43,25 @@ def KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq=4096):
     def decode(self_cache, stop_id, key):
         buffer = jp.zeros((1, max_len), dtype=jp.int32)
         buffer = buffer.at[0, :prompt_len].set(prompt)
-        step = warmup_step(prompt, step_model)
         cache = self_cache
         if prompt_len > 1:
-            cache = jax.lax.fori_loop(0, prompt_len - 1, step, cache)
-        args = (buffer, prompt, prompt_len, cache, stop_id, key)
-        state = build_initial_state(*args)
-        cont = should_continue(max_tokens, max_len)
-        step_fn = build_next_state(step_model, stop_id, select)
-        buffer, _, index, _, _, _, _ = jax.lax.while_loop(cont, step_fn, state)
-        return buffer, index + 1
+            warmup = warmup_step(prompt, step_model)
+            cache = jax.lax.fori_loop(0, prompt_len - 1, warmup, cache)
+        step = build_step(step_model)
+        run = search.build(step, select, max_tokens, max_len)
+        token = jp.reshape(prompt[prompt_len - 1], (1, 1))
+        index = jp.array(prompt_len - 1, dtype=jp.int32)
+        return run(key, buffer, token, index, cache, stop_id)
 
     decode.max_decode_length = max_len
     return decode
+
+
+def build_step(step_model):
+    def step(cache, token, index, key):
+        return step_model(build_step_inputs(token, cache, index))
+
+    return step
 
 
 def warmup_step(prompt, step_model):
@@ -70,40 +70,7 @@ def warmup_step(prompt, step_model):
         inputs = build_step_inputs(token, cache, index)
         _, cache = step_model(inputs)
         return cache
-    return step
 
-
-def build_initial_state(buffer, prompt, prompt_len, cache, stop_id, key):
-    last_token = jp.reshape(prompt[prompt_len - 1], (1, 1))
-    index = jp.array(prompt_len - 1, dtype=jp.int32)
-    num_generated = jp.array(0, dtype=jp.int32)
-    finished = jp.array(False)
-    return (buffer, last_token, index, cache, num_generated, finished, key)
-
-
-def should_continue(max_gen, max_len):
-    def check(state):
-        _, _, index, _, num_generated, finished, _ = state
-        not_done = ~finished
-        under_gen = num_generated < max_gen
-        under_len = index + 1 < max_len
-        return not_done & under_gen & under_len
-    return check
-
-
-def build_next_state(step_model, stop_id, select):
-    def step(state):
-        buffer, token, index, cache, num_generated, _, key = state
-        inputs = build_step_inputs(token, cache, index)
-        logits, cache = step_model(inputs)
-        key, step_key = jax.random.split(key)
-        next_id = select(logits[:, 0, :], step_key)
-        next_index = index + 1
-        buffer = buffer.at[0, next_index].set(next_id[0])
-        token = jp.expand_dims(next_id, axis=-1)
-        finished = next_id[0] == stop_id
-        num_generated = num_generated + 1
-        return (buffer, token, next_index, cache, num_generated, finished, key)
     return step
 
 

--- a/examples/gemma4/decoding_test.py
+++ b/examples/gemma4/decoding_test.py
@@ -1,8 +1,9 @@
 import jax
 import jax.numpy as jp
 
-from .decoding import (KVDecoder, extract_generated_ids, kv_decode, kv_sample,
-                       select_greedy)
+from paz.models.transformers import search
+
+from .decoding import KVDecoder, extract_generated_ids, kv_decode, kv_sample
 from .inference import Gemma4DecoderStep, build_empty_cache
 from .model import build_text_backbone_args
 from .sampling import SamplingArgs
@@ -16,7 +17,7 @@ def test_kv_decoder_generates_tokens():
     config = build_test_config()
     step_model = Gemma4DecoderStep(config)
     prompt = [1, 2, 3]
-    decoder = KVDecoder(step_model, prompt, 5, select_greedy, 16)
+    decoder = KVDecoder(step_model, prompt, 5, search.greedy, 16)
     cache = jp.asarray(build_empty_cache(config, decoder.max_decode_length))
     stop_id = jp.array(config.vocabulary_size - 1, dtype=jp.int32)
     buffer, length = decoder(cache, stop_id, jax.random.PRNGKey(0))


### PR DESCRIPTION
## What

Final phase-1 PR of the `paz.transformers` rollout. Gemma4's **text** decode
loop now uses `paz.transformers.search`:

- `KVDecoder` drives `search.build(step, select, max_tokens, max_len)`; greedy
  is `search.greedy`, sampling is `search.build_sampler(...)`.
- Removes Gemma4's local while-loop, selectors, and state helpers
  (`select_greedy`, `build_sampler`, `build_initial_state`, `should_continue`,
  `build_next_state`). Net -32 lines.

This is the same adoption Whisper did in #366: a 2-D prompt-seeded buffer, a
`fori_loop` warmup, and a model-closure `step` — so it's structurally identical
and bit-for-bit.

## What stays model-side (deliberately)

The **multimodal** jitted loop (`multimodal_decoding.py`) keeps its own loop. It
threads weights as jit arguments (the stateless trick), folds in per-layer
embeddings, and uses a generated-only buffer with scalar tokens. Unifying it
onto `search` would force a leaky parameterization (buffer layout, token shape,
weights-as-args) that hurts readability more than the duplication costs — so it
stays as is. Future decoder-only LLMs use `search` directly (as Whisper and
Gemma4-text now do).

## Validation

- `pytest examples/gemma4/{decoding,multimodal_decoding,sampling,inference,model,causal_lm}_test.py paz/models/transformers/ examples/speech_to_text/push_to_talk_test.py` -> 52 passed.
- `KERAS_BACKEND=jax`, lines <= 80, pyflakes clean.

## Phase 1 complete

| PR | Scope | Status |
|----|-------|--------|
| #366 | toolkit core + Whisper | merged |
| #371 | Gemma4 rotary / RMSNorm / logits | merged |
| #372 | Gemma4 KV-cache | merged |
| #373 | stateless helpers -> paz.backend.standard | merged |
| this | Gemma4 text decoding -> paz.transformers.search | open |

Both models now share `paz.transformers` for cache, search/decoding, sampling,
masks, rotary, RMSNorm and the stateless helpers. Deferred to a later phase
(only one consumer today): `feedforward.glu` adoption in Gemma4, and moving
`reshape_query` / `attend` into the toolkit.
