### PR TITLE
Add paz.audio backend for WAV load and resampling

### DIFF
--- a/paz/__init__.py
+++ b/paz/__init__.py
@@ -2,6 +2,7 @@ from paz import datasets
 from paz.backend import draw
 from paz.backend import boxes
 from paz.backend import image
+from paz.backend import audio
 from paz.backend import classes
 from paz.backend import pinhole
 from paz.backend import mask

--- a/paz/backend/audio.py
+++ b/paz/backend/audio.py
@@ -1,0 +1,56 @@
+import warnings
+from math import gcd
+
+import numpy as np
+from scipy.io import wavfile
+from scipy.io.wavfile import WavFileWarning
+from scipy.signal import resample_poly
+
+
+def load(wav_path):
+    # SciPy warns on extra non-audio WAV chunks; keep loading the audio data.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", WavFileWarning)
+        sample_rate, waveform = wavfile.read(wav_path)
+    return waveform, sample_rate
+
+
+def to_float(waveform):
+    waveform = np.asarray(waveform)
+    if np.issubdtype(waveform.dtype, np.floating):
+        waveform = waveform.astype("float32")
+    elif np.issubdtype(waveform.dtype, np.signedinteger):
+        min_value = abs(np.iinfo(waveform.dtype).min)
+        max_value = np.iinfo(waveform.dtype).max
+        scale = max(min_value, max_value)
+        waveform = waveform.astype("float32") / float(scale)
+        waveform = np.clip(waveform, -1.0, 1.0)
+    elif np.issubdtype(waveform.dtype, np.unsignedinteger):
+        info = np.iinfo(waveform.dtype)
+        midpoint = (info.max + 1) / 2.0
+        waveform = waveform.astype("float32")
+        waveform = (waveform - midpoint) / midpoint
+        waveform = np.clip(waveform, -1.0, 1.0)
+    else:
+        raise ValueError("Unsupported WAV dtype: {}".format(waveform.dtype))
+    return waveform
+
+
+def to_mono(waveform):
+    if len(waveform.shape) == 2 and waveform.shape[1] == 1:
+        waveform = waveform[:, 0]
+    elif len(waveform.shape) == 2 and waveform.shape[1] == 2:
+        waveform = np.mean(waveform, axis=1)
+    elif len(waveform.shape) != 1:
+        raise ValueError("Expected WAV input of shape (N,), (N, 1), or (N, 2).")
+    return waveform
+
+
+def resample(waveform, sample_rate, expected_sample_rate):
+    if sample_rate != expected_sample_rate:
+        common_divisor = gcd(sample_rate, expected_sample_rate)
+        upsample = expected_sample_rate // common_divisor
+        downsample = sample_rate // common_divisor
+        waveform = resample_poly(waveform, upsample, downsample)
+    waveform = waveform.astype("float32")
+    return waveform

--- a/paz/backend/audio_test.py
+++ b/paz/backend/audio_test.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from paz.backend.audio import to_float, to_mono, resample
+
+
+def test_to_float_int16_full_scale():
+    waveform = np.array([-32768, 0, 32767], dtype="int16")
+    result = to_float(waveform)
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(result, [-1.0, 0.0, 1.0], atol=1e-4)
+
+
+def test_to_float_passes_through_floating():
+    waveform = np.array([-0.5, 0.0, 0.5], dtype="float64")
+    result = to_float(waveform)
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(result, [-0.5, 0.0, 0.5])
+
+
+def test_to_mono_averages_stereo():
+    waveform = np.array([[1.0, 3.0], [2.0, 4.0]], dtype="float32")
+    np.testing.assert_allclose(to_mono(waveform), [2.0, 3.0])
+
+
+def test_to_mono_keeps_single_channel():
+    waveform = np.arange(4, dtype="float32")
+    np.testing.assert_allclose(to_mono(waveform), waveform)
+
+
+def test_resample_changes_length_by_ratio():
+    waveform = np.zeros(16000, dtype="float32")
+    result = resample(waveform, 16000, 8000)
+    assert result.dtype == np.float32
+    assert result.shape[0] == 8000
+
+
+def test_resample_keeps_rate_when_equal():
+    waveform = np.linspace(-1.0, 1.0, 100, dtype="float32")
+    result = resample(waveform, 16000, 16000)
+    np.testing.assert_allclose(result, waveform)


### PR DESCRIPTION
## What

First PR of promoting the Whisper speech-to-text port into first-class paz.
Adds a small audio I/O backend so audio models can load and resample WAV data
through `paz.audio`, mirroring the `paz.image` convention.

- New `paz/backend/audio.py`: `load`, `to_float`, `to_mono`, `resample`
  (moved verbatim from `examples/speech_to_text/audio.py`).
- Surfaced as `paz.audio` in `paz/__init__.py` next to `paz.image`.
- `paz/backend/audio_test.py`: int16 full-scale normalization, float
  pass-through, stereo->mono averaging, and resample length/ratio.

## Why

There is no audio backend in paz today; audio I/O lives only inside the
speech_to_text example. Extracting it lets the upcoming Whisper foundation
model and application reuse it, and gives any future audio model a shared,
paz-consistent entry point.

## Validation

- `pytest paz/backend/audio_test.py` -> 6 passed (KERAS_BACKEND=jax).
- `import paz; paz.audio.load` / `paz.audio.resample` resolve.
- pyflakes clean.

## Roadmap (3 PRs)

- **this PR** — `paz.audio` backend
- next — Whisper foundation model under `paz/models/foundation/whisper/`
  (layers, builders, decoding, tokenizer) with detector-style weight loading
- last — `paz.applications.TranscribeWhisper` + rewire the example onto paz
