### PR TITLE
Lift tanh soft-cap and sliding-window mask into paz.transformers

### DIFF
--- a/examples/gemma4/causal_lm.py
+++ b/examples/gemma4/causal_lm.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 from keras import Model
 
-from .layers.core import apply_tanh_soft_cap
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
+
 from .model import build_text_backbone
 
 
@@ -12,7 +13,7 @@ def Gemma4CausalLM(config, weights_path=None, name="gemma4_causal_lm"):
     hidden = backbone(inputs)
     embedding = backbone.get_layer("token_embedding")
     logits = embedding(hidden, reverse=True)
-    logits = apply_tanh_soft_cap(logits, config.final_logit_soft_cap)
+    logits = apply_soft_cap(logits, config.final_logit_soft_cap)
     model = Model(inputs, logits, name=name)
     if weights_path is not None:
         model.load_weights(str(Path(weights_path)))

--- a/examples/gemma4/inference.py
+++ b/examples/gemma4/inference.py
@@ -3,7 +3,8 @@ from keras.layers import Input
 
 from paz.models.transformers import cache as kv_cache
 
-from .layers.core import apply_tanh_soft_cap
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
+
 from .layers.decoder import cached_decoder_block
 from .layers.normalization import build_rms_norm
 from .model import (build_cache_head_dim,
@@ -120,7 +121,7 @@ def build_cached_step(hidden, embedding, cache, cache_index, per_layer, config,
                  "final_normalization")
     hidden = build_rms_norm(*norm_args)(hidden)
     logits = embedding(hidden, reverse=True)
-    logits = apply_tanh_soft_cap(logits, config.final_logit_soft_cap)
+    logits = apply_soft_cap(logits, config.final_logit_soft_cap)
     return logits, updated_cache
 
 

--- a/examples/gemma4/layers/attention.py
+++ b/examples/gemma4/layers/attention.py
@@ -3,9 +3,10 @@ from keras.layers import Dropout, EinsumDense, Softmax
 
 from paz.layers import MergeDims, SplitDim
 from paz.models.transformers import cache as kv_cache
+from paz.models.transformers import mask as attention_mask
 from paz.models.transformers.embeddings import rotary
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
 
-from .core import apply_tanh_soft_cap
 from .normalization import build_rms_norm, build_v_norm
 
 
@@ -83,9 +84,9 @@ def build_cache_mask(full_key, index, positions, window):
     ones = ops.ones_like(full_key[:, :, 0, 0], dtype="int32")
     key_pos = ops.cumsum(ones, axis=1) - 1
     query_pos = query_positions(index, positions)
-    mask = ops.less_equal(key_pos[:, None, :], query_pos[:, :, None])
+    mask = attention_mask.causal(query_pos, key_pos)
     if window is not None:
-        recent = ops.less(query_pos[:, :, None] - key_pos[:, None, :], window)
+        recent = attention_mask.sliding_window(query_pos, key_pos, window)
         mask = ops.logical_and(mask, recent)
     return ops.cast(mask, "bool")
 
@@ -132,7 +133,7 @@ def compute_attention(query, key, value, mask, num_query_heads, num_kv_heads,
                       head_dim, soft_cap, dropout, dtype, name):
     query = reshape_query(query, num_query_heads, num_kv_heads, head_dim)
     logits = ops.einsum("btkgh,bskh->bkgts", query, key)
-    logits = apply_tanh_soft_cap(logits, soft_cap)
+    logits = apply_soft_cap(logits, soft_cap)
     if mask is not None:
         mask = mask[:, None, None, :, :]
     softmax = Softmax(dtype="float32", name="{}_softmax".format(name))

--- a/examples/gemma4/layers/core.py
+++ b/examples/gemma4/layers/core.py
@@ -1,6 +1,8 @@
 import keras
 from keras import ops
 
+from paz.models.transformers import mask
+
 
 def build_attention_mask(padding_mask, bidirectional, sliding_window_size):
     if padding_mask is None:
@@ -8,11 +10,10 @@ def build_attention_mask(padding_mask, bidirectional, sliding_window_size):
     if bidirectional:
         return build_bidirectional_mask(padding_mask)
     positions = build_positions(padding_mask)
-    causal_mask = compute_causal_mask(positions)
+    causal_mask = mask.causal(positions, positions)
     if sliding_window_size is not None:
-        args = (positions, sliding_window_size)
-        window_mask = compute_sliding_window_mask(*args)
-        causal_mask = ops.logical_and(causal_mask, window_mask)
+        window = mask.sliding_window(positions, positions, sliding_window_size)
+        causal_mask = ops.logical_and(causal_mask, window)
     decoder_mask = merge_padding_mask(padding_mask)
     return ops.logical_and(causal_mask, decoder_mask)
 
@@ -20,19 +21,6 @@ def build_attention_mask(padding_mask, bidirectional, sliding_window_size):
 def build_positions(padding_mask):
     ones = ops.ones_like(padding_mask, dtype="int32")
     return ops.cumsum(ones, axis=1) - 1
-
-
-def compute_causal_mask(positions):
-    out_pos = ops.expand_dims(positions, axis=2)
-    in_pos = ops.expand_dims(positions, axis=1)
-    return ops.greater_equal(out_pos, in_pos)
-
-
-def compute_sliding_window_mask(positions, window_size):
-    out_pos = ops.expand_dims(positions, axis=2)
-    in_pos = ops.expand_dims(positions, axis=1)
-    distance = out_pos - in_pos
-    return ops.less(distance, window_size)
 
 
 def build_bidirectional_mask(padding_mask):
@@ -47,14 +35,6 @@ def merge_padding_mask(padding_mask):
         return None
     mask = ops.cast(padding_mask, "bool")
     return ops.expand_dims(mask, axis=1)
-
-
-def apply_tanh_soft_cap(values, soft_cap):
-    if soft_cap is None:
-        return values
-    values = ops.divide(values, soft_cap)
-    values = ops.tanh(values)
-    return ops.multiply(values, soft_cap)
 
 
 def clip_float16(values):

--- a/examples/gemma4/multimodal_decoding_test.py
+++ b/examples/gemma4/multimodal_decoding_test.py
@@ -6,7 +6,7 @@ import numpy as np
 import keras
 from keras import Model
 
-from .layers.core import apply_tanh_soft_cap
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
 from .model import build_text_backbone_args
 from .vision import build_vision_encoder, build_vision_encoder_args, num_patches
 import jax
@@ -38,7 +38,7 @@ def transfer(source, target):
 def build_full_sequence_causal_lm():
     backbone = build_multimodal_backbone(TEXT, VISION)
     embedding = backbone.get_layer("token_embedding")
-    logits = apply_tanh_soft_cap(
+    logits = apply_soft_cap(
         embedding(backbone.output, reverse=True), TEXT.final_logit_soft_cap)
     return Model(backbone.input, logits), backbone
 

--- a/paz/models/transformers/logits.py
+++ b/paz/models/transformers/logits.py
@@ -1,9 +1,19 @@
-"""Logit-shaping transforms over (batch, vocabulary) for sampling.
+"""Logit-shaping transforms.
 
-top_k <= 0 disables top-k; top_p >= 1 disables nucleus truncation.
+The sampling transforms run over (batch, vocabulary): top_k <= 0 disables
+top-k; top_p >= 1 disables nucleus truncation. ``soft_cap`` is an in-graph
+tanh cap on attention or output logits and uses ``keras.ops`` so it composes
+with symbolic Keras tensors.
 """
 import jax
 import jax.numpy as jp
+from keras import ops
+
+
+def soft_cap(values, cap):
+    if cap is None:
+        return values
+    return ops.multiply(ops.tanh(ops.divide(values, cap)), cap)
 
 
 def apply_temperature(logits, temperature):

--- a/paz/models/transformers/logits_test.py
+++ b/paz/models/transformers/logits_test.py
@@ -8,6 +8,25 @@ import jax.numpy as jp
 from paz.models.transformers import logits
 
 
+def test_soft_cap_none_is_identity():
+    values = jp.array([[1.0, -2.0, 30.0]])
+    out = np.asarray(logits.soft_cap(values, None))
+    assert np.allclose(out, [[1.0, -2.0, 30.0]])
+
+
+def test_soft_cap_matches_scaled_tanh():
+    values = jp.array([[0.0, 5.0, -5.0]])
+    out = np.asarray(logits.soft_cap(values, 10.0))
+    expected = 10.0 * np.tanh(np.array([0.0, 5.0, -5.0]) / 10.0)
+    assert np.allclose(out, expected)
+
+
+def test_soft_cap_saturates_at_cap():
+    values = jp.array([[1e6, -1e6]])
+    out = np.asarray(logits.soft_cap(values, 30.0))
+    assert np.allclose(out, [[30.0, -30.0]], atol=1e-3)
+
+
 def test_apply_temperature_scales():
     values = jp.array([[2.0, 4.0]])
     out = np.asarray(logits.apply_temperature(values, 2.0))

--- a/paz/models/transformers/mask.py
+++ b/paz/models/transformers/mask.py
@@ -6,3 +6,9 @@ def causal(query_positions, key_positions):
     query = ops.expand_dims(query_positions, axis=-1)
     key = ops.expand_dims(key_positions, axis=-2)
     return ops.less_equal(key, query)
+
+
+def sliding_window(query_positions, key_positions, window_size):
+    query = ops.expand_dims(query_positions, axis=-1)
+    key = ops.expand_dims(key_positions, axis=-2)
+    return ops.less(query - key, window_size)

--- a/paz/models/transformers/mask_test.py
+++ b/paz/models/transformers/mask_test.py
@@ -21,3 +21,22 @@ def test_causal_full_grid_is_lower_triangular():
     assert out[0].tolist() == [[True, False, False],
                                [True, True, False],
                                [True, True, True]]
+
+
+def test_sliding_window_keeps_recent_keys():
+    positions = np.array([[0, 1, 2, 3]], dtype="int32")
+    out = np.asarray(mask.sliding_window(positions, positions, 2)).astype(bool)
+    # A key is kept when query - key < window. Future keys (negative distance)
+    # pass too; the window mask is meant to be combined with the causal mask.
+    assert out[0].tolist() == [[True, True, True, True],
+                               [True, True, True, True],
+                               [False, True, True, True],
+                               [False, False, True, True]]
+
+
+def test_sliding_window_combines_with_causal():
+    positions = np.array([[0, 1, 2, 3]], dtype="int32")
+    causal = np.asarray(mask.causal(positions, positions)).astype(bool)
+    window = np.asarray(mask.sliding_window(positions, positions, 2))
+    combined = np.logical_and(causal, window.astype(bool))
+    assert combined[0, 3].tolist() == [False, False, True, True]


### PR DESCRIPTION
First PR of the Gemma4 promotion series (foundation model + application),
applying the reuse-first lesson from the Whisper series: anything a future
model can reuse is abstracted up into `paz.transformers` rather than left in
the model package.

## What changed
- `paz.transformers.logits.soft_cap(values, cap)` — generic tanh logit
  soft-cap (no-op when `cap is None`), in `keras.ops` so it composes with
  symbolic Keras tensors. Used on attention logits and output logits.
- `paz.transformers.mask.sliding_window(query_positions, key_positions,
  window_size)` — windowed predicate mirroring the existing `mask.causal`,
  meant to be ANDed with the causal mask.
- Gemma4 (still under `examples/`) now consumes both shared primitives in
  place of its local `apply_tanh_soft_cap` and `compute_causal_mask` /
  `compute_sliding_window_mask` helpers.

## Behavior
Unchanged — the lifts are pure functions with identical math. Layer names and
weights are untouched.

## Tests (KERAS_BACKEND=jax, XLA_PYTHON_CLIENT_PREALLOCATE=false)
- `pytest paz/models/transformers/` — green (new `soft_cap` + `sliding_window`
  tests included).
- Gemma4 small-model forward passes exercising the rewired mask/soft-cap
  paths (`model_test`, `inference_test`, `causal_lm_test`, `decoding_test`,
  `multimodal_test`, `multimodal_decoding_test`, `sampling_test`,
  `vision_test`) — all green.