### PR TITLE
Add Gemma4 as a first-class paz foundation model

### DIFF
--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -34,4 +34,4 @@ from .foundation.dinov3.models.vision_transformer import DINOV3VITS
 from .foundation.dinov3.models.vision_transformer import DINOV3VITB
 from .foundation.dinov3.models.vision_transformer import DINOV3VITL
 from .foundation.whisper.model import Whisper
-from .foundation.gemma4.model import Gemma4
+from .foundation.gemma4.pretrained import Gemma4

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -34,3 +34,4 @@ from .foundation.dinov3.models.vision_transformer import DINOV3VITS
 from .foundation.dinov3.models.vision_transformer import DINOV3VITB
 from .foundation.dinov3.models.vision_transformer import DINOV3VITL
 from .foundation.whisper.model import Whisper
+from .foundation.gemma4.model import Gemma4

--- a/paz/models/foundation/gemma4/causal_lm.py
+++ b/paz/models/foundation/gemma4/causal_lm.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from keras import Model
+
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
+
+from paz.models.foundation.gemma4.model import build_text_backbone
+
+
+def Gemma4CausalLM(config, weights_path=None, name="gemma4_causal_lm"):
+    backbone = build_text_backbone(config)
+    inputs = backbone.input
+    hidden = backbone(inputs)
+    embedding = backbone.get_layer("token_embedding")
+    logits = embedding(hidden, reverse=True)
+    logits = apply_soft_cap(logits, config.final_logit_soft_cap)
+    model = Model(inputs, logits, name=name)
+    if weights_path is not None:
+        model.load_weights(str(Path(weights_path)))
+    return model

--- a/paz/models/foundation/gemma4/causal_lm_test.py
+++ b/paz/models/foundation/gemma4/causal_lm_test.py
@@ -1,0 +1,48 @@
+import jax.numpy as jp
+
+from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
+from paz.models.foundation.gemma4.model import build_text_backbone_args
+
+
+def build_test_inputs():
+    token_ids = jp.array([[1, 2, 3, 4, 0]], dtype=jp.int32)
+    padding_mask = jp.array([[1, 1, 1, 1, 0]], dtype=jp.int32)
+    return {"token_ids": token_ids, "padding_mask": padding_mask}
+
+
+def assert_close(left, right, tol=1e-6):
+    diff = jp.max(jp.abs(left - right))
+    assert float(diff) <= tol
+
+
+def test_causal_lm_output_shape():
+    config = build_text_backbone_args()
+    model = Gemma4CausalLM(config)
+    logits = model(build_test_inputs())
+    assert logits.shape == (1, 5, config.vocabulary_size)
+
+
+def test_causal_lm_logits_are_raw_scores():
+    config = build_text_backbone_args()
+    model = Gemma4CausalLM(config)
+    logits = model(build_test_inputs())
+    total = float(jp.sum(jp.exp(logits[0, 0, :])))
+    assert abs(total - 1.0) > 0.1
+
+
+def test_causal_lm_soft_cap():
+    config = build_text_backbone_args(final_logit_soft_cap=30.0)
+    model = Gemma4CausalLM(config)
+    logits = model(build_test_inputs())
+    assert bool(jp.all(jp.abs(logits) < 30.0))
+
+
+def test_causal_lm_save_and_load(tmp_path):
+    config = build_text_backbone_args()
+    model = Gemma4CausalLM(config)
+    inputs = build_test_inputs()
+    output = model(inputs)
+    path = tmp_path / "causal_lm.weights.h5"
+    model.save_weights(str(path))
+    loaded = Gemma4CausalLM(config, weights_path=path)
+    assert_close(output, loaded(inputs))

--- a/paz/models/foundation/gemma4/configuration.py
+++ b/paz/models/foundation/gemma4/configuration.py
@@ -1,6 +1,20 @@
 import json
+from collections import namedtuple
 
-from paz.models.foundation.gemma4.model import TextBackboneArgs
+TEXT_BACKBONE_FIELDS = (
+    "vocabulary_size image_size num_layers num_query_heads "
+    "num_key_value_heads hidden_dim intermediate_dim head_dim "
+    "attention_logit_soft_cap final_logit_soft_cap "
+    "use_sliding_window_attention sliding_window_size "
+    "sliding_window_pattern global_head_dim "
+    "local_rope_wavelength global_rope_wavelength "
+    "local_rope_scaling_factor global_rope_scaling_factor "
+    "global_rope_partial_rotary_factor "
+    "use_bidirectional_attention layer_norm_epsilon dropout dtype "
+    "hidden_size_per_layer_input num_kv_shared_layers global_layer_indices "
+    "use_double_wide_mlp"
+)
+TextBackboneArgs = namedtuple("TextBackboneArgs", TEXT_BACKBONE_FIELDS)
 
 CONFIGS = {
     "gemma4_2b": {
@@ -95,3 +109,91 @@ def build_global_indices(values):
     if indices is None:
         return None
     return tuple(indices)
+
+
+def build_cache_head_dim(config):
+    if config.global_head_dim is not None:
+        return config.global_head_dim
+    return config.head_dim
+
+
+def is_global_attention_layer(config, layer_index):
+    if config.global_layer_indices is not None:
+        return layer_index in config.global_layer_indices
+    pattern_index = layer_index % config.sliding_window_pattern
+    return pattern_index == config.sliding_window_pattern - 1
+
+
+def is_kv_shared_layer(config, layer_index):
+    if not config.num_kv_shared_layers:
+        return False
+    return layer_index >= config.num_layers - config.num_kv_shared_layers
+
+
+def layer_attention_type(config, layer_index):
+    if is_global_attention_layer(config, layer_index):
+        return "global"
+    return "local"
+
+
+def build_kv_source_map(config):
+    """Map each kv_shared layer to the most recent layer of the same type.
+
+    Returns a dict {layer_index: source_index} for kv_shared layers only,
+    mirroring the keras-hub backbone precomputation of _kv_source.
+    """
+    num_shared = config.num_kv_shared_layers
+    if not num_shared:
+        return {}
+    first_shared = config.num_layers - num_shared
+    non_shared_types = []
+    for layer_index in range(first_shared):
+        non_shared_types.append(layer_attention_type(config, layer_index))
+    kv_source = {}
+    for layer_index in range(first_shared, config.num_layers):
+        layer_type = layer_attention_type(config, layer_index)
+        source_index = last_matching_layer(non_shared_types, layer_type)
+        if source_index is not None:
+            kv_source[layer_index] = source_index
+    return kv_source
+
+
+def last_matching_layer(layer_types, layer_type):
+    for source_index in range(len(layer_types) - 1, -1, -1):
+        if layer_types[source_index] == layer_type:
+            return source_index
+    return None
+
+
+def build_feedforward_dim(config, layer_index):
+    if config.use_double_wide_mlp and is_kv_shared_layer(config, layer_index):
+        return config.intermediate_dim * 2
+    return config.intermediate_dim
+
+
+def build_head_dim(config, is_global):
+    if is_global and config.global_head_dim is not None:
+        return config.global_head_dim
+    return config.head_dim
+
+
+def use_sliding_window(config, is_global):
+    return config.use_sliding_window_attention and not is_global
+
+
+def build_rope_wavelength(config, is_global):
+    if is_global:
+        return config.global_rope_wavelength
+    return config.local_rope_wavelength
+
+
+def build_rope_scaling_factor(config, is_global):
+    if is_global:
+        return config.global_rope_scaling_factor
+    return config.local_rope_scaling_factor
+
+
+def build_partial_rotary_factor(config, is_global):
+    if is_global:
+        return config.global_rope_partial_rotary_factor
+    return 1.0

--- a/paz/models/foundation/gemma4/configuration.py
+++ b/paz/models/foundation/gemma4/configuration.py
@@ -1,0 +1,97 @@
+import json
+
+from paz.models.foundation.gemma4.model import TextBackboneArgs
+
+CONFIGS = {
+    "gemma4_2b": {
+        "vocabulary_size": 262_144,
+        "image_size": 896,
+        "num_layers": 35,
+        "num_query_heads": 8,
+        "num_key_value_heads": 1,
+        "hidden_dim": 1536,
+        "intermediate_dim": 6144,
+        "head_dim": 256,
+        "attention_logit_soft_cap": None,
+        "final_logit_soft_cap": 30.0,
+        "use_sliding_window_attention": True,
+        "sliding_window_size": 512,
+        "sliding_window_pattern": 5,
+        "global_head_dim": 512,
+        "local_rope_wavelength": 10_000.0,
+        "global_rope_wavelength": 1_000_000.0,
+        "local_rope_scaling_factor": 1.0,
+        "global_rope_scaling_factor": 1.0,
+        "global_rope_partial_rotary_factor": 0.25,
+        "use_bidirectional_attention": False,
+        "layer_norm_epsilon": 1e-6,
+        "dropout": 0.0,
+        "dtype": "bfloat16",
+        "hidden_size_per_layer_input": 256,
+        "num_kv_shared_layers": 20,
+        "global_layer_indices": None,
+        "use_double_wide_mlp": True,
+    },
+    "gemma4_4b": {
+        "vocabulary_size": 262_144,
+        "image_size": 896,
+        "num_layers": 42,
+        "num_query_heads": 8,
+        "num_key_value_heads": 2,
+        "hidden_dim": 2560,
+        "intermediate_dim": 10240,
+        "head_dim": 256,
+        "attention_logit_soft_cap": None,
+        "final_logit_soft_cap": 30.0,
+        "use_sliding_window_attention": True,
+        "sliding_window_size": 512,
+        "sliding_window_pattern": 6,
+        "global_head_dim": 512,
+        "local_rope_wavelength": 10_000.0,
+        "global_rope_wavelength": 1_000_000.0,
+        "local_rope_scaling_factor": 1.0,
+        "global_rope_scaling_factor": 1.0,
+        "global_rope_partial_rotary_factor": 0.25,
+        "use_bidirectional_attention": False,
+        "layer_norm_epsilon": 1e-6,
+        "dropout": 0.0,
+        "dtype": "bfloat16",
+        "hidden_size_per_layer_input": 256,
+        "num_kv_shared_layers": 18,
+        "global_layer_indices": None,
+        "use_double_wide_mlp": False,
+    },
+}
+
+# Defaults for fields added after some configs were serialized, so older
+# config.json files still load.
+LEGACY_DEFAULTS = {
+    "local_rope_wavelength": 10_000.0,
+    "global_rope_wavelength": 1_000_000.0,
+    # Only the E2B config predates this field, and E2B uses double-wide MLPs.
+    "use_double_wide_mlp": True,
+}
+
+
+def to_backbone_args(model_name):
+    return TextBackboneArgs(**CONFIGS[model_name])
+
+
+def save_config(config, path):
+    with open(str(path), "w", encoding="utf-8") as file:
+        json.dump(config._asdict(), file, indent=2)
+
+
+def load_config(path):
+    with open(str(path), encoding="utf-8") as file:
+        values = json.load(file)
+    values = {**LEGACY_DEFAULTS, **values}
+    values["global_layer_indices"] = build_global_indices(values)
+    return TextBackboneArgs(**values)
+
+
+def build_global_indices(values):
+    indices = values.get("global_layer_indices")
+    if indices is None:
+        return None
+    return tuple(indices)

--- a/paz/models/foundation/gemma4/conftest.py
+++ b/paz/models/foundation/gemma4/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"

--- a/paz/models/foundation/gemma4/conversion.py
+++ b/paz/models/foundation/gemma4/conversion.py
@@ -1,0 +1,130 @@
+"""Convert a keras_hub Gemma4 text backbone into paz weight files.
+
+Run this with keras_hub's Gemma4 available (keras>=3.13 and the keras-hub
+source on PYTHONPATH); the paz runtime itself does not need keras_hub Gemma4.
+It writes the split inference artifacts that demo_e2b.py loads: config.json,
+decoder_step.weights.h5 and embedding_step.weights.h5.
+"""
+import argparse
+import gc
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from keras import ops
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from paz.models.foundation.gemma4.configuration import save_config
+from paz.models.foundation.gemma4.inference import (
+    Gemma4DecoderStep, Gemma4PerLayerEmbeddingStep)
+from paz.models.foundation.gemma4.model import TextBackboneArgs
+
+ROLE_SYNONYMS = {
+    "per_layer_token_embedding": "per_layer_embeddings",
+    "per_layer_input_gate": "per_layer_gate",
+    "per_layer_up_proj": "per_layer_projection",
+    "post_per_layer_input_norm": "post_per_layer_norm",
+}
+
+
+def convert(preset, output_dir):
+    from keras_hub.src.models.gemma4.gemma4_backbone import Gemma4Backbone
+    # Gemma4 checkpoints are natively bfloat16; loading as bf16 is lossless and
+    # halves peak host memory versus the float32 default, so the larger E4B
+    # backbone plus the paz target both fit on a 31 GB host.
+    backbone = Gemma4Backbone.from_preset(preset, dtype="bfloat16")
+    return save_paz_models(backbone, output_dir)
+
+
+def save_paz_models(backbone, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config = build_paz_config(backbone)
+    save_config(config, output_dir / "config.json")
+    decoder_step = Gemma4DecoderStep(config)
+    transfer(backbone, decoder_step)
+    decoder_step.save_weights(str(output_dir / "decoder_step.weights.h5"))
+    del decoder_step
+    gc.collect()
+    embedding_step = Gemma4PerLayerEmbeddingStep(config)
+    transfer(backbone, embedding_step)
+    embedding_step.save_weights(str(output_dir / "embedding_step.weights.h5"))
+    return config
+
+
+def transfer(source, target):
+    # Map roles to source variables by reference (no bulk numpy copy), then
+    # convert one weight at a time so peak memory stays near a single tensor.
+    sources = {role(w.path): w for w in source.weights}
+    for variable in target.weights:
+        key = role(variable.path)
+        if key not in sources:
+            raise KeyError("no source weight for {}".format(variable.path))
+        variable.assign(to_numpy(sources[key]).reshape(variable.shape))
+
+
+def role(path):
+    match = re.search(r"decoder_block_(\d+)", path)
+    if match:
+        rest = path[match.end():].lstrip("/_").replace("/", "_")
+        if "layer_scalar" in rest:
+            rest = "layer_scalar"
+        return "b{}:{}".format(int(match.group(1)), canonical(rest))
+    return "g:" + canonical(path.replace("/", "_"))
+
+
+def canonical(name):
+    for source_name, target_name in ROLE_SYNONYMS.items():
+        name = name.replace(source_name, target_name)
+    return name
+
+
+def to_numpy(variable):
+    return np.asarray(ops.convert_to_numpy(variable))
+
+
+def build_paz_config(backbone):
+    config = backbone.get_config()
+    return TextBackboneArgs(**read_text_config(config))
+
+
+def read_text_config(config):
+    keys = (
+        "vocabulary_size image_size num_layers num_query_heads "
+        "num_key_value_heads hidden_dim intermediate_dim head_dim "
+        "attention_logit_soft_cap final_logit_soft_cap "
+        "use_sliding_window_attention sliding_window_size "
+        "sliding_window_pattern global_head_dim "
+        "local_rope_scaling_factor global_rope_scaling_factor "
+        "global_rope_partial_rotary_factor use_bidirectional_attention "
+        "layer_norm_epsilon dropout hidden_size_per_layer_input "
+        "num_kv_shared_layers use_double_wide_mlp"
+    ).split()
+    values = {key: config[key] for key in keys}
+    values["dtype"] = extract_dtype(config)
+    values["local_rope_wavelength"] = config.get("local_rope_wavelength") \
+        or 10_000.0
+    values["global_rope_wavelength"] = config.get("global_rope_wavelength") \
+        or 1_000_000.0
+    values["global_layer_indices"] = None
+    return values
+
+
+def extract_dtype(config):
+    dtype = config.get("dtype", "float32")
+    if isinstance(dtype, dict):
+        return dtype.get("config", {}).get("name", "float32")
+    return dtype
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Convert keras_hub Gemma4 to paz")
+    add = parser.add_argument
+    add("--preset", required=True)
+    add("--output_dir", required=True)
+    args = parser.parse_args()
+    convert(args.preset, args.output_dir)

--- a/paz/models/foundation/gemma4/conversion.py
+++ b/paz/models/foundation/gemma4/conversion.py
@@ -21,7 +21,7 @@ if str(ROOT) not in sys.path:
 from paz.models.foundation.gemma4.configuration import save_config
 from paz.models.foundation.gemma4.inference import (
     Gemma4DecoderStep, Gemma4PerLayerEmbeddingStep)
-from paz.models.foundation.gemma4.model import TextBackboneArgs
+from paz.models.foundation.gemma4.configuration import TextBackboneArgs
 
 ROLE_SYNONYMS = {
     "per_layer_token_embedding": "per_layer_embeddings",

--- a/paz/models/foundation/gemma4/conversion_test.py
+++ b/paz/models/foundation/gemma4/conversion_test.py
@@ -1,0 +1,61 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import pytest
+
+from paz.models.foundation.gemma4.configuration import load_config
+from paz.models.foundation.gemma4.conversion import (
+    build_paz_config, save_paz_models, transfer)
+from paz.models.foundation.gemma4.inference import (
+    Gemma4DecoderStep, Gemma4PerLayerEmbeddingStep)
+from paz.models.foundation.gemma4.model import build_text_backbone
+
+gemma4 = pytest.importorskip(
+    "keras_hub.src.models.gemma4.gemma4_backbone")
+Gemma4Backbone = gemma4.Gemma4Backbone
+
+
+def build_reference():
+    return Gemma4Backbone(
+        vocabulary_size=64, image_size=16, num_layers=6, num_query_heads=2,
+        num_key_value_heads=1, hidden_dim=16, intermediate_dim=32,
+        head_dim=16, use_sliding_window_attention=True, sliding_window_size=4,
+        sliding_window_pattern=3, global_head_dim=None,
+        hidden_size_per_layer_input=2, num_kv_shared_layers=2,
+        global_rope_partial_rotary_factor=0.25, use_double_wide_mlp=True,
+        dtype="float32")
+
+
+def build_inputs():
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(1, 64, (2, 7)).astype("int32")
+    padding = np.ones((2, 7), dtype="int32")
+    padding[0, 6] = 0
+    positions = np.broadcast_to(np.arange(7, dtype="int32"), (2, 7)).copy()
+    return tokens, padding, positions
+
+
+def test_transfer_matches_keras_hub():
+    backbone = build_reference()
+    config = build_paz_config(backbone)
+    model = build_text_backbone(config)
+    transfer(backbone, model)
+    tokens, padding, positions = build_inputs()
+    reference = backbone(
+        {"token_ids": tokens, "padding_mask": padding,
+         "position_ids": positions})
+    output = model({"token_ids": tokens, "padding_mask": padding})
+    diff = float(np.max(np.abs(np.array(reference) - np.array(output))))
+    assert diff < 1e-4
+
+
+def test_converter_writes_loadable_artifacts(tmp_path):
+    backbone = build_reference()
+    save_paz_models(backbone, tmp_path)
+    config = load_config(tmp_path / "config.json")
+    Gemma4DecoderStep(config).load_weights(
+        str(tmp_path / "decoder_step.weights.h5"))
+    Gemma4PerLayerEmbeddingStep(config).load_weights(
+        str(tmp_path / "embedding_step.weights.h5"))

--- a/paz/models/foundation/gemma4/decoding.py
+++ b/paz/models/foundation/gemma4/decoding.py
@@ -1,0 +1,86 @@
+import jax
+import jax.numpy as jp
+from keras import ops
+
+from paz.models.transformers import search
+
+from paz.models.foundation.gemma4.inference import build_empty_cache
+
+
+def kv_decode(step_model, config, prompt_ids, stop_id, max_tokens,
+              max_seq=4096):
+    """Single-sequence jitted greedy decoding (text, no per-layer input)."""
+    args = (step_model, config, prompt_ids, stop_id, max_tokens,
+            jax.random.PRNGKey(0), search.greedy, max_seq)
+    return run_kv_decode(*args)
+
+
+def kv_sample(step_model, config, prompt_ids, stop_id, max_tokens, key,
+              sampling, max_seq=4096):
+    """Single-sequence jitted sampling decoding seeded by `key`."""
+    select = search.build_sampler(
+        sampling.temperature, sampling.top_k, sampling.top_p)
+    args = (step_model, config, prompt_ids, stop_id, max_tokens, key, select,
+            max_seq)
+    return run_kv_decode(*args)
+
+
+def run_kv_decode(step_model, config, prompt_ids, stop_id, max_tokens, key,
+                  select, max_seq):
+    decoder = KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq)
+    cache = jp.asarray(build_empty_cache(config, decoder.max_decode_length))
+    stop = jp.array(stop_id, dtype=jp.int32)
+    buffer, length = decoder(cache, stop, key)
+    return ops.convert_to_numpy(buffer[0, :length]).tolist()
+
+
+def KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq=4096):
+    max_len = min(max_seq, len(prompt_ids) + max_tokens)
+    prompt = jp.array(prompt_ids, dtype=jp.int32)
+    prompt_len = len(prompt_ids)
+
+    @jax.jit
+    def decode(self_cache, stop_id, key):
+        buffer = jp.zeros((1, max_len), dtype=jp.int32)
+        buffer = buffer.at[0, :prompt_len].set(prompt)
+        cache = self_cache
+        if prompt_len > 1:
+            warmup = warmup_step(prompt, step_model)
+            cache = jax.lax.fori_loop(0, prompt_len - 1, warmup, cache)
+        step = build_step(step_model)
+        run = search.build(step, select, max_tokens, max_len)
+        token = jp.reshape(prompt[prompt_len - 1], (1, 1))
+        index = jp.array(prompt_len - 1, dtype=jp.int32)
+        return run(key, buffer, token, index, cache, stop_id)
+
+    decode.max_decode_length = max_len
+    return decode
+
+
+def build_step(step_model):
+    def step(cache, token, index, key):
+        return step_model(build_step_inputs(token, cache, index))
+
+    return step
+
+
+def warmup_step(prompt, step_model):
+    def step(index, cache):
+        token = jp.reshape(prompt[index], (1, 1))
+        inputs = build_step_inputs(token, cache, index)
+        _, cache = step_model(inputs)
+        return cache
+
+    return step
+
+
+def build_step_inputs(token, cache, index):
+    index_array = jp.array([index], dtype=jp.int32)
+    return [token, cache, index_array]
+
+
+def extract_generated_ids(ids, prompt_length, stop_id):
+    generated = ids[prompt_length:]
+    if stop_id in generated:
+        generated = generated[:generated.index(stop_id)]
+    return generated

--- a/paz/models/foundation/gemma4/decoding_test.py
+++ b/paz/models/foundation/gemma4/decoding_test.py
@@ -1,0 +1,57 @@
+import jax
+import jax.numpy as jp
+
+from paz.models.transformers import search
+
+from paz.models.foundation.gemma4.decoding import (
+    KVDecoder, extract_generated_ids, kv_decode, kv_sample)
+from paz.models.foundation.gemma4.inference import (
+    Gemma4DecoderStep, build_empty_cache)
+from paz.models.foundation.gemma4.model import build_text_backbone_args
+from paz.models.foundation.gemma4.sampling import SamplingArgs
+
+
+def build_test_config():
+    return build_text_backbone_args(use_sliding_window_attention=False)
+
+
+def test_kv_decoder_generates_tokens():
+    config = build_test_config()
+    step_model = Gemma4DecoderStep(config)
+    prompt = [1, 2, 3]
+    decoder = KVDecoder(step_model, prompt, 5, search.greedy, 16)
+    cache = jp.asarray(build_empty_cache(config, decoder.max_decode_length))
+    stop_id = jp.array(config.vocabulary_size - 1, dtype=jp.int32)
+    buffer, length = decoder(cache, stop_id, jax.random.PRNGKey(0))
+    ids = buffer[0, :length].tolist()
+    assert len(ids) >= len(prompt)
+    assert ids[:len(prompt)] == prompt
+
+
+def test_kv_sample_seeded_and_greedy_matches_kv_decode():
+    config = build_test_config()
+    step_model = Gemma4DecoderStep(config)
+    prompt = [1, 2, 3]
+    stop = config.vocabulary_size - 1
+    greedy = kv_decode(step_model, config, prompt, stop, 6)
+    # top_k=1 sampling reduces to argmax here (no exact ties in float32 logits).
+    peaked = kv_sample(step_model, config, prompt, stop, 6,
+                       jax.random.PRNGKey(0), SamplingArgs(1.0, 1, 1.0))
+    assert peaked == greedy
+    args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
+    key = jax.random.PRNGKey(2)
+    a = kv_sample(step_model, config, prompt, stop, 6, key, args)
+    b = kv_sample(step_model, config, prompt, stop, 6, key, args)
+    assert a == b and a[:len(prompt)] == prompt
+
+
+def test_extract_generated_ids():
+    ids = [1, 2, 3, 50, 60, 255, 70]
+    result = extract_generated_ids(ids, 3, 255)
+    assert result == [50, 60]
+
+
+def test_extract_generated_ids_no_stop():
+    ids = [1, 2, 3, 50, 60, 70]
+    result = extract_generated_ids(ids, 3, 255)
+    assert result == [50, 60, 70]

--- a/paz/models/foundation/gemma4/gemma4_test.py
+++ b/paz/models/foundation/gemma4/gemma4_test.py
@@ -1,0 +1,38 @@
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from paz.models import Gemma4
+from paz.models.foundation.gemma4.tokenizer import Gemma4Tokenizer
+from paz.models.foundation.gemma4.multimodal_decoding import generate_eager
+
+ROOT = Path(__file__).resolve().parents[4]
+WEIGHTS_DIR = ROOT / "examples" / "gemma4" / "weights"
+
+
+def run_weights_test():
+    # The real E2B/E4B weights are multi-GB and need CPU + large RAM, so this
+    # end-to-end check is opt-in: GEMMA4_WEIGHTS_TEST=1 with a local weights dir.
+    if os.environ.get("GEMMA4_WEIGHTS_TEST") != "1":
+        return False
+    return (WEIGHTS_DIR / "decoder_step.weights.h5").exists()
+
+
+def test_gemma4_requires_models_path():
+    with pytest.raises(ValueError):
+        Gemma4("gemma4_2b")
+
+
+@pytest.mark.skipif(not run_weights_test(), reason="set GEMMA4_WEIGHTS_TEST=1")
+def test_gemma4_generates_capital_of_germany():
+    models = Gemma4("gemma4_2b", models_path=str(WEIGHTS_DIR))
+    tokenizer = Gemma4Tokenizer(WEIGHTS_DIR / "tokenizer.json")
+    prompt = tokenizer.tokenize_generation_prompt("The capital of Germany is")
+    stop = tokenizer.get_stop_token_ids()[-1]
+    no_vision = np.zeros((0, models.config.hidden_dim), "float32")
+    args = (models.decoder_step, models.per_layer_step, no_vision,
+            models.config, prompt, [], stop, 16)
+    generated = generate_eager(*args)
+    assert "Berlin" in tokenizer.detokenize(generated)

--- a/paz/models/foundation/gemma4/gemma4_test.py
+++ b/paz/models/foundation/gemma4/gemma4_test.py
@@ -14,7 +14,7 @@ WEIGHTS_DIR = ROOT / "examples" / "gemma4" / "weights"
 
 def run_weights_test():
     # The real E2B/E4B weights are multi-GB and need CPU + large RAM, so this
-    # end-to-end check is opt-in: GEMMA4_WEIGHTS_TEST=1 with a local weights dir.
+    # end-to-end check is opt-in via GEMMA4_WEIGHTS_TEST=1 with local weights.
     if os.environ.get("GEMMA4_WEIGHTS_TEST") != "1":
         return False
     return (WEIGHTS_DIR / "decoder_step.weights.h5").exists()

--- a/paz/models/foundation/gemma4/image_converter.py
+++ b/paz/models/foundation/gemma4/image_converter.py
@@ -1,0 +1,72 @@
+"""Image preprocessing for the Gemma4 vision encoder.
+
+Resizes images preserving aspect ratio to roughly `max_patches` patches (each
+side a multiple of patch_size*pool_size), extracts patches into the flattened
+`(num_patches, 3*patch**2)` layout, builds the matching `(x, y)` position ids,
+and pads to `max_patches` (pixel values with 0, positions with -1). Pixel values
+are assumed to be in [0, 1]; the patch embedder rescales them to [-1, 1].
+
+Run eagerly (concrete image shapes); not part of a functional graph.
+"""
+from keras import ops
+
+
+def preprocess_images(images, config):
+    resized = resize_to_aspect(images, config)
+    pixel_values, position_ids = extract_patches(resized, config.patch_size)
+    return pad_to_max_patches(pixel_values, position_ids, config)
+
+
+def resize_to_aspect(images, config):
+    side_mult = config.patch_size * config.pool_size
+    target_pixels = config.max_patches * config.patch_size ** 2
+    shape = ops.shape(images)
+    height, width = shape[1], shape[2]
+    total = ops.cast(height * width, "float32")
+    factor = ops.sqrt(ops.cast(target_pixels, "float32") / total)
+    target_height = round_to_multiple(factor * ops.cast(height, "float32"),
+                                      side_mult)
+    target_width = round_to_multiple(factor * ops.cast(width, "float32"),
+                                     side_mult)
+    return ops.image.resize(
+        images, (target_height, target_width), interpolation="bicubic",
+        antialias=True)
+
+
+def round_to_multiple(value, multiple):
+    rounded = ops.cast(ops.floor(value / multiple) * multiple, "int32")
+    return ops.maximum(rounded, multiple)
+
+
+def extract_patches(images, patch_size):
+    shape = ops.shape(images)
+    batch, height, width = shape[0], shape[1], shape[2]
+    rows, columns = height // patch_size, width // patch_size
+    patched = ops.reshape(
+        images, (batch, rows, patch_size, columns, patch_size, 3))
+    patched = ops.transpose(patched, (0, 1, 3, 2, 4, 5))
+    pixel_values = ops.reshape(
+        patched, (batch, rows * columns, 3 * patch_size * patch_size))
+    position_ids = build_position_grid(rows, columns)
+    position_ids = ops.broadcast_to(
+        position_ids, (batch,) + tuple(ops.shape(position_ids)[1:]))
+    return pixel_values, position_ids
+
+
+def build_position_grid(rows, columns):
+    grid_x = ops.tile(ops.reshape(ops.arange(columns), (1, columns)), (rows, 1))
+    grid_y = ops.tile(ops.reshape(ops.arange(rows), (rows, 1)), (1, columns))
+    grid = ops.stack(
+        (ops.reshape(grid_x, (-1,)), ops.reshape(grid_y, (-1,))), axis=-1)
+    return ops.expand_dims(ops.cast(grid, "int32"), axis=0)
+
+
+def pad_to_max_patches(pixel_values, position_ids, config):
+    shape = ops.shape(pixel_values)
+    batch, count = shape[0], shape[1]
+    pad = config.max_patches - count
+    value_pad = ops.zeros((batch, pad, shape[2]), pixel_values.dtype)
+    position_pad = -ops.ones((batch, pad, 2), dtype="int32")
+    pixel_values = ops.concatenate([pixel_values, value_pad], axis=1)
+    position_ids = ops.concatenate([position_ids, position_pad], axis=1)
+    return {"pixel_values": pixel_values, "pixel_position_ids": position_ids}

--- a/paz/models/foundation/gemma4/image_converter_test.py
+++ b/paz/models/foundation/gemma4/image_converter_test.py
@@ -1,0 +1,44 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+
+from paz.models.foundation.gemma4.image_converter import preprocess_images
+from paz.models.foundation.gemma4.vision import (
+    build_vision_encoder, build_vision_encoder_args, num_patches)
+
+
+def test_preprocess_shapes_and_positions():
+    config = build_vision_encoder_args()
+    images = np.random.default_rng(0).random((2, 40, 40, 3)).astype("float32")
+    out = preprocess_images(images, config)
+    patch_dim = 3 * config.patch_size ** 2
+    count = num_patches(config)
+    assert tuple(out["pixel_values"].shape) == (2, count, patch_dim)
+    assert tuple(out["pixel_position_ids"].shape) == (2, count, 2)
+    positions = np.array(out["pixel_position_ids"])[0]
+    columns = int((positions[:, 1] == 0).sum())
+    assert positions[0].tolist() == [0, 0]
+    assert positions[1].tolist() == [1, 0]
+    assert positions[columns].tolist() == [0, 1]
+
+
+def test_preprocess_rectangular_pads():
+    config = build_vision_encoder_args()
+    images = np.random.default_rng(2).random((1, 60, 30, 3)).astype("float32")
+    out = preprocess_images(images, config)
+    positions = np.array(out["pixel_position_ids"])[0]
+    assert tuple(out["pixel_values"].shape) == (
+        1, config.max_patches, 3 * config.patch_size ** 2)
+    assert (positions == -1).any()        # padded slots present
+    assert (positions[0] != -1).all()     # first patch is real
+
+
+def test_preprocess_feeds_vision_encoder():
+    config = build_vision_encoder_args()
+    encoder = build_vision_encoder(config)
+    images = np.random.default_rng(1).random((1, 33, 51, 3)).astype("float32")
+    out = encoder(preprocess_images(images, config))
+    pooled = config.max_patches // config.pool_size ** 2
+    assert tuple(np.array(out).shape) == (1, pooled, config.output_dim)

--- a/paz/models/foundation/gemma4/inference.py
+++ b/paz/models/foundation/gemma4/inference.py
@@ -1,0 +1,180 @@
+from keras import Model, ops
+from keras.layers import Input
+
+from paz.models.transformers import cache as kv_cache
+
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
+
+from paz.models.foundation.gemma4.layers.decoder import cached_decoder_block
+from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
+from paz.models.foundation.gemma4.model import (
+    build_cache_head_dim, build_per_layer_combined_inputs,
+    build_per_layer_embedding, build_per_layer_model_projection,
+    build_token_embedding, scale_per_layer_embedding, scale_token_embeddings)
+
+
+def Gemma4PerLayerEmbeddingStep(
+        config, name="gemma4_per_layer_embedding_step"):
+    """Per-layer embedding lookup only (4.7 GB for E2B).
+
+    Kept as a separate Keras model so it can be built and loaded
+    before Gemma4DecoderStep.  Loading the large embedding table in
+    isolation (peak ~9.4 GB) avoids the ~14 GB peak that would occur
+    if it were part of the full 9.27 GB decoder step model.
+
+    Output shape: (batch, 1, num_layers * hidden_size_per_layer_input).
+    The output is pre-scaled by sqrt(hidden_size_per_layer_input).
+
+    Pass this output directly as the per_layer_full_embedding input
+    of Gemma4DecoderStep.
+    """
+    p = config.hidden_size_per_layer_input
+    token_ids = Input((1,), dtype="int32", name="token_ids")
+    per_layer_embedding = build_per_layer_embedding(
+        config.vocabulary_size, p * config.num_layers, config.dtype)
+    full_embedding = per_layer_embedding(token_ids)
+    full_embedding = scale_per_layer_embedding(
+        full_embedding, p, config.dtype)
+    return Model(token_ids, full_embedding, name=name)
+
+
+def Gemma4DecoderStep(config, name="gemma4_decoder_step"):
+    cache, cache_index = build_cache_inputs(config)
+    token_ids = Input((1,), dtype="int32", name="token_ids")
+    embedding = build_token_embedding(
+        config.vocabulary_size, config.hidden_dim, config.dtype)
+    hidden = embedding(token_ids)
+    per_layer = build_per_layer_input(config)
+    outputs = build_cached_step(
+        hidden, embedding, cache, cache_index, per_layer, config)
+    inputs = [token_ids, cache, cache_index]
+    if per_layer is not None:
+        inputs.append(per_layer)
+    return Model(inputs, list(outputs), name=name)
+
+
+def Gemma4MultimodalDecoderStep(
+        config, name="gemma4_multimodal_decoder_step"):
+    """Cached decoder step fed a precomputed (unscaled) input embedding.
+
+    Image positions feed the vision embedding (pre-scaled by hidden_dim**-0.5);
+    text positions feed the token embedding. Otherwise identical to
+    Gemma4DecoderStep.
+    """
+    cache, cache_index = build_cache_inputs(config)
+    input_embedding = Input(
+        (None, config.hidden_dim), dtype=config.dtype, name="input_embedding")
+    positions = Input((None,), dtype="int32", name="positions")
+    embedding = build_token_embedding(
+        config.vocabulary_size, config.hidden_dim, config.dtype)
+    per_layer = None
+    if config.hidden_size_per_layer_input:
+        dim = config.hidden_size_per_layer_input * config.num_layers
+        per_layer = Input(
+            (None, dim), dtype=config.dtype, name="per_layer_full_embedding")
+    outputs = build_cached_step(
+        input_embedding, embedding, cache, cache_index, per_layer, config,
+        positions=positions)
+    inputs = [input_embedding, cache, cache_index, positions]
+    if per_layer is not None:
+        inputs.append(per_layer)
+    return Model(inputs, list(outputs), name=name)
+
+
+def build_cache_inputs(config):
+    cache_head_dim = build_cache_head_dim(config)
+    cache_shape = (config.num_layers, 2, None,
+                   config.num_key_value_heads, cache_head_dim)
+    cache = Input(cache_shape, dtype=config.dtype, name="self_attention_cache")
+    cache_index = Input((), dtype="int32", name="cache_update_index")
+    return cache, cache_index
+
+
+def build_per_layer_input(config):
+    if not config.hidden_size_per_layer_input:
+        return None
+    dim = config.hidden_size_per_layer_input * config.num_layers
+    return Input((1, dim), dtype=config.dtype, name="per_layer_full_embedding")
+
+
+def build_cached_step(hidden, embedding, cache, cache_index, per_layer, config,
+                      positions=None):
+    index_scalar = extract_cache_index(cache_index)
+    per_layer_embeddings = None
+    if per_layer is not None:
+        p = config.hidden_size_per_layer_input
+        # Per-layer model projection of the UNSCALED embedding (before scaling).
+        projection_full = build_per_layer_model_projection(
+            hidden, config.num_layers, p, config.dtype)
+        per_layer_embeddings = build_per_layer_combined_inputs(
+            projection_full, per_layer, config.num_layers, p,
+            config.layer_norm_epsilon, config.dtype)
+    hidden = scale_token_embeddings(hidden, config.hidden_dim)
+    hidden, updated_cache = build_cached_decoder_blocks(
+        hidden, cache, index_scalar, config,
+        per_layer_embeddings=per_layer_embeddings, positions=positions)
+    updated_cache = ops.cast(updated_cache, config.dtype)
+    norm_args = (config.layer_norm_epsilon, config.dtype,
+                 "final_normalization")
+    hidden = build_rms_norm(*norm_args)(hidden)
+    logits = embedding(hidden, reverse=True)
+    logits = apply_soft_cap(logits, config.final_logit_soft_cap)
+    return logits, updated_cache
+
+
+def extract_cache_index(cache_index):
+    return ops.cast(cache_index[0], "int32")
+
+
+def squeeze_shared_cache(cache):
+    return ops.squeeze(cache, axis=1)
+
+
+def slice_layer_cache(cache, layer_index):
+    return cache[:, layer_index, ...]
+
+
+def expand_layer_cache(layer_cache):
+    return ops.expand_dims(layer_cache, axis=1)
+
+
+def concat_layer_caches(caches):
+    return ops.concatenate(caches, axis=1)
+
+
+def build_cached_decoder_blocks(hidden, cache, index, config,
+                                 per_layer_embeddings=None, positions=None):
+    from paz.models.foundation.gemma4.model import build_kv_source_map
+    kv_source_map = build_kv_source_map(config)
+    updated_caches = []
+    for layer_index in range(config.num_layers):
+        block_name = "decoder_block_{}".format(layer_index)
+        layer_cache = slice_layer_cache(cache, layer_index)
+        per_layer_embedding = None
+        if per_layer_embeddings is not None:
+            per_layer_embedding = per_layer_embeddings[layer_index]
+        shared_kv_cache = None
+        source = kv_source_map.get(layer_index)
+        if source is not None:
+            shared_kv_cache = squeeze_shared_cache(
+                updated_caches[source])
+        args = (hidden, layer_cache, index,
+                config, layer_index, block_name)
+        kwargs = {
+            "per_layer_embedding": per_layer_embedding,
+            "shared_kv_cache": shared_kv_cache,
+            "positions": positions,
+        }
+        hidden, layer_cache = cached_decoder_block(
+            *args, **kwargs)
+        updated_caches.append(expand_layer_cache(layer_cache))
+    updated = concat_layer_caches(updated_caches)
+    return hidden, updated
+
+
+def build_empty_cache(config, max_length, batch_size=1):
+    num_kv_heads = config.num_key_value_heads
+    cache_head_dim = build_cache_head_dim(config)
+    args = (batch_size, config.num_layers, max_length, num_kv_heads,
+            cache_head_dim, config.dtype)
+    return kv_cache.build(*args)

--- a/paz/models/foundation/gemma4/inference.py
+++ b/paz/models/foundation/gemma4/inference.py
@@ -2,15 +2,15 @@ from keras import Model, ops
 from keras.layers import Input
 
 from paz.models.transformers import cache as kv_cache
-
 from paz.models.transformers.logits import soft_cap as apply_soft_cap
-
+from paz.models.foundation.gemma4.configuration import build_cache_head_dim
+from paz.models.foundation.gemma4.configuration import build_kv_source_map
 from paz.models.foundation.gemma4.layers.decoder import cached_decoder_block
 from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
 from paz.models.foundation.gemma4.model import (
-    build_cache_head_dim, build_per_layer_combined_inputs,
-    build_per_layer_embedding, build_per_layer_model_projection,
-    build_token_embedding, scale_per_layer_embedding, scale_token_embeddings)
+    build_per_layer_combined_inputs, build_per_layer_embedding,
+    build_per_layer_model_projection, build_token_embedding,
+    scale_per_layer_embedding, scale_token_embeddings)
 
 
 def Gemma4PerLayerEmbeddingStep(
@@ -144,7 +144,6 @@ def concat_layer_caches(caches):
 
 def build_cached_decoder_blocks(hidden, cache, index, config,
                                  per_layer_embeddings=None, positions=None):
-    from paz.models.foundation.gemma4.model import build_kv_source_map
     kv_source_map = build_kv_source_map(config)
     updated_caches = []
     for layer_index in range(config.num_layers):

--- a/paz/models/foundation/gemma4/inference_test.py
+++ b/paz/models/foundation/gemma4/inference_test.py
@@ -1,0 +1,51 @@
+import jax.numpy as jp
+
+from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
+from paz.models.foundation.gemma4.inference import (
+    Gemma4DecoderStep, build_empty_cache)
+from paz.models.foundation.gemma4.model import build_text_backbone_args
+
+
+def build_test_config():
+    return build_text_backbone_args(use_sliding_window_attention=False)
+
+
+def assert_close(left, right, tol=1e-3):
+    diff = jp.max(jp.abs(left - right))
+    assert float(diff) <= tol
+
+
+def test_decoder_step_output_shape():
+    config = build_test_config()
+    step_model = Gemma4DecoderStep(config)
+    cache = build_empty_cache(config, 8)
+    token = jp.array([[1]], dtype=jp.int32)
+    index = jp.array([0], dtype=jp.int32)
+    logits, new_cache = step_model([token, cache, index])
+    assert logits.shape == (1, 1, config.vocabulary_size)
+    assert new_cache.shape == cache.shape
+
+
+def test_cached_step_matches_full_sequence():
+    config = build_test_config()
+    full_model = Gemma4CausalLM(config)
+    step_model = Gemma4DecoderStep(config)
+    copy_decoder_step_weights(step_model, full_model)
+    token_ids = jp.array([[5, 10, 15]], dtype=jp.int32)
+    padding_mask = jp.ones_like(token_ids)
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    full_logits = full_model(inputs)
+    cache = build_empty_cache(config, 8)
+    for position in range(3):
+        token = token_ids[:, position:position + 1]
+        index = jp.array([position], dtype=jp.int32)
+        step_logits, cache = step_model([token, cache, index])
+    step_last = step_logits[0, 0, :]
+    full_last = full_logits[0, 2, :]
+    assert_close(step_last, full_last)
+
+
+def copy_decoder_step_weights(step_model, full_model):
+    full_by_path = {weight.path: weight for weight in full_model.weights}
+    for step_weight in step_model.weights:
+        step_weight.assign(full_by_path[step_weight.path])

--- a/paz/models/foundation/gemma4/layers/__init__.py
+++ b/paz/models/foundation/gemma4/layers/__init__.py
@@ -1,0 +1,18 @@
+from paz.models.foundation.gemma4.layers.attention import attend
+from paz.models.foundation.gemma4.layers.decoder import decoder_block
+from paz.models.foundation.gemma4.layers.normalization import Gemma4VNorm
+from paz.models.foundation.gemma4.layers.normalization import ScalarMultiply
+from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
+from paz.models.foundation.gemma4.layers.normalization import build_v_norm
+from paz.models.foundation.gemma4.layers.normalization import (
+    build_scalar_multiply)
+
+__all__ = [
+    "attend",
+    "decoder_block",
+    "Gemma4VNorm",
+    "ScalarMultiply",
+    "build_rms_norm",
+    "build_v_norm",
+    "build_scalar_multiply",
+]

--- a/paz/models/foundation/gemma4/layers/attention.py
+++ b/paz/models/foundation/gemma4/layers/attention.py
@@ -1,0 +1,173 @@
+from keras import ops
+from keras.layers import Dropout, EinsumDense, Softmax
+
+from paz.layers import MergeDims, SplitDim
+from paz.models.transformers import cache as kv_cache
+from paz.models.transformers import mask as attention_mask
+from paz.models.transformers.embeddings import rotary
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
+
+from paz.models.foundation.gemma4.layers.normalization import (
+    build_rms_norm, build_v_norm)
+
+
+def attend(x, mask, head_dim, num_query_heads, num_kv_heads, epsilon,
+           wavelength, scaling_factor, partial_rotary, soft_cap, dropout,
+           dtype, name, shared_kv=None):
+    query = project_query(x, num_query_heads, head_dim, epsilon, dtype, name)
+    rope_args = (wavelength, scaling_factor, partial_rotary)
+    query = rotary.apply_partial(query, *rope_args)
+    if shared_kv is not None:
+        key, value = shared_kv[:, 0, ...], shared_kv[:, 1, ...]
+    else:
+        key = project_key(x, num_kv_heads, head_dim, epsilon, dtype, name)
+        value = project_value(x, num_kv_heads, head_dim, epsilon, dtype, name)
+        key = rotary.apply_partial(key, *rope_args)
+    kv = ops.stack((key, value), axis=1)
+    args = (query, key, value, mask, num_query_heads, num_kv_heads, head_dim,
+            soft_cap, dropout, dtype, name)
+    output = compute_attention(*args)
+    output = zero_masked_positions(output, mask)
+    return project_output(output, x.shape[-1], dtype, name), kv
+
+
+def cached_attend(x, cache, index, head_dim, num_query_heads, num_kv_heads,
+                  epsilon, wavelength, scaling_factor, partial_rotary, soft_cap,
+                  dtype, name, cache_head_dim, window, positions,
+                  shared_kv_cache=None):
+    """Single-step cached attention.
+
+    When shared_kv_cache is provided (kv_shared layers), K/V are read from
+    that cache instead of being projected from x.
+    """
+    cache_head_dim = cache_head_dim or head_dim
+    query = project_query(x, num_query_heads, head_dim, epsilon, dtype, name)
+    cache_positions = build_cache_positions(index, positions)
+    rope_args = (wavelength, scaling_factor, partial_rotary, cache_positions)
+    query = rotary.apply_partial(query, *rope_args)
+    if shared_kv_cache is not None:
+        kv_src = shared_kv_cache
+        updated_cache = cache
+    else:
+        key = project_key(x, num_kv_heads, head_dim, epsilon, dtype, name)
+        value = project_value(x, num_kv_heads, head_dim, epsilon, dtype, name)
+        key = rotary.apply_partial(key, *rope_args)
+        key = ops.cast(key, dtype)
+        value = ops.cast(value, dtype)
+        if head_dim < cache_head_dim:
+            key = pad_to_cache_dim(key, cache_head_dim - head_dim)
+            value = pad_to_cache_dim(value, cache_head_dim - head_dim)
+        updated_cache = kv_cache.update(cache, index, key, value)
+        kv_src = updated_cache
+    full_key, full_value = ops.split(kv_src, 2, axis=1)
+    full_key = ops.squeeze(full_key, axis=1)
+    full_value = ops.squeeze(full_value, axis=1)
+    if head_dim < cache_head_dim:
+        full_key = full_key[..., :head_dim]
+        full_value = full_value[..., :head_dim]
+    mask = build_cache_mask(full_key, index, positions, window)
+    args = (query, full_key, full_value, mask, num_query_heads, num_kv_heads,
+            head_dim, soft_cap, 0.0, dtype, name)
+    output = compute_attention(*args)
+    return project_output(output, x.shape[-1], dtype, name), updated_cache
+
+
+def pad_to_cache_dim(tensor, pad_size):
+    ndim = len(tensor.shape)
+    padding = [(0, 0)] * (ndim - 1) + [(0, pad_size)]
+    return ops.pad(tensor, padding)
+
+
+def build_cache_mask(full_key, index, positions, window):
+    # Causal (+ optional sliding-window) mask between the query positions and
+    # the cache positions. Works for one query (decode) or many (prefill);
+    # cumsum avoids arange so the cache length and query count stay dynamic.
+    ones = ops.ones_like(full_key[:, :, 0, 0], dtype="int32")
+    key_pos = ops.cumsum(ones, axis=1) - 1
+    query_pos = query_positions(index, positions)
+    mask = attention_mask.causal(query_pos, key_pos)
+    if window is not None:
+        recent = attention_mask.sliding_window(query_pos, key_pos, window)
+        mask = ops.logical_and(mask, recent)
+    return ops.cast(mask, "bool")
+
+
+def query_positions(index, positions):
+    if positions is None:
+        return ops.reshape(index, (1, 1))
+    return ops.reshape(positions, (1, -1))
+
+
+def build_cache_positions(index, positions):
+    transposed = ops.transpose(query_positions(index, positions))
+    return ops.cast(transposed, "float32")
+
+
+def project_query(x, num_heads, head_dim, epsilon, dtype, name):
+    shape = (None, num_heads, head_dim)
+    equation = "btd,ndh->btnh"
+    proj_name = "{}_query".format(name)
+    proj = EinsumDense(equation, shape, dtype=dtype, name=proj_name)
+    norm = build_rms_norm(epsilon, dtype, "{}_query_norm".format(name))
+    return norm(proj(x))
+
+
+def project_key(x, num_kv_heads, head_dim, epsilon, dtype, name):
+    shape = (None, num_kv_heads, head_dim)
+    equation = "btd,kdh->btkh"
+    proj_name = "{}_key".format(name)
+    proj = EinsumDense(equation, shape, dtype=dtype, name=proj_name)
+    norm = build_rms_norm(epsilon, dtype, "{}_key_norm".format(name))
+    return norm(proj(x))
+
+
+def project_value(x, num_kv_heads, head_dim, epsilon, dtype, name):
+    shape = (None, num_kv_heads, head_dim)
+    equation = "btd,kdh->btkh"
+    proj_name = "{}_value".format(name)
+    proj = EinsumDense(equation, shape, dtype=dtype, name=proj_name)
+    norm = build_v_norm(epsilon, dtype, "{}_value_norm".format(name))
+    return norm(proj(x))
+
+
+def compute_attention(query, key, value, mask, num_query_heads, num_kv_heads,
+                      head_dim, soft_cap, dropout, dtype, name):
+    query = reshape_query(query, num_query_heads, num_kv_heads, head_dim)
+    logits = ops.einsum("btkgh,bskh->bkgts", query, key)
+    logits = apply_soft_cap(logits, soft_cap)
+    if mask is not None:
+        mask = mask[:, None, None, :, :]
+    softmax = Softmax(dtype="float32", name="{}_softmax".format(name))
+    weights = ops.cast(softmax(logits, mask=mask), logits.dtype)
+    drop = build_dropout(dropout, dtype, name)
+    if drop is not None:
+        weights = drop(weights)
+    output = ops.einsum("bkgts,bskh->btkgh", weights, value)
+    return MergeDims(axis=-3)(output)
+
+
+def project_output(output, output_dim, dtype, name):
+    shape = (None, output_dim)
+    proj_name = "{}_attention_output".format(name)
+    proj = EinsumDense("btnh,nhd->btd", shape, dtype=dtype, name=proj_name)
+    return proj(output)
+
+
+def zero_masked_positions(output, mask):
+    if mask is None:
+        return output
+    no_tokens = ops.all(ops.equal(mask, 0), axis=-1, keepdims=True)
+    zeros = ops.zeros_like(output)
+    return ops.where(no_tokens[..., None], zeros, output)
+
+
+def reshape_query(query, num_query_heads, num_kv_heads, head_dim):
+    group_size = num_query_heads // num_kv_heads
+    sizes = (num_kv_heads, group_size)
+    return SplitDim(axis=-2, sizes=sizes)(query)
+
+
+def build_dropout(rate, dtype, name):
+    if not rate:
+        return None
+    return Dropout(rate, dtype=dtype, name="{}_dropout".format(name))

--- a/paz/models/foundation/gemma4/layers/core.py
+++ b/paz/models/foundation/gemma4/layers/core.py
@@ -1,4 +1,3 @@
-import keras
 from keras import ops
 
 from paz.models.transformers import mask
@@ -35,20 +34,3 @@ def merge_padding_mask(padding_mask):
         return None
     mask = ops.cast(padding_mask, "bool")
     return ops.expand_dims(mask, axis=1)
-
-
-def clip_float16(values):
-    dtype = keras.backend.standardize_dtype(values.dtype)
-    if dtype != "float16":
-        return values
-    return ops.clip(values, -65504, 65504)
-
-
-def add_residual(left, right):
-    dtype = keras.backend.standardize_dtype(left.dtype)
-    if dtype != "float16":
-        return left + right
-    left = ops.cast(left, "float32")
-    right = ops.cast(right, "float32")
-    output = clip_float16(ops.add(left, right))
-    return ops.cast(output, "float16")

--- a/paz/models/foundation/gemma4/layers/core.py
+++ b/paz/models/foundation/gemma4/layers/core.py
@@ -1,0 +1,54 @@
+import keras
+from keras import ops
+
+from paz.models.transformers import mask
+
+
+def build_attention_mask(padding_mask, bidirectional, sliding_window_size):
+    if padding_mask is None:
+        return None
+    if bidirectional:
+        return build_bidirectional_mask(padding_mask)
+    positions = build_positions(padding_mask)
+    causal_mask = mask.causal(positions, positions)
+    if sliding_window_size is not None:
+        window = mask.sliding_window(positions, positions, sliding_window_size)
+        causal_mask = ops.logical_and(causal_mask, window)
+    decoder_mask = merge_padding_mask(padding_mask)
+    return ops.logical_and(causal_mask, decoder_mask)
+
+
+def build_positions(padding_mask):
+    ones = ops.ones_like(padding_mask, dtype="int32")
+    return ops.cumsum(ones, axis=1) - 1
+
+
+def build_bidirectional_mask(padding_mask):
+    if padding_mask is None:
+        return None
+    mask = merge_padding_mask(padding_mask)
+    return ops.logical_and(mask, ops.transpose(mask, (0, 2, 1)))
+
+
+def merge_padding_mask(padding_mask):
+    if padding_mask is None:
+        return None
+    mask = ops.cast(padding_mask, "bool")
+    return ops.expand_dims(mask, axis=1)
+
+
+def clip_float16(values):
+    dtype = keras.backend.standardize_dtype(values.dtype)
+    if dtype != "float16":
+        return values
+    return ops.clip(values, -65504, 65504)
+
+
+def add_residual(left, right):
+    dtype = keras.backend.standardize_dtype(left.dtype)
+    if dtype != "float16":
+        return left + right
+    left = ops.cast(left, "float32")
+    right = ops.cast(right, "float32")
+    output = clip_float16(ops.add(left, right))
+    return ops.cast(output, "float16")

--- a/paz/models/foundation/gemma4/layers/decoder.py
+++ b/paz/models/foundation/gemma4/layers/decoder.py
@@ -1,9 +1,13 @@
 import keras
 from keras.layers import Dropout, EinsumDense
 
+from paz.models.foundation.gemma4.configuration import (
+    build_cache_head_dim, build_feedforward_dim, build_head_dim,
+    build_partial_rotary_factor, build_rope_scaling_factor,
+    build_rope_wavelength, is_global_attention_layer, use_sliding_window)
+from paz.models.transformers.numerics import add_residual, clip_float16
 from paz.models.foundation.gemma4.layers.attention import attend, cached_attend
-from paz.models.foundation.gemma4.layers.core import (
-    add_residual, build_attention_mask, clip_float16)
+from paz.models.foundation.gemma4.layers.core import build_attention_mask
 from paz.models.foundation.gemma4.layers.normalization import (
     build_rms_norm, build_scalar_multiply)
 
@@ -26,10 +30,10 @@ def decoder_block(x, padding_mask, config, layer_index, name,
 
 def per_layer_input_path(x, per_layer_embed, config, name):
     epsilon, dtype = config.layer_norm_epsilon, config.dtype
-    pl = config.hidden_size_per_layer_input
+    per_layer_dim = config.hidden_size_per_layer_input
     gate_name = "{}_per_layer_gate".format(name)
     gate = keras.activations.gelu(
-        build_einsum_dense("btd,dp->btp", pl, dtype, gate_name)(x),
+        build_einsum_dense("btd,dp->btp", per_layer_dim, dtype, gate_name)(x),
         approximate=True)
     hidden = gate * per_layer_embed
     proj_name = "{}_per_layer_projection".format(name)
@@ -46,8 +50,8 @@ def attention_path(x, padding_mask, config, layer_index, name,
     norm_name = "{}_pre_attention_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
     mask = build_block_attention_mask(padding_mask, config, layer_index)
-    attn_args = build_attend_args(hidden, mask, config, layer_index, name)
-    hidden, kv = attend(*attn_args, shared_kv=shared_kv)
+    attention_args = build_attend_args(hidden, mask, config, layer_index, name)
+    hidden, kv = attend(*attention_args, shared_kv=shared_kv)
     post_name = "{}_post_attention_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
     if config.dropout:
@@ -57,21 +61,23 @@ def attention_path(x, padding_mask, config, layer_index, name,
 
 
 def feedforward_path(x, config, name, layer_index=None):
-    from paz.models.foundation.gemma4.model import build_feedforward_dim
     epsilon, dtype = config.layer_norm_epsilon, config.dtype
-    f_dim = (build_feedforward_dim(config, layer_index)
-             if layer_index is not None else config.intermediate_dim)
+    feedforward_dim = (build_feedforward_dim(config, layer_index)
+                       if layer_index is not None else config.intermediate_dim)
     pre_name = "{}_pre_ffw_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, pre_name)(x)
-    up_eq = "btd,df->btf"
+    up_equation = "btd,df->btf"
     gate_name = "{}_ffw_gating".format(name)
-    gate = build_einsum_dense(up_eq, f_dim, dtype, gate_name)(hidden)
+    gate = build_einsum_dense(
+        up_equation, feedforward_dim, dtype, gate_name)(hidden)
     gate_2_name = "{}_ffw_gating_2".format(name)
-    value = build_einsum_dense(up_eq, f_dim, dtype, gate_2_name)(hidden)
+    value = build_einsum_dense(
+        up_equation, feedforward_dim, dtype, gate_2_name)(hidden)
     hidden = keras.activations.gelu(gate, approximate=True) * value
-    down_eq = "btf,fd->btd"
+    down_equation = "btf,fd->btd"
     linear_name = "{}_ffw_linear".format(name)
-    layer = build_einsum_dense(down_eq, config.hidden_dim, dtype, linear_name)
+    layer = build_einsum_dense(
+        down_equation, config.hidden_dim, dtype, linear_name)
     hidden = layer(hidden)
     post_name = "{}_post_ffw_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
@@ -82,8 +88,6 @@ def feedforward_path(x, config, name, layer_index=None):
 
 
 def build_block_attention_mask(padding_mask, config, layer_index):
-    from paz.models.foundation.gemma4.model import (
-        is_global_attention_layer, use_sliding_window)
     is_global = is_global_attention_layer(config, layer_index)
     window = None
     if use_sliding_window(config, is_global):
@@ -93,11 +97,8 @@ def build_block_attention_mask(padding_mask, config, layer_index):
 
 
 def build_attend_args(hidden, mask, config, layer_index, name):
-    from paz.models.foundation.gemma4.model import (
-        is_global_attention_layer, build_head_dim, build_rope_wavelength,
-        build_rope_scaling_factor, build_partial_rotary_factor)
     is_global = is_global_attention_layer(config, layer_index)
-    attn_name = "{}_attention".format(name)
+    attention_name = "{}_attention".format(name)
     return (
         hidden,
         mask,
@@ -111,7 +112,7 @@ def build_attend_args(hidden, mask, config, layer_index, name):
         config.attention_logit_soft_cap,
         config.dropout,
         config.dtype,
-        attn_name,
+        attention_name,
     )
 
 
@@ -141,10 +142,10 @@ def cached_attention_path(x, cache, cache_index, config, layer_index, name,
     epsilon, dtype = config.layer_norm_epsilon, config.dtype
     norm_name = "{}_pre_attention_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
-    attn_args = build_cached_attend_args(
+    attention_args = build_cached_attend_args(
         hidden, cache, cache_index, config, layer_index, name, positions)
     hidden, cache = cached_attend(
-        *attn_args, shared_kv_cache=shared_kv_cache)
+        *attention_args, shared_kv_cache=shared_kv_cache)
     post_name = "{}_post_attention_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
     return add_residual(x, hidden), cache
@@ -152,15 +153,11 @@ def cached_attention_path(x, cache, cache_index, config, layer_index, name,
 
 def build_cached_attend_args(hidden, cache, index, config, layer_index, name,
                              positions=None):
-    from paz.models.foundation.gemma4.model import (
-        is_global_attention_layer, build_head_dim, build_rope_wavelength,
-        build_rope_scaling_factor, build_partial_rotary_factor,
-        build_cache_head_dim, use_sliding_window)
     is_global = is_global_attention_layer(config, layer_index)
     window = None
     if use_sliding_window(config, is_global):
         window = config.sliding_window_size
-    attn_name = "{}_attention".format(name)
+    attention_name = "{}_attention".format(name)
     return (
         hidden,
         cache,
@@ -174,7 +171,7 @@ def build_cached_attend_args(hidden, cache, index, config, layer_index, name,
         build_partial_rotary_factor(config, is_global),
         config.attention_logit_soft_cap,
         config.dtype,
-        attn_name,
+        attention_name,
         build_cache_head_dim(config),
         window,
         positions,

--- a/paz/models/foundation/gemma4/layers/decoder.py
+++ b/paz/models/foundation/gemma4/layers/decoder.py
@@ -1,0 +1,186 @@
+import keras
+from keras.layers import Dropout, EinsumDense
+
+from paz.models.foundation.gemma4.layers.attention import attend, cached_attend
+from paz.models.foundation.gemma4.layers.core import (
+    add_residual, build_attention_mask, clip_float16)
+from paz.models.foundation.gemma4.layers.normalization import (
+    build_rms_norm, build_scalar_multiply)
+
+
+def decoder_block(x, padding_mask, config, layer_index, name,
+                  per_layer_embedding=None, shared_kv=None):
+    dtype = keras.backend.standardize_dtype(x.dtype)
+    if dtype == "float16":
+        x = clip_float16(x)
+    hidden, kv = attention_path(
+        x, padding_mask, config, layer_index, name, shared_kv=shared_kv)
+    hidden = feedforward_path(hidden, config, name, layer_index=layer_index)
+    # Per-layer input applied AFTER FFW, BEFORE layer scalar.
+    if per_layer_embedding is not None:
+        hidden = per_layer_input_path(
+            hidden, per_layer_embedding, config, name)
+    scaled = build_scalar_multiply("{}_layer_scalar".format(name))(hidden)
+    return scaled, kv
+
+
+def per_layer_input_path(x, per_layer_embed, config, name):
+    epsilon, dtype = config.layer_norm_epsilon, config.dtype
+    pl = config.hidden_size_per_layer_input
+    gate_name = "{}_per_layer_gate".format(name)
+    gate = keras.activations.gelu(
+        build_einsum_dense("btd,dp->btp", pl, dtype, gate_name)(x),
+        approximate=True)
+    hidden = gate * per_layer_embed
+    proj_name = "{}_per_layer_projection".format(name)
+    hidden = build_einsum_dense(
+        "btp,pd->btd", config.hidden_dim, dtype, proj_name)(hidden)
+    norm_name = "{}_post_per_layer_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, norm_name)(hidden)
+    return add_residual(x, hidden)
+
+
+def attention_path(x, padding_mask, config, layer_index, name,
+                   shared_kv=None):
+    epsilon, dtype = config.layer_norm_epsilon, config.dtype
+    norm_name = "{}_pre_attention_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
+    mask = build_block_attention_mask(padding_mask, config, layer_index)
+    attn_args = build_attend_args(hidden, mask, config, layer_index, name)
+    hidden, kv = attend(*attn_args, shared_kv=shared_kv)
+    post_name = "{}_post_attention_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
+    if config.dropout:
+        drop_name = "{}_attention_dropout".format(name)
+        hidden = Dropout(config.dropout, dtype=dtype, name=drop_name)(hidden)
+    return add_residual(x, hidden), kv
+
+
+def feedforward_path(x, config, name, layer_index=None):
+    from paz.models.foundation.gemma4.model import build_feedforward_dim
+    epsilon, dtype = config.layer_norm_epsilon, config.dtype
+    f_dim = (build_feedforward_dim(config, layer_index)
+             if layer_index is not None else config.intermediate_dim)
+    pre_name = "{}_pre_ffw_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, pre_name)(x)
+    up_eq = "btd,df->btf"
+    gate_name = "{}_ffw_gating".format(name)
+    gate = build_einsum_dense(up_eq, f_dim, dtype, gate_name)(hidden)
+    gate_2_name = "{}_ffw_gating_2".format(name)
+    value = build_einsum_dense(up_eq, f_dim, dtype, gate_2_name)(hidden)
+    hidden = keras.activations.gelu(gate, approximate=True) * value
+    down_eq = "btf,fd->btd"
+    linear_name = "{}_ffw_linear".format(name)
+    layer = build_einsum_dense(down_eq, config.hidden_dim, dtype, linear_name)
+    hidden = layer(hidden)
+    post_name = "{}_post_ffw_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
+    if config.dropout:
+        drop_name = "{}_ffw_dropout".format(name)
+        hidden = Dropout(config.dropout, dtype=dtype, name=drop_name)(hidden)
+    return add_residual(x, hidden)
+
+
+def build_block_attention_mask(padding_mask, config, layer_index):
+    from paz.models.foundation.gemma4.model import (
+        is_global_attention_layer, use_sliding_window)
+    is_global = is_global_attention_layer(config, layer_index)
+    window = None
+    if use_sliding_window(config, is_global):
+        window = config.sliding_window_size
+    return build_attention_mask(
+        padding_mask, config.use_bidirectional_attention, window)
+
+
+def build_attend_args(hidden, mask, config, layer_index, name):
+    from paz.models.foundation.gemma4.model import (
+        is_global_attention_layer, build_head_dim, build_rope_wavelength,
+        build_rope_scaling_factor, build_partial_rotary_factor)
+    is_global = is_global_attention_layer(config, layer_index)
+    attn_name = "{}_attention".format(name)
+    return (
+        hidden,
+        mask,
+        build_head_dim(config, is_global),
+        config.num_query_heads,
+        config.num_key_value_heads,
+        config.layer_norm_epsilon,
+        build_rope_wavelength(config, is_global),
+        build_rope_scaling_factor(config, is_global),
+        build_partial_rotary_factor(config, is_global),
+        config.attention_logit_soft_cap,
+        config.dropout,
+        config.dtype,
+        attn_name,
+    )
+
+
+def cached_decoder_block(x, cache, cache_index, config,
+                          layer_index, name,
+                          per_layer_embedding=None,
+                          shared_kv_cache=None, positions=None):
+    dtype = keras.backend.standardize_dtype(x.dtype)
+    if dtype == "float16":
+        x = clip_float16(x)
+    hidden, cache = cached_attention_path(
+        x, cache, cache_index, config, layer_index, name,
+        shared_kv_cache=shared_kv_cache, positions=positions)
+    hidden = feedforward_path(
+        hidden, config, name, layer_index=layer_index)
+    # Per-layer input applied AFTER FFW, BEFORE layer scalar.
+    if per_layer_embedding is not None:
+        hidden = per_layer_input_path(
+            hidden, per_layer_embedding, config, name)
+    scaled = build_scalar_multiply(
+        "{}_layer_scalar".format(name))(hidden)
+    return scaled, cache
+
+
+def cached_attention_path(x, cache, cache_index, config, layer_index, name,
+                           shared_kv_cache=None, positions=None):
+    epsilon, dtype = config.layer_norm_epsilon, config.dtype
+    norm_name = "{}_pre_attention_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
+    attn_args = build_cached_attend_args(
+        hidden, cache, cache_index, config, layer_index, name, positions)
+    hidden, cache = cached_attend(
+        *attn_args, shared_kv_cache=shared_kv_cache)
+    post_name = "{}_post_attention_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
+    return add_residual(x, hidden), cache
+
+
+def build_cached_attend_args(hidden, cache, index, config, layer_index, name,
+                             positions=None):
+    from paz.models.foundation.gemma4.model import (
+        is_global_attention_layer, build_head_dim, build_rope_wavelength,
+        build_rope_scaling_factor, build_partial_rotary_factor,
+        build_cache_head_dim, use_sliding_window)
+    is_global = is_global_attention_layer(config, layer_index)
+    window = None
+    if use_sliding_window(config, is_global):
+        window = config.sliding_window_size
+    attn_name = "{}_attention".format(name)
+    return (
+        hidden,
+        cache,
+        index,
+        build_head_dim(config, is_global),
+        config.num_query_heads,
+        config.num_key_value_heads,
+        config.layer_norm_epsilon,
+        build_rope_wavelength(config, is_global),
+        build_rope_scaling_factor(config, is_global),
+        build_partial_rotary_factor(config, is_global),
+        config.attention_logit_soft_cap,
+        config.dtype,
+        attn_name,
+        build_cache_head_dim(config),
+        window,
+        positions,
+    )
+
+
+def build_einsum_dense(equation, output_dim, dtype, name):
+    shape = (None, output_dim)
+    return EinsumDense(equation, shape, dtype=dtype, name=name)

--- a/paz/models/foundation/gemma4/layers/normalization.py
+++ b/paz/models/foundation/gemma4/layers/normalization.py
@@ -1,0 +1,63 @@
+import keras
+from keras import ops
+from keras.layers import Layer
+
+from paz.layers import RMSNormalization
+
+
+@keras.saving.register_keras_serializable(package="gemma4")
+class Gemma4VNorm(Layer):
+    def __init__(self, epsilon=1e-6, **kwargs):
+        super().__init__(**kwargs)
+        self.epsilon = epsilon
+
+    def get_config(self):
+        config = super().get_config()
+        config["epsilon"] = self.epsilon
+        return config
+
+    def build(self, input_shape):
+        self.built = True
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def call(self, x):
+        x = ops.cast(x, "float32")
+        variance = ops.mean(
+            ops.square(x), axis=-1, keepdims=True)
+        output = x * ops.power(variance + self.epsilon, -0.5)
+        return ops.cast(output, self.compute_dtype)
+
+
+@keras.saving.register_keras_serializable(package="gemma4")
+class ScalarMultiply(Layer):
+    def get_config(self):
+        return super().get_config()
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
+    def build(self, input_shape):
+        self.scale = self.add_weight(
+            name="scale",
+            shape=(),
+            initializer="ones",
+            trainable=False,
+        )
+        self.built = True
+
+    def call(self, x):
+        return x * ops.cast(self.scale, x.dtype)
+
+
+def build_rms_norm(epsilon, dtype, name):
+    return RMSNormalization(epsilon=epsilon, dtype=dtype, name=name)
+
+
+def build_v_norm(epsilon, dtype, name):
+    return Gemma4VNorm(epsilon=epsilon, dtype=dtype, name=name)
+
+
+def build_scalar_multiply(name):
+    return ScalarMultiply(name=name)

--- a/paz/models/foundation/gemma4/layers/vision.py
+++ b/paz/models/foundation/gemma4/layers/vision.py
@@ -1,0 +1,229 @@
+import keras
+from keras import ops
+from keras.layers import Dense, EinsumDense, Layer
+
+from paz.models.foundation.gemma4.layers.attention import compute_attention
+from paz.models.foundation.gemma4.layers.normalization import (
+    build_rms_norm, build_v_norm)
+
+
+@keras.saving.register_keras_serializable(package="gemma4")
+class ClippableEinsumDense(Layer):
+    """EinsumDense whose input and output are clipped to learned ranges.
+
+    Matches keras_hub's Gemma4ClippableEinsumDense (Gemma4 vision). The clip
+    buffers default to +-65504 (no clipping) and are loaded from a checkpoint.
+    """
+
+    def __init__(self, equation, output_shape, **kwargs):
+        super().__init__(**kwargs)
+        self.equation = equation
+        self.target_shape = output_shape
+
+    def get_config(self):
+        config = super().get_config()
+        config["equation"] = self.equation
+        config["output_shape"] = self.target_shape
+        return config
+
+    def build(self, input_shape):
+        self.dense = EinsumDense(
+            self.equation, self.target_shape, dtype=self.dtype, name="dense")
+        self.dense.build(input_shape)
+        bounds = (("input_min", -65504.0), ("input_max", 65504.0),
+                  ("output_min", -65504.0), ("output_max", 65504.0))
+        for name, value in bounds:
+            weight = self.add_weight(
+                name=name, shape=(), trainable=False,
+                initializer=keras.initializers.Constant(value))
+            setattr(self, name, weight)
+        self.built = True
+
+    def call(self, x):
+        x = ops.clip(x, ops.cast(self.input_min, x.dtype),
+                     ops.cast(self.input_max, x.dtype))
+        x = ops.einsum(self.equation, x, self.dense.kernel)
+        return ops.clip(x, ops.cast(self.output_min, x.dtype),
+                        ops.cast(self.output_max, x.dtype))
+
+    def compute_output_shape(self, input_shape):
+        return self.dense.compute_output_shape(input_shape)
+
+
+def build_clippable_einsum_dense(equation, output_shape, dtype, name):
+    return ClippableEinsumDense(equation, output_shape, dtype=dtype, name=name)
+
+
+@keras.saving.register_keras_serializable(package="gemma4")
+class PositionEmbeddingTable(Layer):
+    def __init__(self, count, hidden_dim, **kwargs):
+        super().__init__(**kwargs)
+        self.count = count
+        self.hidden_dim = hidden_dim
+
+    def get_config(self):
+        config = super().get_config()
+        config["count"] = self.count
+        config["hidden_dim"] = self.hidden_dim
+        return config
+
+    def build(self, input_shape):
+        self.table = self.add_weight(
+            name="position_embedding_table",
+            shape=(2, self.count, self.hidden_dim),
+            initializer="ones",
+            trainable=True,
+        )
+        self.built = True
+
+    def call(self, position_ids):
+        clamped = ops.maximum(position_ids, 0)
+        x_embeds = ops.take(self.table[0], clamped[..., 0], axis=0)
+        y_embeds = ops.take(self.table[1], clamped[..., 1], axis=0)
+        embeds = x_embeds + y_embeds
+        is_padding = ops.all(
+            ops.equal(position_ids, -1), axis=-1, keepdims=True)
+        return embeds * (1.0 - ops.cast(is_padding, embeds.dtype))
+
+
+def build_patch_embedder(pixel_values, position_ids, config):
+    pixel_values = 2.0 * (pixel_values - 0.5)
+    projection = Dense(
+        config.hidden_dim, use_bias=False, dtype=config.dtype,
+        name="input_proj")
+    table = PositionEmbeddingTable(
+        config.position_embedding_size, config.hidden_dim,
+        dtype=config.dtype, name="position_embedding_table")
+    return projection(pixel_values) + table(position_ids)
+
+
+def vision_decoder_block(x, mask, position_ids, config, name):
+    epsilon, dtype = config.layer_norm_epsilon, config.dtype
+    residual = x
+    norm_name = "{}_pre_attention_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
+    hidden = vision_attend(hidden, mask, position_ids, config, name)
+    post_name = "{}_post_attention_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
+    x = residual + hidden
+    residual = x
+    pre_ffw_name = "{}_pre_ffw_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, pre_ffw_name)(x)
+    hidden = vision_feedforward(hidden, config, name)
+    post_ffw_name = "{}_post_ffw_norm".format(name)
+    hidden = build_rms_norm(epsilon, dtype, post_ffw_name)(hidden)
+    return residual + hidden
+
+
+def vision_attend(x, mask, position_ids, config, name):
+    attn_name = "{}_attention".format(name)
+    query = vision_project(x, "query", config.num_heads, config, attn_name)
+    key = vision_project(
+        x, "key", config.num_key_value_heads, config, attn_name)
+    value = vision_value(x, config, attn_name)
+    query = apply_vision_rotary_embedding(
+        query, position_ids, config.rope_wavelength)
+    key = apply_vision_rotary_embedding(
+        key, position_ids, config.rope_wavelength)
+    args = (query, key, value, mask, config.num_heads,
+            config.num_key_value_heads, config.head_dim, None, config.dropout,
+            config.dtype, attn_name)
+    output = compute_attention(*args)
+    proj = build_clippable_einsum_dense(
+        "btnh,nhd->btd", (None, x.shape[-1]), config.dtype,
+        "{}_attention_output".format(attn_name))
+    return proj(output)
+
+
+def vision_project(x, role, num_heads, config, name):
+    equation = "btd,ndh->btnh" if role == "query" else "btd,kdh->btkh"
+    shape = (None, num_heads, config.head_dim)
+    proj = build_clippable_einsum_dense(
+        equation, shape, config.dtype, "{}_{}".format(name, role))
+    norm = build_rms_norm(
+        config.layer_norm_epsilon, config.dtype,
+        "{}_{}_norm".format(name, role))
+    return norm(proj(x))
+
+
+def vision_value(x, config, name):
+    shape = (None, config.num_key_value_heads, config.head_dim)
+    proj = build_clippable_einsum_dense(
+        "btd,kdh->btkh", shape, config.dtype, "{}_value".format(name))
+    norm = build_v_norm(
+        config.layer_norm_epsilon, config.dtype, "{}_value_norm".format(name))
+    return norm(proj(x))
+
+
+def vision_feedforward(x, config, name):
+    dtype = config.dtype
+    up_shape = (None, config.intermediate_dim)
+    gate = build_clippable_einsum_dense(
+        "btd,df->btf", up_shape, dtype, "{}_ffw_gating".format(name))(x)
+    value = build_clippable_einsum_dense(
+        "btd,df->btf", up_shape, dtype, "{}_ffw_gating_2".format(name))(x)
+    hidden = keras.activations.gelu(gate, approximate=True) * value
+    return build_clippable_einsum_dense(
+        "btf,fd->btd", (None, config.hidden_dim), dtype,
+        "{}_ffw_linear".format(name))(hidden)
+
+
+def apply_vision_rotary_embedding(inputs, position_ids, wavelength):
+    half_head = inputs.shape[-1] // 2
+    first_half = inputs[..., :half_head]
+    second_half = inputs[..., half_head:]
+    x_rotated = rotate_axis(first_half, position_ids[..., 0], wavelength)
+    y_rotated = rotate_axis(second_half, position_ids[..., 1], wavelength)
+    return ops.concatenate((x_rotated, y_rotated), axis=-1)
+
+
+def rotate_axis(part, ids, wavelength):
+    dim = part.shape[-1]
+    index = ops.arange(0, dim, 2, dtype="float32")
+    inverse = ops.power(ops.cast(wavelength, "float32"), -index / dim)
+    angles = ops.einsum("bi,j->bij", ops.cast(ids, "float32"), inverse)
+    angles = ops.concatenate((angles, angles), axis=-1)
+    cosine = ops.cast(ops.expand_dims(ops.cos(angles), axis=2), part.dtype)
+    sine = ops.cast(ops.expand_dims(ops.sin(angles), axis=2), part.dtype)
+    first, second = ops.split(part, 2, axis=-1)
+    rotated = ops.concatenate((-second, first), axis=-1)
+    return part * cosine + rotated * sine
+
+
+def build_vision_attention_mask(position_ids):
+    # Mask only keys (padding patches); queries stay unmasked, matching HF.
+    # Shape (batch, 1, keys) broadcasts over query positions in the softmax.
+    valid = ops.any(ops.not_equal(position_ids, -1), axis=-1)
+    return ops.expand_dims(valid, axis=1)
+
+
+def build_real_patch_mask(position_ids):
+    valid = ops.any(ops.not_equal(position_ids, -1), axis=-1, keepdims=True)
+    return ops.cast(valid, "float32")
+
+
+def build_average_pooling(hidden, position_ids, config):
+    # hidden (images, max_patches, dim). The pooled-grid width is derived from
+    # the patch positions, so rectangular/padded images pool correctly.
+    k = config.pool_size
+    pooled_length = config.max_patches // (k * k)
+    clamped = ops.maximum(position_ids, 0)
+    kernel_x = clamped[..., 0] // k
+    kernel_y = clamped[..., 1] // k
+    width = (ops.max(clamped[..., 0]) + 1) // k
+    kernel_index = kernel_x + width * kernel_y
+    is_padding = ops.all(ops.equal(position_ids, -1), axis=-1, keepdims=True)
+    hidden = hidden * (1.0 - ops.cast(is_padding, hidden.dtype))
+    weights = ops.cast(ops.one_hot(kernel_index, pooled_length), hidden.dtype)
+    weights = weights / ops.cast(k * k, hidden.dtype)
+    pooled = ops.matmul(ops.transpose(weights, (0, 2, 1)), hidden)
+    scale = ops.cast(float(config.hidden_dim) ** 0.5, hidden.dtype)
+    return pooled * scale
+
+
+def build_vision_output(hidden, config):
+    epsilon, dtype = config.layer_norm_epsilon, config.dtype
+    hidden = build_v_norm(epsilon, dtype, "output_norm")(hidden)
+    return Dense(
+        config.output_dim, use_bias=False, dtype=dtype,
+        name="vision_input_projection")(hidden)

--- a/paz/models/foundation/gemma4/layers/vision.py
+++ b/paz/models/foundation/gemma4/layers/vision.py
@@ -97,65 +97,66 @@ def build_patch_embedder(pixel_values, position_ids, config):
     return projection(pixel_values) + table(position_ids)
 
 
-def vision_decoder_block(x, mask, position_ids, config, name):
+def build_vision_decoder_block(x, mask, position_ids, config, name):
     epsilon, dtype = config.layer_norm_epsilon, config.dtype
     residual = x
     norm_name = "{}_pre_attention_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
-    hidden = vision_attend(hidden, mask, position_ids, config, name)
+    hidden = build_vision_attention(hidden, mask, position_ids, config, name)
     post_name = "{}_post_attention_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
     x = residual + hidden
     residual = x
     pre_ffw_name = "{}_pre_ffw_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, pre_ffw_name)(x)
-    hidden = vision_feedforward(hidden, config, name)
+    hidden = build_vision_feedforward(hidden, config, name)
     post_ffw_name = "{}_post_ffw_norm".format(name)
     hidden = build_rms_norm(epsilon, dtype, post_ffw_name)(hidden)
     return residual + hidden
 
 
-def vision_attend(x, mask, position_ids, config, name):
-    attn_name = "{}_attention".format(name)
-    query = vision_project(x, "query", config.num_heads, config, attn_name)
-    key = vision_project(
-        x, "key", config.num_key_value_heads, config, attn_name)
-    value = vision_value(x, config, attn_name)
+def build_vision_attention(x, mask, position_ids, config, name):
+    attention_name = "{}_attention".format(name)
+    query = build_vision_projection(
+        x, "query", config.num_heads, config, attention_name)
+    key = build_vision_projection(
+        x, "key", config.num_key_value_heads, config, attention_name)
+    value = build_vision_value(x, config, attention_name)
     query = apply_vision_rotary_embedding(
         query, position_ids, config.rope_wavelength)
     key = apply_vision_rotary_embedding(
         key, position_ids, config.rope_wavelength)
     args = (query, key, value, mask, config.num_heads,
             config.num_key_value_heads, config.head_dim, None, config.dropout,
-            config.dtype, attn_name)
+            config.dtype, attention_name)
     output = compute_attention(*args)
-    proj = build_clippable_einsum_dense(
+    projection = build_clippable_einsum_dense(
         "btnh,nhd->btd", (None, x.shape[-1]), config.dtype,
-        "{}_attention_output".format(attn_name))
-    return proj(output)
+        "{}_attention_output".format(attention_name))
+    return projection(output)
 
 
-def vision_project(x, role, num_heads, config, name):
+def build_vision_projection(x, role, num_heads, config, name):
     equation = "btd,ndh->btnh" if role == "query" else "btd,kdh->btkh"
     shape = (None, num_heads, config.head_dim)
-    proj = build_clippable_einsum_dense(
+    projection = build_clippable_einsum_dense(
         equation, shape, config.dtype, "{}_{}".format(name, role))
     norm = build_rms_norm(
         config.layer_norm_epsilon, config.dtype,
         "{}_{}_norm".format(name, role))
-    return norm(proj(x))
+    return norm(projection(x))
 
 
-def vision_value(x, config, name):
+def build_vision_value(x, config, name):
     shape = (None, config.num_key_value_heads, config.head_dim)
-    proj = build_clippable_einsum_dense(
+    projection = build_clippable_einsum_dense(
         "btd,kdh->btkh", shape, config.dtype, "{}_value".format(name))
     norm = build_v_norm(
         config.layer_norm_epsilon, config.dtype, "{}_value_norm".format(name))
-    return norm(proj(x))
+    return norm(projection(x))
 
 
-def vision_feedforward(x, config, name):
+def build_vision_feedforward(x, config, name):
     dtype = config.dtype
     up_shape = (None, config.intermediate_dim)
     gate = build_clippable_einsum_dense(
@@ -205,17 +206,17 @@ def build_real_patch_mask(position_ids):
 def build_average_pooling(hidden, position_ids, config):
     # hidden (images, max_patches, dim). The pooled-grid width is derived from
     # the patch positions, so rectangular/padded images pool correctly.
-    k = config.pool_size
-    pooled_length = config.max_patches // (k * k)
+    pool = config.pool_size
+    pooled_length = config.max_patches // (pool * pool)
     clamped = ops.maximum(position_ids, 0)
-    kernel_x = clamped[..., 0] // k
-    kernel_y = clamped[..., 1] // k
-    width = (ops.max(clamped[..., 0]) + 1) // k
+    kernel_x = clamped[..., 0] // pool
+    kernel_y = clamped[..., 1] // pool
+    width = (ops.max(clamped[..., 0]) + 1) // pool
     kernel_index = kernel_x + width * kernel_y
     is_padding = ops.all(ops.equal(position_ids, -1), axis=-1, keepdims=True)
     hidden = hidden * (1.0 - ops.cast(is_padding, hidden.dtype))
     weights = ops.cast(ops.one_hot(kernel_index, pooled_length), hidden.dtype)
-    weights = weights / ops.cast(k * k, hidden.dtype)
+    weights = weights / ops.cast(pool * pool, hidden.dtype)
     pooled = ops.matmul(ops.transpose(weights, (0, 2, 1)), hidden)
     scale = ops.cast(float(config.hidden_dim) ** 0.5, hidden.dtype)
     return pooled * scale

--- a/paz/models/foundation/gemma4/model.py
+++ b/paz/models/foundation/gemma4/model.py
@@ -1,0 +1,360 @@
+from collections import namedtuple
+from pathlib import Path
+
+from keras import Model, ops
+from keras.initializers import VarianceScaling
+from keras.layers import Embedding, EinsumDense, Input
+from keras_hub.layers import ReversibleEmbedding
+
+from paz.models.foundation.gemma4.layers.decoder import decoder_block
+from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
+
+BACKBONE_NAME = "gemma4_text_backbone"
+GEMMA4_WEIGHTS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.24/"  # fmt: skip
+Gemma4Models = namedtuple(
+    "Gemma4", "config decoder_step per_layer_step vision_encoder")
+TEXT_BACKBONE_FIELDS = (
+    "vocabulary_size image_size num_layers num_query_heads "
+    "num_key_value_heads hidden_dim intermediate_dim head_dim "
+    "attention_logit_soft_cap final_logit_soft_cap "
+    "use_sliding_window_attention sliding_window_size "
+    "sliding_window_pattern global_head_dim "
+    "local_rope_wavelength global_rope_wavelength "
+    "local_rope_scaling_factor global_rope_scaling_factor "
+    "global_rope_partial_rotary_factor "
+    "use_bidirectional_attention layer_norm_epsilon dropout dtype "
+    "hidden_size_per_layer_input num_kv_shared_layers global_layer_indices "
+    "use_double_wide_mlp"
+)
+TextBackboneArgs = namedtuple("TextBackboneArgs", TEXT_BACKBONE_FIELDS)
+TextIntermediates = namedtuple(
+    "TextIntermediates",
+    "embedding_output block_outputs final_output",
+)
+
+
+def Gemma4(model_name="gemma4_2b", weights="paz", models_path=None):
+    model_dir = resolve_gemma4_dir(model_name, models_path)
+    config = read_gemma4_config(model_dir)
+    decoder_step = build_gemma4_decoder_step(config)
+    per_layer_step = build_gemma4_per_layer_step(config)
+    vision_encoder = build_gemma4_vision_encoder(model_dir)
+    if weights is not None:
+        args = (model_dir, decoder_step, per_layer_step, vision_encoder)
+        load_gemma4_weights(*args)
+    return Gemma4Models(config, decoder_step, per_layer_step, vision_encoder)
+
+
+def resolve_gemma4_dir(model_name, models_path):
+    if models_path is not None:
+        return Path(models_path)
+    message = ("Gemma4 weights for '{}' are not hosted yet; pass models_path "
+               "to a local weights directory.").format(model_name)
+    raise ValueError(message)
+
+
+def read_gemma4_config(model_dir):
+    from paz.models.foundation.gemma4.configuration import load_config
+    return load_config(Path(model_dir) / "config.json")
+
+
+def build_gemma4_decoder_step(config):
+    from paz.models.foundation.gemma4.inference import (
+        Gemma4MultimodalDecoderStep)
+    return Gemma4MultimodalDecoderStep(config)
+
+
+def build_gemma4_per_layer_step(config):
+    if not config.hidden_size_per_layer_input:
+        return None
+    from paz.models.foundation.gemma4.inference import (
+        Gemma4PerLayerEmbeddingStep)
+    return Gemma4PerLayerEmbeddingStep(config)
+
+
+def build_gemma4_vision_encoder(model_dir):
+    import json
+    from paz.models.foundation.gemma4.vision import (
+        VisionEncoderArgs, build_vision_encoder)
+    path = Path(model_dir) / "vision_config.json"
+    if not path.exists():
+        return None
+    with open(str(path), encoding="utf-8") as file:
+        config = VisionEncoderArgs(**json.load(file))
+    return build_vision_encoder(config)
+
+
+def load_gemma4_weights(model_dir, decoder_step, per_layer_step,
+                        vision_encoder):
+    model_dir = Path(model_dir)
+    decoder_step.load_weights(str(model_dir / "decoder_step.weights.h5"))
+    if per_layer_step is not None:
+        per_layer_step.load_weights(
+            str(model_dir / "embedding_step.weights.h5"))
+    if vision_encoder is not None:
+        vision_encoder.load_weights(
+            str(model_dir / "vision_encoder.weights.h5"))
+
+
+def build_text_backbone_args(**overrides):
+    values = {
+        "vocabulary_size": 256,
+        "image_size": 8,
+        "num_layers": 2,
+        "num_query_heads": 2,
+        "num_key_value_heads": 1,
+        "hidden_dim": 8,
+        "intermediate_dim": 16,
+        "head_dim": 4,
+        "attention_logit_soft_cap": None,
+        "final_logit_soft_cap": None,
+        "use_sliding_window_attention": True,
+        "sliding_window_size": 16,
+        "sliding_window_pattern": 6,
+        "global_head_dim": None,
+        "local_rope_wavelength": 10_000.0,
+        "global_rope_wavelength": 1_000_000.0,
+        "local_rope_scaling_factor": 1.0,
+        "global_rope_scaling_factor": 1.0,
+        "global_rope_partial_rotary_factor": 1.0,
+        "use_bidirectional_attention": False,
+        "layer_norm_epsilon": 1e-6,
+        "dropout": 0.0,
+        "dtype": "float32",
+        "hidden_size_per_layer_input": None,
+        "num_kv_shared_layers": 0,
+        "global_layer_indices": None,
+        "use_double_wide_mlp": False,
+    }
+    values.update(overrides)
+    return TextBackboneArgs(**values)
+
+
+def build_text_backbone(config, weights_path=None, name=BACKBONE_NAME):
+    token_embedding = build_token_embedding(
+        config.vocabulary_size, config.hidden_dim, config.dtype)
+    token_ids = Input((None,), dtype="int32", name="token_ids")
+    padding_mask = Input((None,), dtype="int32", name="padding_mask")
+    embedding = token_embedding(token_ids)
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    return build_backbone_from_embedding(
+        embedding, token_ids, padding_mask, inputs, config, name, weights_path)
+
+
+def build_backbone_from_embedding(embedding, token_ids, padding_mask, inputs,
+                                  config, name, weights_path=None):
+    hidden = scale_token_embeddings(embedding, config.hidden_dim)
+    embedding_output = hidden
+    per_layer = build_backbone_per_layer_embeddings(
+        config, token_ids, embedding)
+    kv_source = build_kv_source_map(config)
+    block_outputs, layer_kvs = [], []
+    for layer_index in range(config.num_layers):
+        block_name = "decoder_block_{}".format(layer_index)
+        source = kv_source.get(layer_index)
+        shared_kv = layer_kvs[source] if source is not None else None
+        args = (hidden, padding_mask, config, layer_index, block_name)
+        kwargs = {"per_layer_embedding": per_layer[layer_index],
+                  "shared_kv": shared_kv}
+        hidden, kv = decoder_block(*args, **kwargs)
+        block_outputs.append(hidden)
+        layer_kvs.append(kv)
+    norm_args = (config.layer_norm_epsilon, config.dtype,
+                 "final_normalization")
+    final_output = build_rms_norm(*norm_args)(hidden)
+    model = Model(inputs, final_output, name=name)
+    attach_intermediates(model, embedding_output, block_outputs, final_output)
+    if weights_path is not None:
+        model.load_weights(str(Path(weights_path)))
+    return model
+
+
+def build_backbone_per_layer_embeddings(config, token_ids, token_embedding):
+    if not config.hidden_size_per_layer_input:
+        return [None] * config.num_layers
+    p = config.hidden_size_per_layer_input
+    embedding = build_per_layer_embedding(
+        config.vocabulary_size, p * config.num_layers, config.dtype)
+    full_embedding = embedding(token_ids)
+    full_embedding = scale_per_layer_embedding(full_embedding, p, config.dtype)
+    projection = build_per_layer_model_projection(
+        token_embedding, config.num_layers, p, config.dtype)
+    args = (projection, full_embedding, config.num_layers, p,
+            config.layer_norm_epsilon, config.dtype)
+    return build_per_layer_combined_inputs(*args)
+
+
+def scale_per_layer_embedding(full_embedding, per_layer_dim, dtype):
+    scale = ops.cast(float(per_layer_dim) ** 0.5, dtype)
+    return ops.cast(full_embedding, dtype) * scale
+
+
+def attach_intermediates(model, embedding_output, block_outputs, final_output):
+    model._embedding_output = embedding_output
+    model._block_outputs = tuple(block_outputs)
+    model._final_output = final_output
+
+
+def compute_text_intermediates(model, token_ids, padding_mask):
+    outputs = [model._embedding_output]
+    outputs.extend(model._block_outputs)
+    outputs.append(model._final_output)
+    debug = Model(model.input, outputs, name="debug_intermediates")
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    results = debug(inputs)
+    embedding_output = results[0]
+    block_outputs = tuple(results[1:-1])
+    final_output = results[-1]
+    return TextIntermediates(embedding_output, block_outputs, final_output)
+
+
+def build_token_embedding(vocabulary_size, hidden_dim, dtype):
+    initializer = VarianceScaling(1.0, "fan_in", "untruncated_normal")
+    keys = ("tie_weights", "embeddings_initializer", "dtype", "name")
+    values = (True, initializer, dtype, "token_embedding")
+    kwargs = dict(zip(keys, values))
+    return ReversibleEmbedding(vocabulary_size, hidden_dim, **kwargs)
+
+
+def scale_token_embeddings(hidden, hidden_dim):
+    scale = ops.cast(hidden_dim ** 0.5, hidden.dtype)
+    return hidden * scale
+
+
+def build_per_layer_embedding(vocabulary_size, dim, dtype):
+    # Use zeros initializer to avoid a large float32 temporary buffer
+    # during construction (relevant when vocab_size is large).
+    # Pre-trained weights are always loaded from file, so the initial
+    # values do not matter.
+    return Embedding(vocabulary_size, dim, dtype=dtype,
+                     embeddings_initializer="zeros",
+                     name="per_layer_embeddings")
+
+
+def slice_per_layer(tensor, layer_index, per_layer_dim):
+    start = layer_index * per_layer_dim
+    end = (layer_index + 1) * per_layer_dim
+    return tensor[..., start:end]
+
+
+def build_per_layer_model_projection(hidden, num_layers, per_layer_dim, dtype):
+    """Project initial hidden state to (num_layers * per_layer_dim) dimensions.
+
+    This is the 'model projection' component of the per-layer input — it
+    provides a context-dependent conditioning signal derived from the scaled
+    token embedding (before any decoder blocks).
+    """
+    n = num_layers * per_layer_dim
+    eq = "btd,dn->btn"
+    name = "per_layer_model_projection"
+    proj = EinsumDense(eq, (None, n), dtype=dtype, name=name)
+    return proj(hidden)
+
+
+def combine_projection_and_embedding(projection, embedding, scale):
+    return (projection + embedding) * scale
+
+
+def build_per_layer_combined_inputs(projection_full, embedding_full,
+                                     num_layers, per_layer_dim,
+                                     epsilon, dtype):
+    """Combine per-layer projection and token embedding.
+
+    For each layer i:
+        per_layer_i = (rms_norm(proj_i) + embedding_i) * 2^-0.5
+
+    The projection norm is shared across all layers.
+    """
+    proj_norm = build_rms_norm(
+        epsilon, dtype, "per_layer_projection_norm")
+    scale = ops.cast(2 ** -0.5, dtype)
+    inputs = []
+    for i in range(num_layers):
+        proj_i = slice_per_layer(projection_full, i, per_layer_dim)
+        embedding_i = slice_per_layer(
+            embedding_full, i, per_layer_dim)
+        proj_i_normed = proj_norm(proj_i)
+        combined = combine_projection_and_embedding(
+            proj_i_normed, embedding_i, scale)
+        inputs.append(combined)
+    return inputs
+
+
+def build_cache_head_dim(config):
+    if config.global_head_dim is not None:
+        return config.global_head_dim
+    return config.head_dim
+
+
+def is_global_attention_layer(config, layer_index):
+    if config.global_layer_indices is not None:
+        return layer_index in config.global_layer_indices
+    pattern_index = layer_index % config.sliding_window_pattern
+    return pattern_index == config.sliding_window_pattern - 1
+
+
+def is_kv_shared_layer(config, layer_index):
+    if not config.num_kv_shared_layers:
+        return False
+    return layer_index >= config.num_layers - config.num_kv_shared_layers
+
+
+def build_kv_source_map(config):
+    """Map each kv_shared layer index to its K/V source layer index.
+
+    Returns a dict {layer_index: source_index} for kv_shared layers only.
+    Mirrors the keras-hub backbone precomputation of _kv_source.
+    """
+    num_kv_shared = config.num_kv_shared_layers
+    if not num_kv_shared:
+        return {}
+    first_shared = config.num_layers - num_kv_shared
+    non_shared_types = [
+        "global" if is_global_attention_layer(config, j) else "local"
+        for j in range(first_shared)
+    ]
+    kv_source = {}
+    for j in range(first_shared, config.num_layers):
+        is_global = is_global_attention_layer(config, j)
+        layer_type = "global" if is_global else "local"
+        for k in range(len(non_shared_types) - 1, -1, -1):
+            if non_shared_types[k] == layer_type:
+                kv_source[j] = k
+                break
+    return kv_source
+
+
+def build_feedforward_dim(config, layer_index):
+    double_wide = config.use_double_wide_mlp and is_kv_shared_layer(
+        config, layer_index)
+    if double_wide:
+        return config.intermediate_dim * 2
+    return config.intermediate_dim
+
+
+def build_head_dim(config, is_global):
+    if is_global and config.global_head_dim is not None:
+        return config.global_head_dim
+    return config.head_dim
+
+
+def use_sliding_window(config, is_global):
+    return config.use_sliding_window_attention and not is_global
+
+
+def build_rope_wavelength(config, is_global):
+    if is_global:
+        return config.global_rope_wavelength
+    return config.local_rope_wavelength
+
+
+def build_rope_scaling_factor(config, is_global):
+    if is_global:
+        return config.global_rope_scaling_factor
+    return config.local_rope_scaling_factor
+
+
+def build_partial_rotary_factor(config, is_global):
+    if is_global:
+        return config.global_rope_partial_rotary_factor
+    return 1.0

--- a/paz/models/foundation/gemma4/model.py
+++ b/paz/models/foundation/gemma4/model.py
@@ -6,94 +6,14 @@ from keras.initializers import VarianceScaling
 from keras.layers import Embedding, EinsumDense, Input
 from keras_hub.layers import ReversibleEmbedding
 
+from paz.models.foundation.gemma4.configuration import TextBackboneArgs
+from paz.models.foundation.gemma4.configuration import build_kv_source_map
 from paz.models.foundation.gemma4.layers.decoder import decoder_block
 from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
 
 BACKBONE_NAME = "gemma4_text_backbone"
-GEMMA4_WEIGHTS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.24/"  # fmt: skip
-Gemma4Models = namedtuple(
-    "Gemma4", "config decoder_step per_layer_step vision_encoder")
-TEXT_BACKBONE_FIELDS = (
-    "vocabulary_size image_size num_layers num_query_heads "
-    "num_key_value_heads hidden_dim intermediate_dim head_dim "
-    "attention_logit_soft_cap final_logit_soft_cap "
-    "use_sliding_window_attention sliding_window_size "
-    "sliding_window_pattern global_head_dim "
-    "local_rope_wavelength global_rope_wavelength "
-    "local_rope_scaling_factor global_rope_scaling_factor "
-    "global_rope_partial_rotary_factor "
-    "use_bidirectional_attention layer_norm_epsilon dropout dtype "
-    "hidden_size_per_layer_input num_kv_shared_layers global_layer_indices "
-    "use_double_wide_mlp"
-)
-TextBackboneArgs = namedtuple("TextBackboneArgs", TEXT_BACKBONE_FIELDS)
 TextIntermediates = namedtuple(
-    "TextIntermediates",
-    "embedding_output block_outputs final_output",
-)
-
-
-def Gemma4(model_name="gemma4_2b", weights="paz", models_path=None):
-    model_dir = resolve_gemma4_dir(model_name, models_path)
-    config = read_gemma4_config(model_dir)
-    decoder_step = build_gemma4_decoder_step(config)
-    per_layer_step = build_gemma4_per_layer_step(config)
-    vision_encoder = build_gemma4_vision_encoder(model_dir)
-    if weights is not None:
-        args = (model_dir, decoder_step, per_layer_step, vision_encoder)
-        load_gemma4_weights(*args)
-    return Gemma4Models(config, decoder_step, per_layer_step, vision_encoder)
-
-
-def resolve_gemma4_dir(model_name, models_path):
-    if models_path is not None:
-        return Path(models_path)
-    message = ("Gemma4 weights for '{}' are not hosted yet; pass models_path "
-               "to a local weights directory.").format(model_name)
-    raise ValueError(message)
-
-
-def read_gemma4_config(model_dir):
-    from paz.models.foundation.gemma4.configuration import load_config
-    return load_config(Path(model_dir) / "config.json")
-
-
-def build_gemma4_decoder_step(config):
-    from paz.models.foundation.gemma4.inference import (
-        Gemma4MultimodalDecoderStep)
-    return Gemma4MultimodalDecoderStep(config)
-
-
-def build_gemma4_per_layer_step(config):
-    if not config.hidden_size_per_layer_input:
-        return None
-    from paz.models.foundation.gemma4.inference import (
-        Gemma4PerLayerEmbeddingStep)
-    return Gemma4PerLayerEmbeddingStep(config)
-
-
-def build_gemma4_vision_encoder(model_dir):
-    import json
-    from paz.models.foundation.gemma4.vision import (
-        VisionEncoderArgs, build_vision_encoder)
-    path = Path(model_dir) / "vision_config.json"
-    if not path.exists():
-        return None
-    with open(str(path), encoding="utf-8") as file:
-        config = VisionEncoderArgs(**json.load(file))
-    return build_vision_encoder(config)
-
-
-def load_gemma4_weights(model_dir, decoder_step, per_layer_step,
-                        vision_encoder):
-    model_dir = Path(model_dir)
-    decoder_step.load_weights(str(model_dir / "decoder_step.weights.h5"))
-    if per_layer_step is not None:
-        per_layer_step.load_weights(
-            str(model_dir / "embedding_step.weights.h5"))
-    if vision_encoder is not None:
-        vision_encoder.load_weights(
-            str(model_dir / "vision_encoder.weights.h5"))
+    "TextIntermediates", "embedding_output block_outputs final_output")
 
 
 def build_text_backbone_args(**overrides):
@@ -244,11 +164,12 @@ def build_per_layer_model_projection(hidden, num_layers, per_layer_dim, dtype):
     provides a context-dependent conditioning signal derived from the scaled
     token embedding (before any decoder blocks).
     """
-    n = num_layers * per_layer_dim
-    eq = "btd,dn->btn"
+    combined_dim = num_layers * per_layer_dim
+    equation = "btd,dn->btn"
     name = "per_layer_model_projection"
-    proj = EinsumDense(eq, (None, n), dtype=dtype, name=name)
-    return proj(hidden)
+    projection = EinsumDense(
+        equation, (None, combined_dim), dtype=dtype, name=name)
+    return projection(hidden)
 
 
 def combine_projection_and_embedding(projection, embedding, scale):
@@ -265,96 +186,15 @@ def build_per_layer_combined_inputs(projection_full, embedding_full,
 
     The projection norm is shared across all layers.
     """
-    proj_norm = build_rms_norm(
+    projection_norm = build_rms_norm(
         epsilon, dtype, "per_layer_projection_norm")
     scale = ops.cast(2 ** -0.5, dtype)
     inputs = []
-    for i in range(num_layers):
-        proj_i = slice_per_layer(projection_full, i, per_layer_dim)
-        embedding_i = slice_per_layer(
-            embedding_full, i, per_layer_dim)
-        proj_i_normed = proj_norm(proj_i)
-        combined = combine_projection_and_embedding(
-            proj_i_normed, embedding_i, scale)
+    for layer_index in range(num_layers):
+        projection = slice_per_layer(
+            projection_full, layer_index, per_layer_dim)
+        embedding = slice_per_layer(embedding_full, layer_index, per_layer_dim)
+        normed = projection_norm(projection)
+        combined = combine_projection_and_embedding(normed, embedding, scale)
         inputs.append(combined)
     return inputs
-
-
-def build_cache_head_dim(config):
-    if config.global_head_dim is not None:
-        return config.global_head_dim
-    return config.head_dim
-
-
-def is_global_attention_layer(config, layer_index):
-    if config.global_layer_indices is not None:
-        return layer_index in config.global_layer_indices
-    pattern_index = layer_index % config.sliding_window_pattern
-    return pattern_index == config.sliding_window_pattern - 1
-
-
-def is_kv_shared_layer(config, layer_index):
-    if not config.num_kv_shared_layers:
-        return False
-    return layer_index >= config.num_layers - config.num_kv_shared_layers
-
-
-def build_kv_source_map(config):
-    """Map each kv_shared layer index to its K/V source layer index.
-
-    Returns a dict {layer_index: source_index} for kv_shared layers only.
-    Mirrors the keras-hub backbone precomputation of _kv_source.
-    """
-    num_kv_shared = config.num_kv_shared_layers
-    if not num_kv_shared:
-        return {}
-    first_shared = config.num_layers - num_kv_shared
-    non_shared_types = [
-        "global" if is_global_attention_layer(config, j) else "local"
-        for j in range(first_shared)
-    ]
-    kv_source = {}
-    for j in range(first_shared, config.num_layers):
-        is_global = is_global_attention_layer(config, j)
-        layer_type = "global" if is_global else "local"
-        for k in range(len(non_shared_types) - 1, -1, -1):
-            if non_shared_types[k] == layer_type:
-                kv_source[j] = k
-                break
-    return kv_source
-
-
-def build_feedforward_dim(config, layer_index):
-    double_wide = config.use_double_wide_mlp and is_kv_shared_layer(
-        config, layer_index)
-    if double_wide:
-        return config.intermediate_dim * 2
-    return config.intermediate_dim
-
-
-def build_head_dim(config, is_global):
-    if is_global and config.global_head_dim is not None:
-        return config.global_head_dim
-    return config.head_dim
-
-
-def use_sliding_window(config, is_global):
-    return config.use_sliding_window_attention and not is_global
-
-
-def build_rope_wavelength(config, is_global):
-    if is_global:
-        return config.global_rope_wavelength
-    return config.local_rope_wavelength
-
-
-def build_rope_scaling_factor(config, is_global):
-    if is_global:
-        return config.global_rope_scaling_factor
-    return config.local_rope_scaling_factor
-
-
-def build_partial_rotary_factor(config, is_global):
-    if is_global:
-        return config.global_rope_partial_rotary_factor
-    return 1.0

--- a/paz/models/foundation/gemma4/model_test.py
+++ b/paz/models/foundation/gemma4/model_test.py
@@ -1,0 +1,66 @@
+import jax.numpy as jp
+
+from paz.models.foundation.gemma4.model import (
+    build_text_backbone, build_text_backbone_args, compute_text_intermediates)
+
+
+def build_test_inputs():
+    token_ids = jp.array([[1, 2, 3, 4, 0], [5, 6, 7, 0, 0]], dtype=jp.int32)
+    padding_mask = jp.array([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]], dtype=jp.int32)
+    return token_ids, padding_mask
+
+
+def assert_close(left, right, tol=1e-6):
+    diff = jp.max(jp.abs(left - right))
+    assert float(diff) <= tol
+
+
+def test_runtime_backbone_builds_successfully():
+    config = build_text_backbone_args()
+    model = build_text_backbone(config)
+    token_ids, padding_mask = build_test_inputs()
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    outputs = model(inputs)
+    assert outputs.shape == (2, 5, config.hidden_dim)
+
+
+def test_runtime_backbone_save_and_load(tmp_path):
+    config = build_text_backbone_args()
+    model = build_text_backbone(config)
+    token_ids, padding_mask = build_test_inputs()
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    output = model(inputs)
+    path = tmp_path / "gemma4_text_backbone.weights.h5"
+    model.save_weights(str(path))
+    loaded = build_text_backbone(config, weights_path=path)
+    assert_close(output, loaded(inputs))
+
+
+def test_runtime_backbone_exposes_intermediates():
+    config = build_text_backbone_args()
+    model = build_text_backbone(config)
+    token_ids, padding_mask = build_test_inputs()
+    data = compute_text_intermediates(model, token_ids, padding_mask)
+    assert data.embedding_output.shape == (2, 5, config.hidden_dim)
+    assert len(data.block_outputs) == config.num_layers
+    assert data.final_output.shape == (2, 5, config.hidden_dim)
+
+
+def test_runtime_backbone_supports_per_layer_inputs():
+    config = build_text_backbone_args(hidden_size_per_layer_input=2)
+    model = build_text_backbone(config)
+    token_ids, padding_mask = build_test_inputs()
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    outputs = model(inputs)
+    assert outputs.shape == (2, 5, config.hidden_dim)
+
+
+def test_runtime_backbone_runs_global_partial_rope():
+    config = build_text_backbone_args(
+        num_layers=6, sliding_window_pattern=3, head_dim=16,
+        global_head_dim=16, global_rope_partial_rotary_factor=0.25)
+    model = build_text_backbone(config)
+    token_ids, padding_mask = build_test_inputs()
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    outputs = model(inputs)
+    assert outputs.shape == (2, 5, config.hidden_dim)

--- a/paz/models/foundation/gemma4/multimodal.py
+++ b/paz/models/foundation/gemma4/multimodal.py
@@ -1,0 +1,74 @@
+"""Multimodal (text + vision) Gemma4 backbone.
+
+Places image embeddings from the vision encoder into the token-embedding
+sequence at the image-placeholder positions, then runs the text decoder stack.
+Mirrors keras_hub Gemma4Backbone's interleaving: image embeddings are pre-scaled
+by hidden_dim**-0.5 and the global sqrt(hidden_dim) scale is applied after
+interleaving (so image positions keep their natural magnitude).
+"""
+from keras import ops
+from keras.layers import Input, Lambda
+
+from paz.models.foundation.gemma4.model import (
+    build_backbone_from_embedding, build_token_embedding)
+from paz.models.foundation.gemma4.vision import (
+    build_vision_encoder, num_patches)
+
+MULTIMODAL_NAME = "gemma4_multimodal_backbone"
+
+
+def build_multimodal_backbone(config, vision_config, weights_path=None,
+                              name=MULTIMODAL_NAME):
+    token_embedding = build_token_embedding(
+        config.vocabulary_size, config.hidden_dim, config.dtype)
+    token_ids = Input((None,), dtype="int32", name="token_ids")
+    padding_mask = Input((None,), dtype="int32", name="padding_mask")
+    patch_dim = 3 * vision_config.patch_size ** 2
+    pixel_values = Input(
+        (num_patches(vision_config), patch_dim), name="pixel_values")
+    pixel_position_ids = Input(
+        (num_patches(vision_config), 2), dtype="int32",
+        name="pixel_position_ids")
+    vision_indices = Input((None,), dtype="int32", name="vision_indices")
+    embedding = build_image_text_embedding(
+        token_embedding(token_ids), pixel_values, pixel_position_ids,
+        vision_indices, vision_config, config.hidden_dim)
+    inputs = {"token_ids": token_ids, "padding_mask": padding_mask,
+              "pixel_values": pixel_values,
+              "pixel_position_ids": pixel_position_ids,
+              "vision_indices": vision_indices}
+    return build_backbone_from_embedding(
+        embedding, token_ids, padding_mask, inputs, config, name, weights_path)
+
+
+def build_image_text_embedding(text_embedding, pixel_values,
+                               pixel_position_ids, vision_indices,
+                               vision_config, hidden_dim):
+    vision = build_vision_encoder(vision_config)
+    images = vision({"pixel_values": pixel_values,
+                     "pixel_position_ids": pixel_position_ids})
+    images = images * ops.cast(float(hidden_dim) ** -0.5, images.dtype)
+    images = ops.expand_dims(images, axis=1)
+    return build_interleave(images, text_embedding, vision_indices)
+
+
+def interleave_embeddings(image_embeddings, text_embeddings, vision_indices):
+    batch, seq, dim = ops.shape(text_embeddings)
+    num_images = ops.shape(image_embeddings)[1]
+    num_patches = ops.shape(image_embeddings)[2]
+    flat_text = ops.reshape(text_embeddings, (batch * seq, dim))
+    offset = ops.expand_dims(ops.arange(batch, dtype="int32") * seq, axis=-1)
+    valid = vision_indices[:, : num_images * num_patches]
+    flat_image = ops.reshape(image_embeddings, (-1, dim))
+    indices = ops.cast(ops.reshape(valid + offset, (-1, 1)), "int32")
+    zeroth = ops.take(flat_text, ops.squeeze(offset, axis=-1), axis=0)
+    updated = ops.scatter_update(flat_text, indices, flat_image)
+    updated = ops.scatter_update(updated, offset, zeroth)
+    return ops.reshape(updated, (batch, seq, dim))
+
+
+def build_interleave(image_embeddings, text_embeddings, vision_indices):
+    dim = text_embeddings.shape[-1]
+    fn = lambda tensors: interleave_embeddings(*tensors)
+    inputs = [image_embeddings, text_embeddings, vision_indices]
+    return Lambda(fn, output_shape=(None, dim), name="interleave")(inputs)

--- a/paz/models/foundation/gemma4/multimodal_decoding.py
+++ b/paz/models/foundation/gemma4/multimodal_decoding.py
@@ -26,7 +26,9 @@ def as_token(token):
 def build_prompt_rows(step_model, vision_embeddings, prompt_ids,
                       vision_indices, per_layer_step):
     embedding = step_model.get_layer("token_embedding")
-    image_position = {int(p): k for k, p in enumerate(vision_indices)}
+    image_position = {}
+    for image_index, position in enumerate(vision_indices):
+        image_position[int(position)] = image_index
     embeds, per_layers = [], []
     for index, token in enumerate(prompt_ids):
         if index in image_position:

--- a/paz/models/foundation/gemma4/multimodal_decoding.py
+++ b/paz/models/foundation/gemma4/multimodal_decoding.py
@@ -1,0 +1,299 @@
+"""Cached image->text generation for Gemma4.
+
+Image embeddings are baked into the KV cache during prefill: each image
+placeholder position is fed its vision embedding (pre-scaled by
+hidden_dim**-0.5) instead of a token embedding, matching keras_hub. The whole
+prompt is prefilled in ONE forward (parallel prefill); decode is then a jitted
+jax.lax.while_loop, mirroring decoding.py's text KVDecoder. Uses
+Gemma4MultimodalDecoderStep, which takes a precomputed input embedding and the
+query positions.
+"""
+import jax
+import jax.numpy as jp
+import numpy as np
+from keras import ops
+
+from paz import call_stateless, snapshot_variables
+
+from paz.models.foundation.gemma4.inference import build_empty_cache
+from paz.models.foundation.gemma4.sampling import sample_logits
+
+
+def as_token(token):
+    return jp.array([[int(token)]], dtype="int32")
+
+
+def build_prompt_rows(step_model, vision_embeddings, prompt_ids,
+                      vision_indices, per_layer_step):
+    embedding = step_model.get_layer("token_embedding")
+    image_position = {int(p): k for k, p in enumerate(vision_indices)}
+    embeds, per_layers = [], []
+    for index, token in enumerate(prompt_ids):
+        if index in image_position:
+            embeds.append(jp.asarray(vision_embeddings[image_position[index]]))
+            per_layers.append(per_layer_row(per_layer_step, 0))
+        else:
+            embeds.append(embedding(as_token(token))[0, 0])
+            per_layers.append(per_layer_row(per_layer_step, token))
+    input_embeddings = jp.stack(embeds)[None]
+    per_layer = None
+    if per_layer_step is not None:
+        per_layer = jp.stack(per_layers)[None]
+    return input_embeddings, per_layer
+
+
+def per_layer_row(per_layer_step, token):
+    # Image positions reuse the pad-token (id 0) per-layer embedding, matching
+    # keras_hub which zeroes the per-layer token ids at vision positions.
+    if per_layer_step is None:
+        return None
+    return per_layer_step(as_token(token))[0, 0]
+
+
+def call_step(step_model, embeds, cache, start, positions, per_layer):
+    index = jp.reshape(jp.asarray(start, dtype="int32"), (1,))
+    inputs = [embeds, cache, index, positions]
+    if per_layer is not None:
+        inputs.append(per_layer)
+    return step_model(inputs)
+
+
+def generate(step_model, per_layer_step, vision_embeddings, config,
+             prompt_ids, vision_indices, stop_id, max_tokens):
+    """Single-sequence jitted greedy generation."""
+    return run_cached_generate(
+        step_model, per_layer_step, vision_embeddings, config, prompt_ids,
+        vision_indices, stop_id, max_tokens, jax.random.PRNGKey(0),
+        select_greedy_token)
+
+
+def generate_eager(step_model, per_layer_step, vision_embeddings, config,
+                   prompt_ids, vision_indices, stop_id, max_tokens):
+    """Eager parallel prefill + Python greedy decode loop.
+
+    Prefills the whole prompt in ONE forward, then decodes token-by-token. The
+    full-program jit in `generate` constant-folds the multi-GB embedding tables
+    into the executable, which a modest host cannot afford alongside the
+    resident weights; keras compiles each step, so this is equally fast for
+    short outputs while staying within budget on the real E2B/E4B weights.
+    """
+    embeds, per_layer = build_prompt_rows(
+        step_model, vision_embeddings, prompt_ids, vision_indices,
+        per_layer_step)
+    length = embeds.shape[1]
+    cache = jp.asarray(build_empty_cache(config, length + max_tokens))
+    positions = jp.arange(length, dtype="int32")[None]
+    logits, cache = call_step(step_model, embeds, cache, 0, positions,
+                              per_layer)
+    token = int(jp.argmax(logits[0, -1]))
+    embedding = step_model.get_layer("token_embedding")
+    out, index = [token], length
+    while token != stop_id and len(out) < max_tokens:
+        per_layer = decode_per_layer(per_layer_step, token)
+        logits, cache = call_step(
+            step_model, embedding(as_token(token)), cache, index,
+            jp.array([[index]], dtype="int32"), per_layer)
+        token = int(jp.argmax(logits[0, -1]))
+        out.append(token)
+        index += 1
+    return trim_to_stop(out, stop_id)
+
+
+def decode_per_layer(per_layer_step, token):
+    if per_layer_step is None:
+        return None
+    return per_layer_step(as_token(token))
+
+
+def generate_sample(step_model, per_layer_step, vision_embeddings, config,
+                    prompt_ids, vision_indices, stop_id, max_tokens, key,
+                    sampling):
+    """Single-sequence jitted sampling generation seeded by `key`."""
+    return run_cached_generate(
+        step_model, per_layer_step, vision_embeddings, config, prompt_ids,
+        vision_indices, stop_id, max_tokens, key, build_token_sampler(sampling))
+
+
+def select_greedy_token(logits, key):
+    return jp.argmax(logits[0]).astype("int32")
+
+
+def build_token_sampler(sampling):
+    return lambda logits, key: sample_logits(logits, key, sampling)[0]
+
+
+def run_cached_generate(step_model, per_layer_step, vision_embeddings, config,
+                        prompt_ids, vision_indices, stop_id, max_tokens, key,
+                        select):
+    embeds, per_layer = build_prompt_rows(
+        step_model, vision_embeddings, prompt_ids, vision_indices,
+        per_layer_step)
+    length = embeds.shape[1]
+    max_length = length + max_tokens
+    cache = jp.asarray(build_empty_cache(config, max_length))
+    positions = jp.arange(length, dtype="int32")[None]
+    logits, cache = call_step(
+        step_model, embeds, cache, 0, positions, per_layer)
+    key, first_key = jax.random.split(key)
+    first = select(logits[:, -1], first_key)
+    decode = build_decode_loop(
+        step_model, per_layer_step, max_length, max_tokens, select)
+    variables = (
+        snapshot_variables(step_model),
+        snapshot_variables(step_model.get_layer("token_embedding")),
+        snapshot_variables(per_layer_step))
+    buffer, count = decode(cache, first, jp.array(length, "int32"),
+                           jp.array(stop_id, "int32"), key, variables)
+    generated = ops.convert_to_numpy(buffer[:int(count)]).tolist()
+    return trim_to_stop(generated, stop_id)
+
+
+def trim_to_stop(tokens, stop_id):
+    if stop_id in tokens:
+        tokens = tokens[:tokens.index(stop_id)]
+    return tokens
+
+
+def build_decode_loop(step_model, per_layer_step, max_length, max_tokens,
+                      select):
+    embedding = step_model.get_layer("token_embedding")
+
+    @jax.jit
+    def decode(cache, first_token, start_index, stop_id, key, variables):
+        buffer = jp.zeros((max_tokens,), dtype="int32").at[0].set(first_token)
+        count = jp.array(1, dtype="int32")
+        state = (buffer, first_token, start_index, cache, count,
+                 first_token == stop_id, key)
+        cont = build_should_continue(max_tokens, max_length)
+        step = build_decode_step(
+            step_model, embedding, per_layer_step, stop_id, select, variables)
+        buffer, _, _, _, count, _, _ = jax.lax.while_loop(cont, step, state)
+        return buffer, count
+
+    return decode
+
+
+def build_should_continue(max_tokens, max_length):
+    def check(state):
+        _, _, index, _, count, finished, _ = state
+        return (~finished) & (count < max_tokens) & (index < max_length)
+    return check
+
+
+def build_decode_step(step_model, embedding, per_layer_step, stop_id, select,
+                      variables):
+    step_vars, embedding_vars, per_layer_vars = variables
+
+    def step(state):
+        buffer, token, index, cache, count, _, key = state
+        token2d = jp.reshape(token, (1, 1))
+        positions = jp.reshape(index, (1, 1)).astype("int32")
+        embeds = call_stateless(embedding, embedding_vars, token2d)
+        inputs = [embeds, cache, jp.reshape(index, (1,)).astype("int32"),
+                  positions]
+        if per_layer_vars is not None:
+            inputs.append(
+                call_stateless(per_layer_step, per_layer_vars, token2d))
+        logits, cache = call_stateless(step_model, step_vars, inputs)
+        key, step_key = jax.random.split(key)
+        next_id = select(logits[:, 0, :], step_key)
+        buffer = buffer.at[count].set(next_id)
+        finished = next_id == stop_id
+        return (buffer, next_id, index + 1, cache, count + 1, finished, key)
+    return step
+
+
+def generate_batch(step_model, per_layer_step, config, prompts, key, sampling,
+                   stop_id, max_tokens):
+    """Batched sampling generation for equal-length text prompts.
+
+    Each row is sampled independently with `sampling`; `key` seeds the draws.
+    """
+    select = build_sampler(sampling)
+    return run_batch_decode(step_model, per_layer_step, config, prompts, key,
+                            select, stop_id, max_tokens)
+
+
+def generate_batch_greedy(step_model, per_layer_step, config, prompts,
+                          stop_id, max_tokens):
+    """Batched greedy (argmax) generation for equal-length text prompts."""
+    return run_batch_decode(step_model, per_layer_step, config, prompts, None,
+                            select_greedy, stop_id, max_tokens)
+
+
+def build_sampler(sampling):
+    return lambda logits, key: sample_logits(logits, key, sampling)
+
+
+def select_greedy(logits, key):
+    return ops.cast(ops.argmax(logits, axis=-1), "int32")
+
+
+def pick_token(select, logits, key):
+    if key is None:
+        return None, select(logits, None)
+    key, step_key = jax.random.split(key)
+    return key, select(logits, step_key)
+
+
+def run_batch_decode(step_model, per_layer_step, config, prompts, key, select,
+                     stop_id, max_tokens):
+    """Eager parallel prefill + lockstep decode over a (batch, length) grid.
+
+    All rows share query positions, so the cached attention broadcasts across
+    the batch. Returns one stop-trimmed token list per row.
+    """
+    prompts = jp.asarray(prompts, dtype="int32")
+    batch, length = prompts.shape
+    embeds, per_layer = build_text_batch_rows(
+        step_model, per_layer_step, prompts)
+    cache = jp.asarray(build_empty_cache(config, length + max_tokens, batch))
+    positions = jp.arange(length, dtype="int32")[None]
+    logits, cache = call_step(
+        step_model, embeds, cache, 0, positions, per_layer)
+    key, token = pick_token(select, logits[:, -1], key)
+    embedding = step_model.get_layer("token_embedding")
+    collected, index = [token], length
+    finished = np.asarray(token) == stop_id
+    while len(collected) < max_tokens and not finished.all():
+        token2d = token[:, None]
+        per_layer = batch_per_layer(per_layer_step, token2d)
+        logits, cache = call_step(
+            step_model, embedding(token2d), cache, index,
+            jp.full((1, 1), index, dtype="int32"), per_layer)
+        key, token = pick_token(select, logits[:, -1], key)
+        collected.append(token)
+        finished = finished | (np.asarray(token) == stop_id)
+        index += 1
+    return trim_rows(collected, stop_id)
+
+
+def build_text_batch_rows(step_model, per_layer_step, prompts):
+    embedding = step_model.get_layer("token_embedding")
+    embeds = embedding(prompts)
+    per_layer = batch_per_layer(per_layer_step, prompts)
+    return embeds, per_layer
+
+
+def batch_per_layer(per_layer_step, tokens):
+    if per_layer_step is None:
+        return None
+    return per_layer_step(tokens)
+
+
+def trim_rows(collected, stop_id):
+    grid = np.stack([np.asarray(token) for token in collected], axis=1)
+    return [trim_to_stop(row.tolist(), stop_id) for row in grid]
+
+
+def prefill_logits(step_model, per_layer_step, vision_embeddings, config,
+                   prompt_ids, vision_indices):
+    """Prefill the whole prompt in one forward; returns per-position logits."""
+    embeds, per_layer = build_prompt_rows(
+        step_model, vision_embeddings, prompt_ids, vision_indices,
+        per_layer_step)
+    length = embeds.shape[1]
+    cache = jp.asarray(build_empty_cache(config, length))
+    positions = jp.arange(length, dtype="int32")[None]
+    logits, _ = call_step(step_model, embeds, cache, 0, positions, per_layer)
+    return logits

--- a/paz/models/foundation/gemma4/multimodal_decoding_test.py
+++ b/paz/models/foundation/gemma4/multimodal_decoding_test.py
@@ -1,0 +1,180 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import keras
+from keras import Model
+
+from paz.models.transformers.logits import soft_cap as apply_soft_cap
+from paz.models.foundation.gemma4.model import build_text_backbone_args
+from paz.models.foundation.gemma4.vision import (
+    build_vision_encoder, build_vision_encoder_args, num_patches)
+import jax
+
+from paz.models.foundation.gemma4.multimodal import build_multimodal_backbone
+from paz.models.foundation.gemma4.inference import (
+    Gemma4MultimodalDecoderStep, build_empty_cache)
+from paz.models.foundation.gemma4.multimodal_decoding import (
+    prefill_logits, generate, generate_eager, generate_sample, generate_batch,
+    generate_batch_greedy, build_prompt_rows, call_step, trim_to_stop, as_token)
+from paz.models.foundation.gemma4.sampling import SamplingArgs
+
+TEXT = build_text_backbone_args(num_layers=2, sliding_window_pattern=2)
+VISION = build_vision_encoder_args(output_dim=TEXT.hidden_dim)
+
+
+def last2(path):
+    path = path.replace("/dense/", "/")  # unwrap clippable einsum
+    return "/".join(path.split("/")[-2:])
+
+
+def transfer(source, target):
+    weights = {last2(w.path): np.asarray(keras.ops.convert_to_numpy(w))
+               for w in source.weights}
+    for variable in target.weights:
+        variable.assign(weights[last2(variable.path)].reshape(variable.shape))
+
+
+def build_full_sequence_causal_lm():
+    backbone = build_multimodal_backbone(TEXT, VISION)
+    embedding = backbone.get_layer("token_embedding")
+    logits = apply_soft_cap(
+        embedding(backbone.output, reverse=True), TEXT.final_logit_soft_cap)
+    return Model(backbone.input, logits), backbone
+
+
+def build_inputs(pooled):
+    side = VISION.image_size // VISION.patch_size
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(1, TEXT.vocabulary_size, (1, 12)).astype("int32")
+    cols = np.tile(np.arange(side), side)
+    rows = np.repeat(np.arange(side), side)
+    grid = np.stack([cols, rows], -1)[None].astype("int32")
+    patch_dim = 3 * VISION.patch_size ** 2
+    pixels = rng.standard_normal(
+        (1, num_patches(VISION), patch_dim)).astype("float32")
+    vision_indices = np.arange(2, 2 + pooled)[None].astype("int32")
+    return tokens, grid, pixels, vision_indices
+
+
+def test_cached_multimodal_matches_full_sequence():
+    causal, backbone = build_full_sequence_causal_lm()
+    step = Gemma4MultimodalDecoderStep(TEXT)
+    vision = build_vision_encoder(VISION)
+    transfer(backbone, step)
+    transfer(backbone, vision)
+    pooled = num_patches(VISION) // VISION.pool_size ** 2
+    tokens, grid, pixels, vision_indices = build_inputs(pooled)
+    full_logits = np.array(causal({
+        "token_ids": tokens, "padding_mask": np.ones_like(tokens),
+        "pixel_values": pixels, "pixel_position_ids": grid,
+        "vision_indices": vision_indices}))[0]
+    scale = float(TEXT.hidden_dim) ** -0.5
+    image = np.array(vision(
+        {"pixel_values": pixels, "pixel_position_ids": grid}))[0] * scale
+    cached = np.array(prefill_logits(
+        step, None, image, TEXT, tokens[0], vision_indices[0]))[0]
+    assert float(np.max(np.abs(full_logits - cached))) < 1e-4
+
+
+def reference_decode(step, per_layer_step, image, config, prompt_ids,
+                     vision_indices, stop_id, max_tokens):
+    import jax.numpy as jp
+    embeds, per_layer = build_prompt_rows(
+        step, image, prompt_ids, vision_indices, per_layer_step)
+    length = embeds.shape[1]
+    cache = jp.asarray(build_empty_cache(config, length + max_tokens))
+    positions = jp.arange(length, dtype="int32")[None]
+    logits, cache = call_step(step, embeds, cache, 0, positions, per_layer)
+    token = int(jp.argmax(logits[0, -1]))
+    embedding = step.get_layer("token_embedding")
+    out, index = [token], length
+    while token != stop_id and len(out) < max_tokens:
+        positions = jp.array([[index]], dtype="int32")
+        logits, cache = call_step(
+            step, embedding(as_token(token)), cache, index, positions, None)
+        token = int(jp.argmax(logits[0, -1]))
+        out.append(token)
+        index += 1
+    return trim_to_stop(out, stop_id)
+
+
+def test_jitted_decode_matches_reference():
+    causal, backbone = build_full_sequence_causal_lm()
+    step = Gemma4MultimodalDecoderStep(TEXT)
+    vision = build_vision_encoder(VISION)
+    transfer(backbone, step)
+    transfer(backbone, vision)
+    pooled = num_patches(VISION) // VISION.pool_size ** 2
+    tokens, grid, pixels, vision_indices = build_inputs(pooled)
+    scale = float(TEXT.hidden_dim) ** -0.5
+    image = np.array(vision(
+        {"pixel_values": pixels, "pixel_position_ids": grid}))[0] * scale
+    stop = int(TEXT.vocabulary_size - 1)
+    args = (step, None, image, TEXT, tokens[0], vision_indices[0], stop, 5)
+    got = generate(*args)
+    reference = reference_decode(*args)
+    assert len(got) >= 1
+    assert got == reference
+
+
+def build_text_step():
+    causal, backbone = build_full_sequence_causal_lm()
+    step = Gemma4MultimodalDecoderStep(TEXT)
+    transfer(backbone, step)
+    return step
+
+
+def test_generate_batch_greedy_matches_single_sequence():
+    step = build_text_step()
+    prompt = [2, 5, 9, 11, 7]
+    stop = int(TEXT.vocabulary_size - 1)
+    no_vision = np.zeros((0, TEXT.hidden_dim), "float32")
+    single = generate(step, None, no_vision, TEXT, prompt, [], stop, 6)
+    prompts = np.array([prompt, prompt, prompt], dtype="int32")
+    rows = generate_batch_greedy(step, None, TEXT, prompts, stop, 6)
+    assert rows[0] == single
+    assert rows[1] == single and rows[2] == single
+
+
+def test_generate_eager_matches_jitted_greedy():
+    step = build_text_step()
+    prompt = [2, 5, 9, 11, 7]
+    stop = int(TEXT.vocabulary_size - 1)
+    nov = np.zeros((0, TEXT.hidden_dim), "float32")
+    jitted = generate(step, None, nov, TEXT, prompt, [], stop, 6)
+    eager = generate_eager(step, None, nov, TEXT, prompt, [], stop, 6)
+    assert eager == jitted
+
+
+def test_generate_sample_peaked_matches_greedy_and_is_seeded():
+    step = build_text_step()
+    prompt = [2, 5, 9, 11, 7]
+    stop = int(TEXT.vocabulary_size - 1)
+    nov = np.zeros((0, TEXT.hidden_dim), "float32")
+    greedy = generate(step, None, nov, TEXT, prompt, [], stop, 6)
+    peaked = generate_sample(step, None, nov, TEXT, prompt, [], stop, 6,
+                             jax.random.PRNGKey(0), SamplingArgs(1.0, 1, 1.0))
+    assert peaked == greedy  # top_k=1 == argmax (no float32 ties here)
+    args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
+    a = generate_sample(step, None, nov, TEXT, prompt, [], stop, 8,
+                        jax.random.PRNGKey(5), args)
+    b = generate_sample(step, None, nov, TEXT, prompt, [], stop, 8,
+                        jax.random.PRNGKey(5), args)
+    assert a == b
+
+
+def test_generate_batch_sampling_is_seeded_and_valid():
+    step = build_text_step()
+    stop = int(TEXT.vocabulary_size - 1)
+    prompts = np.array([[2, 5, 9, 11, 7]] * 4, dtype="int32")
+    args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
+    rows_a = generate_batch(step, None, TEXT, prompts,
+                            jax.random.PRNGKey(1), args, stop, 8)
+    rows_b = generate_batch(step, None, TEXT, prompts,
+                            jax.random.PRNGKey(1), args, stop, 8)
+    assert rows_a == rows_b  # same key -> reproducible
+    flat = [t for row in rows_a for t in row]
+    assert all(0 <= t < TEXT.vocabulary_size for t in flat)
+    assert len({tuple(r) for r in rows_a}) > 1  # rows diverge under sampling

--- a/paz/models/foundation/gemma4/multimodal_test.py
+++ b/paz/models/foundation/gemma4/multimodal_test.py
@@ -1,0 +1,97 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import keras
+import pytest
+
+from paz.models.foundation.gemma4.conversion import role as text_role
+from paz.models.foundation.gemma4.model import build_text_backbone_args
+from paz.models.foundation.gemma4.multimodal import build_multimodal_backbone
+from paz.models.foundation.gemma4.vision import (
+    build_vision_encoder_args, num_patches)
+
+backbone = pytest.importorskip(
+    "keras_hub.src.models.gemma4.gemma4_backbone")
+vision_module = pytest.importorskip(
+    "keras_hub.src.models.gemma4.gemma4_vision_encoder")
+Gemma4Backbone = backbone.Gemma4Backbone
+Gemma4VisionEncoder = vision_module.Gemma4VisionEncoder
+
+from paz.models.foundation.gemma4.vision_test import role as vision_role
+
+TEXT = build_text_backbone_args(num_layers=2, sliding_window_pattern=2)
+VISION = build_vision_encoder_args(output_dim=TEXT.hidden_dim)
+
+
+def build_reference():
+    vision = Gemma4VisionEncoder(
+        image_size=VISION.image_size, patch_size=VISION.patch_size,
+        num_heads=VISION.num_heads, hidden_dim=VISION.hidden_dim,
+        num_layers=VISION.num_layers, intermediate_dim=VISION.intermediate_dim,
+        head_dim=VISION.head_dim, output_dim=VISION.output_dim,
+        num_key_value_heads=VISION.num_key_value_heads,
+        pool_size=VISION.pool_size,
+        position_embedding_size=VISION.position_embedding_size,
+        rope_max_wavelength=VISION.rope_wavelength,
+        layer_norm_epsilon=VISION.layer_norm_epsilon, dtype="float32")
+    return Gemma4Backbone(
+        vocabulary_size=TEXT.vocabulary_size, image_size=VISION.image_size,
+        num_layers=TEXT.num_layers, num_query_heads=TEXT.num_query_heads,
+        num_key_value_heads=TEXT.num_key_value_heads,
+        hidden_dim=TEXT.hidden_dim, intermediate_dim=TEXT.intermediate_dim,
+        head_dim=TEXT.head_dim, sliding_window_size=TEXT.sliding_window_size,
+        sliding_window_pattern=TEXT.sliding_window_pattern,
+        vision_encoder=vision, layer_norm_epsilon=TEXT.layer_norm_epsilon,
+        dtype="float32")
+
+
+def role(path):
+    if "decoder_block_" in path or "token_embedding" in path \
+            or "final_normalization" in path or "per_layer" in path:
+        return "t:" + text_role(path)
+    return "v:" + vision_role(path)
+
+
+def transfer(source, target):
+    weights = {role(w.path): np.asarray(keras.ops.convert_to_numpy(w))
+               for w in source.weights}
+    for variable in target.weights:
+        variable.assign(weights[role(variable.path)].reshape(variable.shape))
+
+
+def build_inputs():
+    batch, seq = 2, 12
+    side = VISION.image_size // VISION.patch_size
+    pooled = (side // VISION.pool_size) ** 2
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(1, TEXT.vocabulary_size, (batch, seq)).astype("int32")
+    padding = np.ones((batch, seq), dtype="int32")
+    positions = np.broadcast_to(np.arange(seq, dtype="int32"), (batch, seq))
+    cols = np.tile(np.arange(side), side)
+    rows = np.repeat(np.arange(side), side)
+    grid = np.stack([cols, rows], -1).astype("int32")
+    grid = np.broadcast_to(grid, (batch,) + grid.shape)
+    patch_dim = 3 * VISION.patch_size ** 2
+    pixels = rng.standard_normal(
+        (batch, num_patches(VISION), patch_dim)).astype("float32")
+    vision_indices = np.tile(
+        np.arange(2, 2 + pooled, dtype="int32"), (batch, 1))
+    return tokens, padding, positions.copy(), grid, pixels, vision_indices
+
+
+def test_multimodal_matches_keras_hub():
+    reference = build_reference()
+    model = build_multimodal_backbone(TEXT, VISION)
+    transfer(reference, model)
+    tokens, padding, positions, grid, pixels, indices = build_inputs()
+    paz_out = np.array(model({
+        "token_ids": tokens, "padding_mask": padding, "pixel_values": pixels,
+        "pixel_position_ids": grid, "vision_indices": indices}))
+    kh_out = np.array(reference({
+        "token_ids": tokens, "padding_mask": padding,
+        "position_ids": positions, "vision_mask": np.zeros_like(tokens),
+        "vision_indices": indices, "pixel_values": pixels[:, None],
+        "pixel_position_ids": grid[:, None]}))
+    assert float(np.max(np.abs(paz_out - kh_out))) < 1e-4

--- a/paz/models/foundation/gemma4/pretrained.py
+++ b/paz/models/foundation/gemma4/pretrained.py
@@ -1,0 +1,57 @@
+import json
+from collections import namedtuple
+from pathlib import Path
+
+from paz.models.foundation.gemma4.configuration import load_config
+from paz.models.foundation.gemma4.inference import Gemma4MultimodalDecoderStep
+from paz.models.foundation.gemma4.inference import Gemma4PerLayerEmbeddingStep
+from paz.models.foundation.gemma4.vision import VisionEncoderArgs
+from paz.models.foundation.gemma4.vision import build_vision_encoder
+
+GEMMA4_WEIGHTS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.24/"  # fmt: skip
+Gemma4Models = namedtuple(
+    "Gemma4", "config decoder_step per_layer_step vision_encoder")
+
+
+def Gemma4(model_name="gemma4_2b", weights="paz", models_path=None):
+    model_dir = resolve_gemma4_dir(model_name, models_path)
+    config = load_config(model_dir / "config.json")
+    decoder_step = Gemma4MultimodalDecoderStep(config)
+    per_layer_step = build_per_layer_step(config)
+    vision_encoder = build_vision_encoder_from_dir(model_dir)
+    if weights is not None:
+        decoder_step.load_weights(str(model_dir / "decoder_step.weights.h5"))
+        load_optional_weights(model_dir, per_layer_step, vision_encoder)
+    return Gemma4Models(config, decoder_step, per_layer_step, vision_encoder)
+
+
+def resolve_gemma4_dir(model_name, models_path):
+    if models_path is not None:
+        return Path(models_path)
+    message = ("Gemma4 weights for '{}' are not hosted yet; pass models_path "
+               "to a local weights directory.").format(model_name)
+    raise ValueError(message)
+
+
+def build_per_layer_step(config):
+    if not config.hidden_size_per_layer_input:
+        return None
+    return Gemma4PerLayerEmbeddingStep(config)
+
+
+def build_vision_encoder_from_dir(model_dir):
+    path = Path(model_dir) / "vision_config.json"
+    if not path.exists():
+        return None
+    with open(str(path), encoding="utf-8") as file:
+        config = VisionEncoderArgs(**json.load(file))
+    return build_vision_encoder(config)
+
+
+def load_optional_weights(model_dir, per_layer_step, vision_encoder):
+    if per_layer_step is not None:
+        per_layer_step.load_weights(
+            str(model_dir / "embedding_step.weights.h5"))
+    if vision_encoder is not None:
+        vision_encoder.load_weights(
+            str(model_dir / "vision_encoder.weights.h5"))

--- a/paz/models/foundation/gemma4/sampling.py
+++ b/paz/models/foundation/gemma4/sampling.py
@@ -1,0 +1,25 @@
+"""Token sampling for Gemma4 generation: temperature, top-k, top-p.
+
+Pure functions over logits shaped (batch, vocabulary). `sample_logits` composes
+temperature scaling, top-k truncation and top-p (nucleus) truncation, then draws
+one token per row with `jax.random.categorical`. Greedy decoding is NOT done
+here: it is plain `argmax`, which breaks ties deterministically by lowest index;
+`categorical` would instead break the frequent bfloat16 ties stochastically.
+"""
+from collections import namedtuple
+
+import jax
+
+from paz.models.transformers.logits import apply_temperature
+from paz.models.transformers.logits import apply_top_k
+from paz.models.transformers.logits import apply_top_p
+
+# top_k <= 0 disables top-k; top_p >= 1 disables nucleus truncation.
+SamplingArgs = namedtuple("SamplingArgs", "temperature top_k top_p")
+
+
+def sample_logits(logits, key, args):
+    logits = apply_temperature(logits, args.temperature)
+    logits = apply_top_k(logits, args.top_k)
+    logits = apply_top_p(logits, args.top_p)
+    return jax.random.categorical(key, logits, axis=-1).astype("int32")

--- a/paz/models/foundation/gemma4/sampling_test.py
+++ b/paz/models/foundation/gemma4/sampling_test.py
@@ -1,0 +1,47 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from paz.models.foundation.gemma4.sampling import (
+    SamplingArgs, apply_top_k, apply_top_p, sample_logits)
+
+
+def test_top_k_masks_below_threshold():
+    logits = jnp.asarray([[5.0, 4.0, 3.0, 2.0, 1.0]])
+    out = np.asarray(apply_top_k(logits, 2))
+    assert np.isinf(out[0, 2:]).all() and out[0, 2] < 0
+    assert np.array_equal(out[0, :2], [5.0, 4.0])
+
+
+def test_top_p_keeps_smallest_set_over_p():
+    # softmax([3,2,1,0]) ~ [0.643, 0.236, 0.087, 0.032]; p=0.8 keeps first two.
+    logits = jnp.asarray([[3.0, 2.0, 1.0, 0.0]])
+    out = np.asarray(apply_top_p(logits, 0.8))
+    assert np.isfinite(out[0, :2]).all()
+    assert np.isinf(out[0, 2:]).all()
+
+
+def test_top_p_always_keeps_top_token():
+    logits = jnp.asarray([[10.0, 0.0, 0.0]])
+    out = np.asarray(apply_top_p(logits, 0.1))
+    assert np.isfinite(out[0, 0]) and np.isinf(out[0, 1:]).all()
+
+
+def test_sample_shapes_and_range():
+    rng = np.random.default_rng(1)
+    logits = jnp.asarray(rng.standard_normal((8, 100)).astype("float32"))
+    args = SamplingArgs(temperature=0.8, top_k=20, top_p=0.95)
+    token = np.asarray(sample_logits(logits, jax.random.PRNGKey(7), args))
+    assert token.shape == (8,)
+    assert token.min() >= 0 and token.max() < 100
+
+
+def test_sampling_rows_independent_and_seeded():
+    logits = jnp.zeros((6, 200), dtype="float32")  # uniform -> spread of draws
+    args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
+    a = np.asarray(sample_logits(logits, jax.random.PRNGKey(3), args))
+    b = np.asarray(sample_logits(logits, jax.random.PRNGKey(3), args))
+    c = np.asarray(sample_logits(logits, jax.random.PRNGKey(4), args))
+    assert np.array_equal(a, b)        # same key -> reproducible
+    assert not np.array_equal(a, c)    # different key -> different draw
+    assert len(set(a.tolist())) > 1    # rows are not all identical

--- a/paz/models/foundation/gemma4/tokenizer.py
+++ b/paz/models/foundation/gemma4/tokenizer.py
@@ -1,0 +1,334 @@
+import json
+from collections import namedtuple
+from pathlib import Path
+import re
+
+PIECE_NORMAL = 1
+PIECE_CONTROL = 3
+PIECE_USER_DEFINED = 4
+PIECE_BYTE = 6
+
+WHITESPACE = "\u2581"
+SPACE_PATTERN = re.compile(r" +")
+BYTE_PATTERN = re.compile(r"<0x[0-9A-Fa-f]{2}>")
+IMAGE_TOKEN_TEXTS = ("<|image>", "<|image|>", "<image|>")
+AUDIO_TOKEN_TEXTS = ("<|audio>", "<|audio|>", "<audio|>")
+TURN_TOKEN_TEXTS = ("<|turn>", "<turn|>")
+PieceArgs = namedtuple("PieceArgs", "text type index")
+NormalizerArgs = namedtuple(
+    "NormalizerArgs",
+    "name add_dummy_prefix remove_extra_whitespaces escape_whitespaces",
+)
+TokenizerSource = namedtuple(
+    "TokenizerSource", "normalizer denormalizer pieces merge_ranks"
+)
+SpecialTokenIds = namedtuple(
+    "SpecialTokenIds",
+    "start_token_id end_token_id pad_token_id "
+    "start_of_image_token_id image_placeholder_id end_of_image_token_id "
+    "start_of_audio_token_id audio_placeholder_id end_of_audio_token_id "
+    "start_of_turn_token_id end_of_turn_token_id",
+)
+
+
+class Gemma4Tokenizer:
+    def __init__(
+        self,
+        path,
+        add_bos=False,
+        add_eos=False,
+        has_vision_tokens=True,
+        has_audio_tokens=False,
+    ):
+        source = load_tokenizer_source(path)
+        self.path = path
+        self.add_bos = add_bos
+        self.add_eos = add_eos
+        self.normalizer = source.normalizer
+        self.denormalizer = source.denormalizer
+        self.pieces = source.pieces
+        self.merge_ranks = source.merge_ranks
+        self.id_to_piece = self.pieces
+        self.piece_to_id = build_piece_to_id(self.pieces)
+        self.user_tree = build_prefix_tree(self.pieces, PIECE_USER_DEFINED)
+        ids = build_special_token_ids(
+            self.piece_to_id, has_vision_tokens, has_audio_tokens
+        )
+        self.special_ids = ids
+        for name in ids._fields:
+            setattr(self, name, getattr(ids, name))
+
+    def vocabulary_size(self):
+        return len(self.pieces)
+
+    def get_vocabulary(self):
+        return [piece.text for piece in self.pieces]
+
+    def id_to_token(self, token_id):
+        size = self.vocabulary_size()
+        if token_id < 0 or token_id >= size:
+            message = "`id` must be in range [0, {}].".format(size - 1)
+            raise ValueError(message)
+        return self.id_to_piece[token_id].text
+
+    def token_to_id(self, token_text):
+        return self.piece_to_id[token_text]
+
+    def __call__(self, inputs):
+        return self.tokenize(inputs)
+
+    def tokenize(self, inputs):
+        if isinstance(inputs, str):
+            return self._tokenize_text(inputs)
+        return [self._tokenize_text(text) for text in inputs]
+
+    def detokenize(self, inputs):
+        if not inputs:
+            return ""
+        if isinstance(inputs[0], int):
+            return self._detokenize_ids(inputs)
+        return [self._detokenize_ids(token_ids) for token_ids in inputs]
+
+    def format_generation_prompt(self, prompt):
+        return "".join(build_prompt_parts(prompt))
+
+    def tokenize_generation_prompt(self, prompt):
+        return self.tokenize(self.format_generation_prompt(prompt))
+
+    def get_stop_token_ids(self):
+        stop_ids = [self.end_token_id]
+        if self.end_of_turn_token_id >= 0:
+            stop_ids.append(self.end_of_turn_token_id)
+        return tuple(stop_ids)
+
+    def _tokenize_text(self, text):
+        text = normalize_text(text, self.normalizer)
+        parts = self._split_user_segments(text)
+        token_ids = []
+        for is_user, part in parts:
+            if is_user:
+                token_ids.append(self.piece_to_id[part])
+                continue
+            token_ids.extend(self._encode_bpe_segment(part))
+        return self._add_boundary_tokens(token_ids)
+
+    def _detokenize_ids(self, token_ids):
+        pieces = [self.id_to_piece[token_id] for token_id in token_ids]
+        byte_buffer = bytearray()
+        output = bytearray()
+        for piece in pieces:
+            if piece.type == PIECE_CONTROL:
+                continue
+            if piece.type == PIECE_BYTE:
+                byte_buffer.append(int(piece.text[3:5], 16))
+                continue
+            output.extend(self._flush_byte_buffer(byte_buffer))
+            text = piece.text.replace(WHITESPACE, " ")
+            output.extend(text.encode("utf-8"))
+        output.extend(self._flush_byte_buffer(byte_buffer))
+        text = output.decode("utf-8", errors="replace")
+        return denormalize_text(text, self.denormalizer)
+
+    def _add_boundary_tokens(self, token_ids):
+        output = list(token_ids)
+        if self.add_bos:
+            output.insert(0, self.start_token_id)
+        if self.add_eos:
+            output.append(self.end_token_id)
+        return output
+
+    def _split_user_segments(self, text):
+        parts = []
+        start = 0
+        index = 0
+        while index < len(text):
+            token_text = self._find_longest_match(text, index)
+            if token_text is None:
+                index = index + 1
+                continue
+            if start != index:
+                parts.append((False, text[start:index]))
+            parts.append((True, token_text))
+            index = index + len(token_text)
+            start = index
+        if start != len(text):
+            parts.append((False, text[start:]))
+        return parts
+
+    def _find_longest_match(self, text, start):
+        branch = self.user_tree
+        match = None
+        index = start
+        while index < len(text) and text[index] in branch:
+            branch = branch[text[index]]
+            index = index + 1
+            if "id" in branch:
+                match = text[start:index]
+        return match
+
+    def _encode_bpe_segment(self, text):
+        symbols = []
+        for char in text:
+            token_id = self.piece_to_id.get(char)
+            if token_id is not None:
+                symbols.append(char)
+                continue
+            symbols.extend(self._encode_unknown_byte_texts(char))
+        symbols = merge_bpe_symbols(symbols, self.merge_ranks, self.piece_to_id)
+        return [self.piece_to_id[symbol] for symbol in symbols]
+
+    def _encode_unknown_byte_texts(self, text):
+        return encode_byte_texts(text)
+
+    def _flush_byte_buffer(self, byte_buffer):
+        if not byte_buffer:
+            return b""
+        output = bytes(byte_buffer)
+        byte_buffer.clear()
+        return output
+
+
+def load_tokenizer_source(path):
+    path = Path(path)
+    if path.suffix != ".json":
+        message = "Gemma4Tokenizer now supports tokenizer.json only."
+        raise ValueError(message)
+    with open(str(path), encoding="utf-8") as file:
+        data = json.load(file)
+    model = data["model"]
+    if model["type"] != "BPE":
+        message = "Unsupported tokenizer model type: {}".format(model["type"])
+        raise ValueError(message)
+    pieces = build_piece_args(data)
+    normalizer = build_normalizer_args(data.get("normalizer"))
+    denormalizer = build_denormalizer_args(data.get("decoder"))
+    merge_ranks = build_merge_ranks(model["merges"])
+    return TokenizerSource(normalizer, denormalizer, pieces, merge_ranks)
+
+
+def build_piece_args(data):
+    vocab = data["model"]["vocab"]
+    added = data.get("added_tokens", [])
+    pieces = [None] * len(vocab)
+    special_texts = {item["content"] for item in added if item["special"]}
+    for text, index in vocab.items():
+        piece_type = build_piece_type(text, special_texts)
+        pieces[index] = PieceArgs(text, piece_type, index)
+    return tuple(pieces)
+
+
+def build_piece_type(text, special_texts):
+    if BYTE_PATTERN.fullmatch(text):
+        return PIECE_BYTE
+    if text in special_texts:
+        return PIECE_USER_DEFINED
+    return PIECE_NORMAL
+
+
+def build_piece_to_id(pieces):
+    return {piece.text: piece.index for piece in pieces}
+
+
+def build_normalizer_args(spec):
+    if spec is None:
+        return NormalizerArgs("identity", False, False, False)
+    uses_metaspace = spec["type"] == "Replace"
+    return NormalizerArgs("replace", False, False, uses_metaspace)
+
+
+def build_denormalizer_args(spec):
+    if spec is None:
+        return NormalizerArgs("identity", False, False, False)
+    return NormalizerArgs("replace", False, False, False)
+
+
+def build_prefix_tree(pieces, piece_type):
+    tree = {}
+    for piece in pieces:
+        if piece.type != piece_type:
+            continue
+        branch = tree
+        for char in piece.text:
+            branch = branch.setdefault(char, {})
+        branch["id"] = piece.index
+    return tree
+
+
+def build_special_token_ids(piece_to_id, has_vision_tokens, has_audio_tokens):
+    image_ids = build_media_token_ids(
+        piece_to_id, has_vision_tokens, IMAGE_TOKEN_TEXTS
+    )
+    audio_ids = build_media_token_ids(
+        piece_to_id, has_audio_tokens, AUDIO_TOKEN_TEXTS
+    )
+    turn_ids = tuple(piece_to_id.get(text, -1) for text in TURN_TOKEN_TEXTS)
+    values = (
+        piece_to_id["<bos>"],
+        piece_to_id["<eos>"],
+        piece_to_id["<pad>"],
+        *image_ids,
+        *audio_ids,
+        *turn_ids,
+    )
+    return SpecialTokenIds(*values)
+
+
+def build_media_token_ids(piece_to_id, enabled, token_texts):
+    if not enabled:
+        return (-1, -1, -1)
+    return tuple(piece_to_id.get(text, -1) for text in token_texts)
+
+
+def normalize_text(text, normalizer):
+    if normalizer.remove_extra_whitespaces:
+        text = SPACE_PATTERN.sub(" ", text.strip())
+    if normalizer.add_dummy_prefix:
+        text = " " + text
+    if normalizer.escape_whitespaces or normalizer.name == "nmt_nfkc":
+        text = text.replace(" ", WHITESPACE)
+    return text
+
+
+def denormalize_text(text, normalizer):
+    if normalizer.name != "identity":
+        text = text.replace(WHITESPACE, " ")
+    if normalizer.add_dummy_prefix and text.startswith(" "):
+        text = text[1:]
+    return text
+
+
+def build_merge_ranks(merges):
+    return {tuple(merge): index for index, merge in enumerate(merges)}
+
+
+def merge_bpe_symbols(symbols, merge_ranks, piece_to_id):
+    symbols = list(symbols)
+    while True:
+        best = None
+        for index in range(len(symbols) - 1):
+            pair = (symbols[index], symbols[index + 1])
+            rank = merge_ranks.get(pair)
+            if rank is None:
+                continue
+            merged = pair[0] + pair[1]
+            if merged not in piece_to_id:
+                continue
+            choice = (rank, index, merged)
+            if best is None or choice < best:
+                best = choice
+        if best is None:
+            return symbols
+        _, index, merged = best
+        symbols[index:index + 2] = [merged]
+
+
+def build_byte_piece_text(byte_value):
+    return "<0x{:02X}>".format(byte_value)
+
+
+def build_prompt_parts(prompt):
+    return ("<bos>", "<|turn>user\n", prompt, "<turn|>\n", "<|turn>model\n")
+
+
+def encode_byte_texts(text):
+    return [build_byte_piece_text(value) for value in text.encode()]

--- a/paz/models/foundation/gemma4/tokenizer_test.py
+++ b/paz/models/foundation/gemma4/tokenizer_test.py
@@ -1,0 +1,90 @@
+import json
+
+from paz.models.foundation.gemma4.tokenizer import Gemma4Tokenizer
+
+# Tiny hand-built byte-BPE tokenizer whose ids are referenced by the asserts
+# below. Written to a temp file per test so no JSON asset is committed (the
+# repo tracks only source files; real tokenizer.json assets ship with weights).
+TEST_TOKENIZER = {
+    "normalizer": {"type": "Replace"},
+    "decoder": {"type": "Metaspace"},
+    "added_tokens": [
+        {"content": "<pad>", "special": True},
+        {"content": "<eos>", "special": True},
+        {"content": "<bos>", "special": True},
+        {"content": "<unk>", "special": True},
+        {"content": "<mask>", "special": True},
+        {"content": "<|turn>", "special": True},
+        {"content": "<turn|>", "special": True},
+    ],
+    "model": {
+        "type": "BPE",
+        "merges": [],
+        "vocab": {
+            "<pad>": 0, "<eos>": 1, "<bos>": 2, "<unk>": 3, "<mask>": 4,
+            "<|turn>": 5, "<turn|>": 6, "h": 7, "i": 8, "u": 9, "s": 10,
+            "e": 11, "r": 12, "\n": 13, "m": 14, "o": 15, "d": 16, "l": 17,
+            "▁": 18, "t": 19, "<0xC3>": 20, "<0xA9>": 21,
+        },
+    },
+}
+
+
+def build_tokenizer(tmp_path, **kwargs):
+    path = tmp_path / "gemma4_test_tokenizer.json"
+    path.write_text(json.dumps(TEST_TOKENIZER), encoding="utf-8")
+    return Gemma4Tokenizer(path, **kwargs)
+
+
+def test_json_tokenizer_round_trips_text(tmp_path):
+    tokenizer = build_tokenizer(tmp_path)
+    text = "hi there"
+    token_ids = tokenizer.tokenize(text)
+    assert token_ids == [7, 8, 18, 19, 7, 11, 12, 11]
+    assert tokenizer.detokenize(token_ids) == text
+
+
+def test_json_tokenizer_formats_generation_prompt(tmp_path):
+    tokenizer = build_tokenizer(tmp_path)
+    text = tokenizer.format_generation_prompt("hi")
+    assert text == "<bos><|turn>user\nhi<turn|>\n<|turn>model\n"
+    token_ids = tokenizer.tokenize_generation_prompt("hi")
+    assert token_ids == [2, 5, 9, 10, 11, 12, 13, 7, 8, 6, 13, 5,
+                         14, 15, 16, 11, 17, 13]
+    assert tokenizer.get_stop_token_ids() == (1, 6)
+
+
+def test_json_tokenizer_supports_batches(tmp_path):
+    tokenizer = build_tokenizer(tmp_path)
+    texts = ["hi there", "hi"]
+    token_ids = tokenizer.tokenize(texts)
+    assert token_ids == [[7, 8, 18, 19, 7, 11, 12, 11], [7, 8]]
+    assert tokenizer.detokenize(token_ids) == texts
+
+
+def test_json_tokenizer_supports_byte_tokens(tmp_path):
+    tokenizer = build_tokenizer(tmp_path)
+    token_ids = tokenizer.tokenize("é")
+    assert token_ids == [20, 21]
+    assert tokenizer.detokenize(token_ids) == "é"
+
+
+def test_json_tokenizer_exposes_special_ids(tmp_path):
+    tokenizer = build_tokenizer(tmp_path)
+    assert tokenizer.start_token_id == tokenizer.token_to_id("<bos>")
+    assert tokenizer.end_token_id == tokenizer.token_to_id("<eos>")
+    assert tokenizer.pad_token_id == tokenizer.token_to_id("<pad>")
+    assert tokenizer.start_of_turn_token_id == tokenizer.token_to_id("<|turn>")
+    assert tokenizer.end_of_turn_token_id == tokenizer.token_to_id("<turn|>")
+    assert tokenizer.start_of_image_token_id == -1
+
+
+def test_tokenizer_rejects_non_json_assets(tmp_path):
+    path = tmp_path / "tokenizer.spm"
+    path.write_text("stub", encoding="utf-8")
+    try:
+        Gemma4Tokenizer(path)
+    except ValueError as error:
+        assert "tokenizer.json only" in str(error)
+        return
+    raise AssertionError("Gemma4Tokenizer should reject non-json assets")

--- a/paz/models/foundation/gemma4/vision.py
+++ b/paz/models/foundation/gemma4/vision.py
@@ -1,0 +1,69 @@
+from collections import namedtuple
+from pathlib import Path
+
+from keras import Model
+from keras.layers import Input
+
+from paz.models.foundation.gemma4.layers.vision import (
+    build_average_pooling, build_patch_embedder, build_real_patch_mask,
+    build_vision_attention_mask, build_vision_output, vision_decoder_block)
+
+VISION_ENCODER_NAME = "gemma4_vision_encoder"
+VISION_ENCODER_FIELDS = (
+    "image_size patch_size pool_size hidden_dim num_layers num_heads "
+    "num_key_value_heads head_dim intermediate_dim output_dim "
+    "position_embedding_size rope_wavelength layer_norm_epsilon dropout "
+    "max_patches dtype"
+)
+VisionEncoderArgs = namedtuple("VisionEncoderArgs", VISION_ENCODER_FIELDS)
+
+
+def build_vision_encoder_args(**overrides):
+    values = {
+        "image_size": 24,
+        "patch_size": 4,
+        "pool_size": 3,
+        "hidden_dim": 16,
+        "num_layers": 2,
+        "num_heads": 2,
+        "num_key_value_heads": 2,
+        "head_dim": 8,
+        "intermediate_dim": 32,
+        "output_dim": 16,
+        "position_embedding_size": 32,
+        "rope_wavelength": 100.0,
+        "layer_norm_epsilon": 1e-6,
+        "dropout": 0.0,
+        "dtype": "float32",
+    }
+    values.update(overrides)
+    side = values["image_size"] // values["patch_size"]
+    values.setdefault("max_patches", side * side)
+    return VisionEncoderArgs(**values)
+
+
+def num_patches(config):
+    return config.max_patches
+
+
+def build_vision_encoder(config, weights_path=None, name=VISION_ENCODER_NAME):
+    patch_dim = 3 * config.patch_size ** 2
+    pixel_values = Input((num_patches(config), patch_dim), name="pixel_values")
+    pixel_position_ids = Input(
+        (num_patches(config), 2), dtype="int32", name="pixel_position_ids")
+    hidden = build_patch_embedder(pixel_values, pixel_position_ids, config)
+    real_mask = build_real_patch_mask(pixel_position_ids)
+    key_mask = build_vision_attention_mask(pixel_position_ids)
+    for layer_index in range(config.num_layers):
+        block_name = "encoder_block_{}".format(layer_index)
+        hidden = vision_decoder_block(
+            hidden, key_mask, pixel_position_ids, config, block_name)
+        hidden = hidden * real_mask
+    pooled = build_average_pooling(hidden, pixel_position_ids, config)
+    output = build_vision_output(pooled, config)
+    inputs = {"pixel_values": pixel_values,
+              "pixel_position_ids": pixel_position_ids}
+    model = Model(inputs, output, name=name)
+    if weights_path is not None:
+        model.load_weights(str(Path(weights_path)))
+    return model

--- a/paz/models/foundation/gemma4/vision.py
+++ b/paz/models/foundation/gemma4/vision.py
@@ -6,7 +6,8 @@ from keras.layers import Input
 
 from paz.models.foundation.gemma4.layers.vision import (
     build_average_pooling, build_patch_embedder, build_real_patch_mask,
-    build_vision_attention_mask, build_vision_output, vision_decoder_block)
+    build_vision_attention_mask, build_vision_decoder_block,
+    build_vision_output)
 
 VISION_ENCODER_NAME = "gemma4_vision_encoder"
 VISION_ENCODER_FIELDS = (
@@ -56,7 +57,7 @@ def build_vision_encoder(config, weights_path=None, name=VISION_ENCODER_NAME):
     key_mask = build_vision_attention_mask(pixel_position_ids)
     for layer_index in range(config.num_layers):
         block_name = "encoder_block_{}".format(layer_index)
-        hidden = vision_decoder_block(
+        hidden = build_vision_decoder_block(
             hidden, key_mask, pixel_position_ids, config, block_name)
         hidden = hidden * real_mask
     pooled = build_average_pooling(hidden, pixel_position_ids, config)

--- a/paz/models/foundation/gemma4/vision_test.py
+++ b/paz/models/foundation/gemma4/vision_test.py
@@ -1,0 +1,105 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import re
+
+import numpy as np
+import keras
+import pytest
+
+from paz.models.foundation.gemma4.vision import (
+    build_vision_encoder, build_vision_encoder_args, num_patches)
+
+gemma4 = pytest.importorskip(
+    "keras_hub.src.models.gemma4.gemma4_vision_encoder")
+Gemma4VisionEncoder = gemma4.Gemma4VisionEncoder
+
+CONFIG = build_vision_encoder_args()
+
+
+def build_reference():
+    return Gemma4VisionEncoder(
+        image_size=CONFIG.image_size, patch_size=CONFIG.patch_size,
+        num_heads=CONFIG.num_heads, hidden_dim=CONFIG.hidden_dim,
+        num_layers=CONFIG.num_layers, intermediate_dim=CONFIG.intermediate_dim,
+        head_dim=CONFIG.head_dim, output_dim=CONFIG.output_dim,
+        num_key_value_heads=CONFIG.num_key_value_heads,
+        pool_size=CONFIG.pool_size,
+        position_embedding_size=CONFIG.position_embedding_size,
+        rope_max_wavelength=CONFIG.rope_wavelength,
+        layer_norm_epsilon=CONFIG.layer_norm_epsilon, dropout=0.0,
+        use_clipped_linears=True, standardize=False, dtype="float32")
+
+
+def role(path):
+    path = path.replace("/dense/", "/")
+    match = re.search(r"encoder_block_(\d+)", path)
+    if match:
+        rest = path[match.end():].lstrip("/_").replace("/", "_")
+        return "b{}:{}".format(int(match.group(1)), rest)
+    if "position_embedding_table" in path:
+        return "g:position_embedding_table"
+    parts = path.split("/")
+    return "g:{}_{}".format(parts[-2], parts[-1])
+
+
+def transfer(source, target):
+    weights = {role(w.path): np.asarray(keras.ops.convert_to_numpy(w))
+               for w in source.weights}
+    for variable in target.weights:
+        variable.assign(weights[role(variable.path)].reshape(variable.shape))
+
+
+def build_inputs():
+    side = CONFIG.image_size // CONFIG.patch_size
+    cols = np.tile(np.arange(side), side)
+    rows = np.repeat(np.arange(side), side)
+    positions = np.stack([cols, rows], -1).astype("int32")
+    rng = np.random.default_rng(0)
+    patch_dim = 3 * CONFIG.patch_size ** 2
+    values = rng.standard_normal(
+        (1, num_patches(CONFIG), patch_dim)).astype("float32")
+    return values, positions[None]
+
+
+def build_rectangular_inputs():
+    rows, columns = 4, 6
+    grid_x = np.tile(np.arange(columns), rows)
+    grid_y = np.repeat(np.arange(rows), columns)
+    positions = np.stack([grid_x, grid_y], -1).astype("int32")
+    real = rows * columns
+    pad = CONFIG.max_patches - real
+    pad_positions = -np.ones((pad, 2), dtype="int32")
+    positions = np.concatenate([positions, pad_positions], axis=0)
+    patch_dim = 3 * CONFIG.patch_size ** 2
+    values = np.random.default_rng(1).standard_normal(
+        (1, real, patch_dim)).astype("float32")
+    values = np.concatenate(
+        [values, np.zeros((1, pad, patch_dim), "float32")], axis=1)
+    return values, positions[None]
+
+
+def compare(reference, encoder, values, positions):
+    paz_out = np.array(encoder(
+        {"pixel_values": values, "pixel_position_ids": positions}))
+    kh_inputs = {"pixel_values": values[:, None],
+                 "pixel_position_ids": positions[:, None]}
+    kh_out = np.array(reference(kh_inputs)).reshape(paz_out.shape)
+    return float(np.max(np.abs(paz_out - kh_out)))
+
+
+def test_vision_encoder_matches_keras_hub():
+    reference = build_reference()
+    encoder = build_vision_encoder(CONFIG)
+    transfer(reference, encoder)
+    values, positions = build_inputs()
+    assert compare(reference, encoder, values, positions) < 1e-4
+
+
+def test_vision_encoder_matches_keras_hub_rectangular():
+    reference = build_reference()
+    encoder = build_vision_encoder(CONFIG)
+    transfer(reference, encoder)
+    values, positions = build_rectangular_inputs()
+    assert compare(reference, encoder, values, positions) < 1e-4

--- a/paz/models/transformers/__init__.py
+++ b/paz/models/transformers/__init__.py
@@ -8,6 +8,7 @@ and exposes bare-verb functions: ``cache.build``, ``cache.update``,
 from paz.models.transformers import cache
 from paz.models.transformers import mask
 from paz.models.transformers import logits
+from paz.models.transformers import numerics
 from paz.models.transformers import search
 from paz.models.transformers import feedforward
 from paz.models.transformers import attention

--- a/paz/models/transformers/numerics.py
+++ b/paz/models/transformers/numerics.py
@@ -1,0 +1,25 @@
+"""Numeric helpers for low-precision (float16) transformer arithmetic.
+
+Float16 overflows at +-65504, so residual sums are accumulated in float32 and
+clipped before casting back. Models running in float32 or bfloat16 pass through
+unchanged.
+"""
+import keras
+from keras import ops
+
+
+def clip_float16(values):
+    dtype = keras.backend.standardize_dtype(values.dtype)
+    if dtype != "float16":
+        return values
+    return ops.clip(values, -65504, 65504)
+
+
+def add_residual(left, right):
+    dtype = keras.backend.standardize_dtype(left.dtype)
+    if dtype != "float16":
+        return left + right
+    left = ops.cast(left, "float32")
+    right = ops.cast(right, "float32")
+    output = clip_float16(ops.add(left, right))
+    return ops.cast(output, "float16")

--- a/paz/models/transformers/numerics_test.py
+++ b/paz/models/transformers/numerics_test.py
@@ -1,0 +1,34 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+from keras import ops
+
+from paz.models.transformers import numerics
+
+
+def test_clip_float16_passes_through_float32():
+    values = ops.convert_to_tensor([1e6, -1e6], dtype="float32")
+    out = np.asarray(numerics.clip_float16(values))
+    assert np.allclose(out, [1e6, -1e6])
+
+
+def test_clip_float16_clips_float16_overflow():
+    values = ops.convert_to_tensor([70000.0, -70000.0], dtype="float16")
+    out = np.asarray(numerics.clip_float16(values)).astype("float32")
+    assert np.allclose(out, [65504.0, -65504.0])
+
+
+def test_add_residual_float32_is_plain_sum():
+    left = ops.convert_to_tensor([1.0, 2.0], dtype="float32")
+    right = ops.convert_to_tensor([3.0, 4.0], dtype="float32")
+    out = np.asarray(numerics.add_residual(left, right))
+    assert np.allclose(out, [4.0, 6.0])
+
+
+def test_add_residual_float16_accumulates_in_float32():
+    left = ops.convert_to_tensor([1000.0], dtype="float16")
+    right = ops.convert_to_tensor([2000.0], dtype="float16")
+    result = numerics.add_residual(left, right)
+    assert np.allclose(np.asarray(result).astype("float32"), [3000.0])


### PR DESCRIPTION
Second PR of the Gemma4 promotion series (after #379). Relocates the working
text+multimodal Gemma4 port from `examples/gemma4` into a first-class paz
foundation model, mirroring the merged Whisper layout.

## What changed
- New `paz/models/foundation/gemma4/` — a flat **namespace package** (no root
  `__init__.py`, only `layers/__init__.py`, plus a `conftest.py` setting
  `KERAS_BACKEND=jax`, exactly like the whisper/dinov3 foundations). Internal
  imports are absolute; **model logic is unchanged**.
- `Gemma4(model_name="gemma4_2b", weights="paz", models_path=None)` bundle
  returning a namedtuple `Gemma4(config, decoder_step, per_layer_step,
  vision_encoder)`. The pieces stay individually trainable/swappable.
- Weights load from a local `models_path` (`decoder_step.weights.h5`,
  `embedding_step.weights.h5`, optional `vision_encoder.weights.h5`). A
  `GEMMA4_WEIGHTS_URL` scaffold is reserved for hosted weights — deferred,
  since the checkpoints are 9–18 GB (redistribution is allowed under the Gemma
  Terms of Use; the exact license card should be confirmed before any upload).
- Re-export `from .foundation.gemma4.model import Gemma4` in
  `paz/models/__init__.py`.
- The lifted `paz.transformers.{logits.soft_cap, mask.sliding_window}` from
  #379 are consumed (no model-local copies).

## Reuse / kept-local (consistent with the #377 whisper review)
Already reuses `paz.transformers.{cache,search,logits,embeddings.rotary}` and
`paz.layers.{RMSNormalization,MergeDims,SplitDim}`. Gemma attention
(RoPE + Q/K-norm + value VNorm + GQA + soft-cap + KV-cache padding), the GeGLU
feedforward (EinsumDense + approximate GELU + per-block norms), `Gemma4VNorm`,
`ScalarMultiply`, and the SentencePiece/metaspace tokenizer stay in the gemma
package — folding them into shared modules would need behavior-switching flags
or break bit-for-bit weight loading.

## Behavior preservation (proven)
With imports stripped, every relocated module is **byte-identical** to its
`examples/gemma4` counterpart; `model.py` differs only by the added `Gemma4`
bundle. Loading the real local weights produces the **identical** result via
the foundation modules and the example modules (both currently hit the same
pre-existing stale-weights `RMSNormalization` mismatch in
`examples/gemma4/weights`, independent of this move), confirming no behavior
change.

## Tests (KERAS_BACKEND=jax, XLA_PYTHON_CLIENT_PREALLOCATE=false)
- `pytest paz/models/foundation/gemma4/` → **36 passed, 4 skipped**. Skips are
  the keras_hub-gemma4 parity tests (`keras_hub.src.models.gemma4` not
  installed) and the opt-in weights test.
- Tokenizer / image_converter tests, which were broken in the example (missing
  never-committed fixture; a stale position assertion), are fixed and now
  self-contained (the tiny byte-BPE fixture is built in-test; the repo tracks
  no JSON assets).
- `gemma4_test.py` covers the bundle contract; the end-to-end generation check
  (`test_gemma4_generates_capital_of_germany`) is opt-in via
  `GEMMA4_WEIGHTS_TEST=1` because the real weights are multi-GB and need CPU.

The example under `examples/gemma4` is untouched and still works; PR C will add
`GenerateGemma4`/`DescribeImageGemma4` and remove the now-duplicated modules.