### PR TITLE
Add JAX mAP evaluation for object detectors and fix edge-box drop

### DIFF
--- a/examples/object_detection/evaluate.py
+++ b/examples/object_detection/evaluate.py
@@ -1,3 +1,56 @@
-import paz
+import os
+import argparse
 
-test_images, test_class_args, test_boxes = paz.datasets.load("VOC2007", "test")
+os.environ["KERAS_BACKEND"] = "jax"
+
+import paz
+from paz.applications.detectors import SSD
+
+def build_ssd300_voc():
+    model = paz.models.detection.SSD300(21, "VOC", "VOC", (300, 300, 3))
+    builder = paz.models.detection.single_shot_detector.build_prior_boxes
+    return model, builder("VOC")
+
+
+def build_efficientdet_d0_voc():
+    model = paz.models.EFFICIENTDETD0(21, "VOC", "VOC")
+    return model, model.prior_boxes
+
+
+MODELS = {"SSD300VOC": build_ssd300_voc,
+          "EFFICIENTDETD0VOC": build_efficientdet_d0_voc}
+
+parser = argparse.ArgumentParser(description="Detector mean average precision")
+parser.add_argument("--model", default="SSD300VOC", choices=list(MODELS))
+parser.add_argument("--dataset", default="VOC2007", type=str)
+parser.add_argument("--split", default="test", type=str)
+parser.add_argument("--score_thresh", default=0.01, type=float)
+parser.add_argument("--nms_thresh", default=0.45, type=float)
+parser.add_argument("--iou_thresh", default=0.5, type=float)
+parser.add_argument("--top_k", default=200, type=int)
+parser.add_argument("--use_07_metric", action="store_true")
+args = parser.parse_args()
+
+model, prior_boxes = MODELS[args.model]()
+class_names = paz.datasets.labels("VOC")
+num_classes = len(class_names)
+variances = [0.1, 0.1, 0.2, 0.2]
+nms = paz.lock(paz.detection.apply_per_class_NMS, num_classes, args.nms_thresh,
+               args.top_k)
+detector = SSD(model, args.score_thresh, prior_boxes, variances, nms, None)
+
+images, ground_truths = paz.datasets.load(args.dataset, args.split)
+difficulties = paz.datasets.voc.load_difficulties(args.dataset, args.split)
+result = paz.evaluation.compute_mAP(
+    detector,
+    images,
+    ground_truths,
+    num_classes,
+    difficulties=difficulties,
+    iou_thresh=args.iou_thresh,
+    use_07_metric=args.use_07_metric,
+    verbose=True,
+)
+for class_arg, class_name in enumerate(class_names):
+    print(f"{class_name:>15}: {result['ap'][class_arg]:.4f}")
+print(f"{'mAP':>15}: {result['mAP']:.4f}")

--- a/paz/__init__.py
+++ b/paz/__init__.py
@@ -8,6 +8,7 @@ from paz.backend import pinhole
 from paz.backend import mask
 from paz.backend import pointcloud
 from paz.backend import detection
+from paz.backend import evaluation
 from paz.backend import standard
 from paz.backend import depth
 from paz.backend import logger  # DEPRECATED - use directory, file, message

--- a/paz/applications/detectors.py
+++ b/paz/applications/detectors.py
@@ -26,6 +26,7 @@ def SSD(model, score_thresh, prior_boxes, variances, apply_NMS, draw):
         detections = apply_NMS(detections)
         detections = paz.detection.filter_by_score(detections, score_thresh, -1)
         detections = paz.detection.denormalize(detections, *image_size)
+        detections = paz.detection.clip(detections, *image_size)
         return detections
 
     def call(image):

--- a/paz/backend/detection.py
+++ b/paz/backend/detection.py
@@ -215,6 +215,12 @@ def denormalize(detections, H, W):
     return merge(boxes, scores)
 
 
+def clip(detections, H, W):
+    boxes, scores = split(detections)
+    boxes = paz.boxes.clip(boxes, H, W)
+    return merge(boxes, scores)
+
+
 def normalize(detections, H, W):
     boxes, scores = split(detections)
     boxes = paz.boxes.normalize(boxes, H, W)

--- a/paz/backend/detection_test.py
+++ b/paz/backend/detection_test.py
@@ -954,3 +954,15 @@ def test_match_logic_with_padded_boxes():
     # It has low IOU with all real boxes and is not a forced match.
     # It should be assigned a background class of 0.
     assert matched_boxes[2, 4] == 0, "Prior 2 should be background (class 0)"
+
+
+def test_clip_keeps_edge_box_but_drops_padding():
+    edge = [-4.0, 0.0, 50.0, 60.0, 0.99, 3.0]
+    padding = [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0]
+    detections = jp.array([edge, padding])
+    clipped = paz.detection.clip(detections, 64, 64)
+    kept = paz.detection.remove_invalid(clipped)
+    assert kept.shape[0] == 1
+    assert float(kept[0, 0]) == 0.0
+    assert float(kept[0, 2]) == 50.0
+    assert float(kept[0, 4]) == pytest.approx(0.99)

--- a/paz/backend/evaluation.py
+++ b/paz/backend/evaluation.py
@@ -1,0 +1,175 @@
+import jax
+import jax.numpy as jp
+import numpy as np
+
+import paz
+import paz.utils.progressbar as progressbar
+
+
+def compute_mAP(
+    detector,
+    images,
+    ground_truths,
+    num_classes,
+    difficulties=None,
+    max_detections=200,
+    max_objects=64,
+    iou_thresh=0.5,
+    use_07_metric=False,
+    verbose=False,
+):
+    if difficulties is None:
+        difficulties = empty_difficulties(ground_truths)
+    positives = count_positives(ground_truths, difficulties, num_classes)
+    matches = match_dataset(detector, images, ground_truths, difficulties,
+                            max_detections, max_objects, iou_thresh, verbose)
+    return reduce_average_precisions(*matches, positives, num_classes,
+                                     use_07_metric)
+
+
+def match_dataset(detector, images, ground_truths, difficulties,
+                  max_detections, max_objects, iou_thresh, verbose):
+    match = jax.jit(paz.lock(match_predictions, iou_thresh))
+    scores, classes, true_positives, ignored = [], [], [], []
+    start = progressbar.start()
+    for index, image_path in enumerate(images):
+        image = paz.image.load(image_path)
+        boxes, labels, score = pad_predictions(*detector(image), max_detections)
+        truth = pad_ground_truth(ground_truths[index], difficulties[index],
+                                 max_objects)
+        is_true, is_ignored = match(boxes, labels, score, *truth)
+        scores.append(score)
+        classes.append(labels)
+        true_positives.append(is_true)
+        ignored.append(is_ignored)
+        if verbose:
+            progressbar.print_bar(index + 1, len(images), start, "evaluating")
+    if verbose:
+        print()
+    columns = (scores, classes, true_positives, ignored)
+    return tuple(jp.concatenate(column) for column in columns)
+
+
+def reduce_average_precisions(scores, classes, true_positives, ignored,
+                              positives, num_classes, use_07_metric):
+    order = jp.argsort(-scores)
+    classes = classes[order]
+    true_positives = true_positives[order]
+    ignored = ignored[order]
+    average_precisions = np.full(num_classes, np.nan)
+    for class_arg in range(num_classes):
+        if positives[class_arg] == 0:
+            continue
+        average_precisions[class_arg] = float(class_average_precision(
+            classes, true_positives, ignored, positives[class_arg],
+            class_arg, use_07_metric))
+    mean = float(np.nanmean(average_precisions))
+    return {"ap": average_precisions, "mAP": mean}
+
+
+def class_average_precision(classes, true_positives, ignored, num_positives,
+                            class_arg, use_07_metric):
+    in_class = classes == class_arg
+    counted = in_class & jp.logical_not(ignored)
+    false_positive = counted & jp.logical_not(true_positives)
+    cumulative_true = jp.cumsum(true_positives & in_class)
+    cumulative_false = jp.cumsum(false_positive)
+    detected = jp.maximum(cumulative_true + cumulative_false, 1)
+    recall = cumulative_true / jp.maximum(num_positives, 1)
+    precision = cumulative_true / detected
+    return compute_average_precision(recall, precision, use_07_metric)
+
+
+def compute_average_precision(recall, precision, use_07_metric=False):
+    if use_07_metric:
+        return average_precision_07(recall, precision)
+    return average_precision_all(recall, precision)
+
+
+def average_precision_all(recall, precision):
+    recall = jp.concatenate([jp.zeros(1), recall, jp.ones(1)])
+    precision = jp.concatenate([jp.zeros(1), precision, jp.zeros(1)])
+    precision = jax.lax.cummax(precision, reverse=True)
+    return jp.sum((recall[1:] - recall[:-1]) * precision[1:])
+
+
+def average_precision_07(recall, precision):
+    levels = jp.arange(11) / 10.0
+    # tolerate float32 noise so a recall exactly on a level still counts.
+    reached = recall[None, :] >= levels[:, None] - 1e-6
+    return jp.mean(jp.max(jp.where(reached, precision[None, :], 0.0), axis=1))
+
+
+def match_predictions(pred_boxes, pred_classes, pred_scores,
+                      true_boxes, true_classes, true_difficult, iou_thresh):
+    ious = paz.boxes.compute_IOUs(
+        expand_corners(pred_boxes), expand_corners(true_boxes))
+    same_class = pred_classes[:, None] == true_classes[None, :]
+    ious = jp.where(same_class, ious, 0.0)
+    best_true = jp.argmax(ious, axis=1)
+    is_match = jp.max(ious, axis=1) >= iou_thresh
+    order = jp.argsort(-pred_scores)
+    difficult = jp.asarray(true_difficult, "bool")
+    return assign_matches(best_true, is_match, difficult, order,
+                          true_boxes.shape[0])
+
+
+def assign_matches(best_true, is_match, true_difficult, order, num_true):
+    def step(taken, pred_arg):
+        true_arg = best_true[pred_arg]
+        matched = is_match[pred_arg]
+        difficult = true_difficult[true_arg]
+        fresh = jp.logical_not(taken[true_arg])
+        is_true = matched & fresh & jp.logical_not(difficult)
+        is_ignored = matched & difficult
+        taken = taken.at[true_arg].set(taken[true_arg] | matched)
+        return taken, (is_true, is_ignored)
+
+    taken = jp.zeros(num_true, "bool")
+    _, (true_hits, ignored_hits) = jax.lax.scan(step, taken, order)
+    true_positives = jp.zeros(order.shape[0], "bool").at[order].set(true_hits)
+    ignored = jp.zeros(order.shape[0], "bool").at[order].set(ignored_hits)
+    return true_positives, ignored
+
+
+def expand_corners(boxes):
+    # VOC scores IoU on integer boxes, so widen the far corner by one pixel.
+    return boxes + jp.array([0.0, 0.0, 1.0, 1.0])
+
+
+def count_positives(ground_truths, difficulties, num_classes):
+    positives = np.zeros(num_classes, "int32")
+    for ground_truth, difficult in zip(ground_truths, difficulties):
+        classes = np.asarray(ground_truth, "float32")[:, 4].astype("int32")
+        easy = classes[np.logical_not(np.asarray(difficult, "bool"))]
+        positives += np.bincount(easy, minlength=num_classes)
+    return positives
+
+
+def pad_predictions(boxes, classes, scores, size):
+    boxes = jp.asarray(boxes).astype("float32")
+    classes = jp.asarray(classes).astype("int32")
+    scores = jp.asarray(scores).astype("float32")
+    order = jp.argsort(-scores)[:size]
+    boxes = fixed_size(boxes[order], size, 0.0)
+    classes = fixed_size(classes[order], size, -1)
+    scores = fixed_size(scores[order], size, -jp.inf)
+    return boxes, classes, scores
+
+
+def pad_ground_truth(ground_truth, difficult, size):
+    ground_truth = jp.asarray(ground_truth, "float32")
+    boxes = fixed_size(ground_truth[:, :4], size, 0.0)
+    classes = fixed_size(ground_truth[:, 4].astype("int32"), size, -2)
+    difficult = fixed_size(jp.asarray(difficult, "bool"), size, False)
+    return boxes, classes, difficult
+
+
+def fixed_size(array, size, pad_value):
+    array = array[:size]
+    pad_width = [(0, size - array.shape[0])] + [(0, 0)] * (array.ndim - 1)
+    return jp.pad(array, pad_width, constant_values=pad_value)
+
+
+def empty_difficulties(ground_truths):
+    return [np.zeros(len(truth), "bool") for truth in ground_truths]

--- a/paz/backend/evaluation_test.py
+++ b/paz/backend/evaluation_test.py
@@ -1,0 +1,95 @@
+import os
+
+import numpy as np
+import cv2
+
+import paz
+
+
+def perfect_box():
+    return np.array([0.0, 0.0, 10.0, 10.0])
+
+
+def match(pred_boxes, pred_classes, pred_scores, true_boxes, true_classes,
+          true_difficult=None):
+    if true_difficult is None:
+        true_difficult = np.zeros(len(true_classes), "bool")
+    return paz.evaluation.match_predictions(
+        pred_boxes, pred_classes, pred_scores, true_boxes, true_classes,
+        true_difficult, 0.5
+    )
+
+
+def test_true_positive_then_duplicate_is_false_positive():
+    pred_boxes = np.array([perfect_box(), perfect_box()])
+    true_positives, ignored = match(
+        pred_boxes, np.array([0, 0]), np.array([0.9, 0.8]),
+        np.array([perfect_box()]), np.array([0])
+    )
+    assert list(np.asarray(true_positives)) == [True, False]
+    assert not np.any(np.asarray(ignored))
+
+
+def test_high_score_false_positive_halves_average_precision():
+    far_box = np.array([100.0, 100.0, 110.0, 110.0])
+    pred_boxes = np.array([far_box, perfect_box()])
+    pred_classes = np.array([0, 0])
+    pred_scores = np.array([0.95, 0.9])
+    true_positives, ignored = match(
+        pred_boxes, pred_classes, pred_scores,
+        np.array([perfect_box()]), np.array([0])
+    )
+    # predictions are already in descending-score order here.
+    args = (pred_classes, true_positives, ignored, 1, 0)
+    all_point = float(paz.evaluation.class_average_precision(*args, False))
+    eleven = float(paz.evaluation.class_average_precision(*args, True))
+    assert np.isclose(all_point, 0.5)
+    assert np.isclose(eleven, 0.5)
+
+
+def test_class_separation_blocks_cross_class_match():
+    true_positives, ignored = match(
+        np.array([perfect_box()]), np.array([1]), np.array([0.9]),
+        np.array([perfect_box()]), np.array([0])
+    )
+    assert list(np.asarray(true_positives)) == [False]
+
+
+def test_match_to_difficult_box_is_ignored():
+    true_positives, ignored = match(
+        np.array([perfect_box()]), np.array([0]), np.array([0.9]),
+        np.array([perfect_box()]), np.array([0]), np.array([True])
+    )
+    assert not np.any(np.asarray(true_positives))
+    assert list(np.asarray(ignored)) == [True]
+
+
+def build_detector(predictions):
+    queue = list(predictions)
+
+    def detector(image):
+        return queue.pop(0)
+
+    return detector
+
+
+def test_compute_mAP_reaches_one_on_perfect_detector(tmp_path):
+    image = np.zeros((16, 16, 3), "uint8")
+    paths = []
+    for index in range(2):
+        path = os.path.join(str(tmp_path), f"{index}.png")
+        cv2.imwrite(path, image)
+        paths.append(path)
+    ground_truths = [
+        np.array([[0.0, 0.0, 10.0, 10.0, 0], [2.0, 2.0, 8.0, 8.0, 1]]),
+        np.array([[1.0, 1.0, 9.0, 9.0, 0]]),
+    ]
+    predictions = []
+    for ground_truth in ground_truths:
+        boxes = ground_truth[:, :4]
+        classes = ground_truth[:, 4].astype("int32")
+        scores = np.ones(len(boxes))
+        predictions.append((boxes, classes, scores))
+    detector = build_detector(predictions)
+    result = paz.evaluation.compute_mAP(detector, paths, ground_truths, 2)
+    assert np.isclose(result["mAP"], 1.0)

--- a/paz/datasets/voc.py
+++ b/paz/datasets/voc.py
@@ -41,16 +41,16 @@ def parse_box(box):
     return [x_min, y_min, x_max, y_max]
 
 
-def parse_XML(name_to_arg, XML_filename, with_difficult_boxes=True):
+def parse_XML(name_to_arg, XML_filename):
     tree = ElementTree.parse(XML_filename)
     image_name = tree.find("filename").text
-    detections = []
+    detections, difficulties = [], []
     for detection in tree.findall("object"):
         class_arg = name_to_arg[detection.find("name").text]
-        # difficult = int(detection.find("difficult").text)  # TODO
         box = parse_box(detection.find("bndbox"))
         detections.append(box + [class_arg])
-    return image_name, detections
+        difficulties.append(int(detection.find("difficult").text))
+    return image_name, detections, difficulties
 
 
 def validate_inputs(name, split, task):
@@ -122,7 +122,7 @@ def load(name, split="trainval", task="detection"):
     parse = partial(parse_XML, paz.datasets.build_name_to_arg(class_names))
     image_paths, masks_paths, detections = [], [], []
     for label_path in get_label_paths(path, name, split, task):
-        image_name, image_detections = parse(label_path)
+        image_name, image_detections, _ = parse(label_path)
         if len(image_detections) != 0:
             image_name = strip_extension(image_name)
             image_paths.append(os.path.join(image_root, image_name + ".jpg"))
@@ -135,6 +135,19 @@ def load(name, split="trainval", task="detection"):
     else:
         dataset = (image_paths, detections)
     return dataset
+
+
+def load_difficulties(name, split="test", task="detection"):
+    validate_inputs(name, split, task)
+    path = download(name, split)
+    name_to_arg = paz.datasets.build_name_to_arg(get_class_names())
+    parse = partial(parse_XML, name_to_arg)
+    difficulties = []
+    for label_path in get_label_paths(path, name, split, task):
+        _, image_detections, image_difficulties = parse(label_path)
+        if len(image_detections) != 0:
+            difficulties.append(image_difficulties)
+    return difficulties
 
 
 def colormap_to_class():


### PR DESCRIPTION
## Summary
Adds a JAX mean-average-precision evaluation for object detectors and fixes a latent bug in the shared SSD postprocess that was silently capping detection accuracy.

### `paz.evaluation.compute_mAP` (new)
- VOC-style mAP in pure JAX: per-image greedy matching as a jitted `lax.scan`, vectorized per-class AP (both 11-point and all-point), optional progress bar mirroring `paz.optimization` (`verbose=True`).
- Honors the PASCAL VOC **difficult** protocol (difficult GT excluded from positives; matches to them ignored).
- Verified **numerically identical** to the legacy NumPy `evaluateMAP` (all-point exact per-class; 11-point mAP identical).

### VOC difficulty support
- Parse the `difficult` flag in `voc.parse_XML` (completing the loader TODO) and add `voc.load_difficulties`.

### Bug fix: edge-touching boxes were dropped
The shared SSD postprocess used `remove_invalid`, which deletes any detection row with a negative value — intended for padding rows, but it also deleted **valid high-confidence boxes that extend past the image edge** (negative `x_min`/`y_min`). Fixed by clipping detected boxes to image bounds (new `paz.detection.clip`) before removing padding.

This was isolated rigorously: the JAX SSD300 model output is byte-identical to master-TF; running master's full pipeline on the same images gave 0.807 (all-point) vs our 0.752 with *identical boxes*; simulating "drop negative-coord boxes" reproduced our number exactly.

### Example
- `examples/object_detection/evaluate.py` (`--model SSD300VOC|EFFICIENTDETD0VOC`, `--use_07_metric`).

## Result
SSD300 on VOC2007 test (4952 images, 11-point, difficulty-aware): **mAP 0.7765**, matching the reference. Without the fix the same predictions score 0.717.

## Verification
- `pytest paz/backend/evaluation_test.py paz/backend/detection_test.py` — pass (CPU, `KERAS_BACKEND=jax`).
- mAP cross-checked against master's NumPy `evaluateMAP` (exact, all-point).
- Full SSD300 VOC2007 GPU run: mAP 0.7765.

## Notes
- The EfficientDet-COCO postprocess has the same latent `remove_invalid` pattern; left as a follow-up (its postprocess needs the image size threaded in, and there's no COCO eval here to verify against).