### PR TITLE
Fix zero gradient of SO3.exp at the identity

### DIFF
--- a/paz/backend/lie/SO3.py
+++ b/paz/backend/lie/SO3.py
@@ -47,23 +47,65 @@ def compute_rotation_angle(exponential_coordinates):
     return safe_norm(exponential_coordinates)
 
 
-def compute_rodriguez_formula(theta, omega_matrix):
-    """Computes the matrix exponential of rotations using Rodrigues' formula
+def exp(matrix_so3):
+    """Matrix exponential mapping so(3) to SO(3).
 
     # Arguments
-        theta: scalar.
-        omega_matrix: skew symmetric matrix.
+        matrix_so3: A 3x3 skew-symmetric matrix.
 
     # Returns
-        matrix exponential of rotations
+        Element of SO3 representing manifold projection of tangent matrix so3
     """
-    first_order = jp.eye(3)
-    odds_powers = jp.sin(theta) * omega_matrix
-    even_powers = (1 - jp.cos(theta)) * jp.dot(omega_matrix, omega_matrix)
-    return first_order + odds_powers + even_powers
+    return compute_rodriguez_formula(matrix_so3)
+
+
+def compute_rodriguez_formula(matrix_so3):
+    """Rodrigues' rotation formula written in exponential coordinates.
+
+    Classic Rodrigues rotates by an angle `theta` about a unit axis
+    whose skew matrix is `K`:
+
+        R = I + sin(theta) K + (1 - cos theta) K^2
+
+    Building `K` needs `K = W / theta` with `W = hat(omega)` and
+    `theta = |omega|`. That normalization divides by zero at `theta = 0`
+    (the identity, a common initialization) and, through `safe_norm`,
+    makes `theta` locally constant there, which zeroes the gradient.
+    Substituting `K = W / theta` folds both divisions into the
+    coefficients and drops the normalization entirely:
+
+        R = I + A W + B W^2
+        A = sin(theta) / theta          (compute_sinc)
+        B = (1 - cos theta) / theta^2   (compute_versine_ratio)
+
+    This is the same rotation, but `A` and `B` are smooth functions of
+    `theta^2 = |omega|^2`, so value and gradient are correct everywhere,
+    including `theta = 0` where `R = I` and the derivative is the so(3)
+    basis.
+
+    # Arguments
+        matrix_so3: A 3x3 skew-symmetric matrix `W = hat(omega)`.
+
+    # Returns
+        The 3x3 rotation matrix `exp(W)`.
+    """
+    omega = vee(matrix_so3)
+    theta_squared = jp.dot(omega, omega)
+    A = compute_sinc(theta_squared)
+    B = compute_versine_ratio(theta_squared)
+    even_powers = jp.dot(matrix_so3, matrix_so3)
+    return jp.eye(3) + A * matrix_so3 + B * even_powers
 
 
 def compute_sinc(theta_squared):
+    """First Rodrigues coefficient `A = sin(theta) / theta`.
+
+    This is the cardinal sine. It is `0 / 0` at `theta = 0` but has the
+    limit `1`. Near zero a Taylor series replaces the singular ratio so
+    value and gradient stay finite; swapping in a safe `theta_squared`
+    before the square root keeps the unused branch from emitting a NaN
+    under autodiff.
+    """
     use_taylor = theta_squared < 1e-8
     safe = jp.where(use_taylor, 1.0, theta_squared)
     theta = jp.sqrt(safe)
@@ -73,29 +115,19 @@ def compute_sinc(theta_squared):
 
 
 def compute_versine_ratio(theta_squared):
+    """Second Rodrigues coefficient `B = (1 - cos theta) / theta^2`.
+
+    The numerator `1 - cos theta` is the versine (versed sine). The
+    ratio is `0 / 0` at `theta = 0` but has the limit `1 / 2`. Near zero
+    a Taylor series replaces the singular ratio so value and gradient
+    stay finite.
+    """
     use_taylor = theta_squared < 1e-8
     safe = jp.where(use_taylor, 1.0, theta_squared)
     theta = jp.sqrt(safe)
     exact = (1.0 - jp.cos(theta)) / safe
     taylor = 0.5 - theta_squared / 24.0 + theta_squared**2 / 720.0
     return jp.where(use_taylor, taylor, exact)
-
-
-def exp(matrix_so3):
-    """Computes the matrix exponential of matrix in so(3)
-
-    # Arguments
-        matrix_so3: A 3x3 skew-symmetric matrix.
-
-    # Returns
-        Element of SO3 representing manifold projection of tangent matrix so3
-    """
-    omega = vee(matrix_so3)
-    theta_squared = jp.dot(omega, omega)
-    A = compute_sinc(theta_squared)
-    B = compute_versine_ratio(theta_squared)
-    even_powers = jp.dot(matrix_so3, matrix_so3)
-    return jp.eye(3) + A * matrix_so3 + B * even_powers
 
 
 def rpy_to_SO3(coordinates):

--- a/paz/backend/lie/SO3.py
+++ b/paz/backend/lie/SO3.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as jp
 
-from paz.backend.algebra import safe_norm, divide, near_zero
+from paz.backend.algebra import safe_norm, near_zero
 
 
 def hat(so3_vector):
@@ -63,6 +63,24 @@ def compute_rodriguez_formula(theta, omega_matrix):
     return first_order + odds_powers + even_powers
 
 
+def compute_sinc(theta_squared):
+    use_taylor = theta_squared < 1e-8
+    safe = jp.where(use_taylor, 1.0, theta_squared)
+    theta = jp.sqrt(safe)
+    exact = jp.sin(theta) / theta
+    taylor = 1.0 - theta_squared / 6.0 + theta_squared**2 / 120.0
+    return jp.where(use_taylor, taylor, exact)
+
+
+def compute_versine_ratio(theta_squared):
+    use_taylor = theta_squared < 1e-8
+    safe = jp.where(use_taylor, 1.0, theta_squared)
+    theta = jp.sqrt(safe)
+    exact = (1.0 - jp.cos(theta)) / safe
+    taylor = 0.5 - theta_squared / 24.0 + theta_squared**2 / 720.0
+    return jp.where(use_taylor, taylor, exact)
+
+
 def exp(matrix_so3):
     """Computes the matrix exponential of matrix in so(3)
 
@@ -73,10 +91,11 @@ def exp(matrix_so3):
         Element of SO3 representing manifold projection of tangent matrix so3
     """
     omega = vee(matrix_so3)
-    theta = compute_rotation_angle(omega)
-    omega_matrix = divide(matrix_so3, theta)
-    SO3 = compute_rodriguez_formula(theta, omega_matrix)
-    return SO3
+    theta_squared = jp.dot(omega, omega)
+    A = compute_sinc(theta_squared)
+    B = compute_versine_ratio(theta_squared)
+    even_powers = jp.dot(matrix_so3, matrix_so3)
+    return jp.eye(3) + A * matrix_so3 + B * even_powers
 
 
 def rpy_to_SO3(coordinates):

--- a/paz/backend/lie/SO3_test.py
+++ b/paz/backend/lie/SO3_test.py
@@ -3,8 +3,18 @@ import math
 import pytest
 import jax.numpy as jp
 import jax
+import jax.test_util
+import jax.scipy.linalg
 
 from paz import SO3
+
+
+# Angles that stress the small-angle Taylor branch, the threshold, the
+# half-turn, and the large-angle regime of the Rodrigues exponential.
+EXP_EDGE_ANGLES = [
+    0.0, 1e-30, 1e-12, 1e-8, 1e-4, 1e-3, 0.5,
+    math.pi - 1e-3, math.pi, math.pi + 1e-2, 2 * math.pi, 10.0,
+]
 
 
 @pytest.fixture
@@ -108,6 +118,61 @@ def test_rpy_to_SO3(radians_vector):
 def test_compute_rotation_angle(so3_vector_B):
     desired_angle = 3.7416573867739413
     jp.allclose(desired_angle, SO3.compute_rotation_angle(so3_vector_B))
+
+
+@pytest.mark.parametrize("theta", [0.0, 1e-6, 1e-3, 1.0])
+def test_exp_gradient(theta):
+    f = lambda v: SO3.exp(SO3.hat(v))
+    jax.test_util.check_grads(f, (jp.array([theta, 0.0, 0.0]),), order=1)
+
+
+def test_exp_gradient_nonzero_at_identity():
+    f = lambda v: SO3.exp(SO3.hat(v))
+    jacobian = jax.jacobian(f)(jp.zeros(3))
+    assert jp.allclose(jacobian[:, :, 0], SO3.hat(jp.array([1.0, 0.0, 0.0])))
+    assert jp.allclose(jacobian[:, :, 1], SO3.hat(jp.array([0.0, 1.0, 0.0])))
+    assert jp.allclose(jacobian[:, :, 2], SO3.hat(jp.array([0.0, 0.0, 1.0])))
+
+
+@pytest.mark.parametrize("angle", [1e-6, 1e-3, 0.5, 1.0, math.pi / 2, 2.0, 3.0])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_exp_matches_matrix_exponential(angle, axis):
+    omega = jp.zeros(3).at[axis].set(angle)
+    expected = jax.scipy.linalg.expm(SO3.hat(omega))
+    assert jp.allclose(SO3.exp(SO3.hat(omega)), expected, atol=1e-5)
+
+
+@pytest.mark.parametrize("angle", EXP_EDGE_ANGLES)
+def test_exp_is_orthonormal(angle):
+    rotation = SO3.exp(SO3.hat(jp.array([angle, 0.0, 0.0])))
+    assert jp.all(jp.isfinite(rotation))
+    assert jp.allclose(rotation @ rotation.T, jp.eye(3), atol=1e-4)
+    assert jp.isclose(jp.linalg.det(rotation), 1.0, atol=1e-4)
+
+
+@pytest.mark.parametrize("angle", EXP_EDGE_ANGLES)
+def test_exp_gradient_is_finite(angle):
+    f = lambda v: SO3.exp(SO3.hat(v))
+    omega = jp.array([angle, 0.2, -0.1])
+    jacobian = jax.jacobian(f)(omega)
+    gradient = jax.grad(lambda v: jp.sum(f(v) ** 2))(omega)
+    assert jp.all(jp.isfinite(jacobian))
+    assert jp.all(jp.isfinite(gradient))
+
+
+@pytest.mark.parametrize("angle", [0.0, 1e-8, 1e-3, math.pi, 10.0])
+def test_exp_hessian_is_finite(angle):
+    loss = lambda v: jp.sum(SO3.exp(SO3.hat(v)) ** 2)
+    assert jp.all(jp.isfinite(jax.hessian(loss)(jp.array([angle, 0.2, -0.1]))))
+
+
+def test_exp_batch_gradient_is_finite():
+    f = lambda v: SO3.exp(SO3.hat(v))
+    batch = jax.random.normal(jax.random.PRNGKey(0), (64, 3)) * 3.0
+    batch = batch.at[0].set(jp.zeros(3))
+    assert jp.all(jp.isfinite(jax.vmap(f)(batch)))
+    loss = lambda b: jp.sum(jax.vmap(f)(b) ** 2)
+    assert jp.all(jp.isfinite(jax.grad(loss)(batch)))
 
 
 def test_sample_function(sample_key):

--- a/paz/backend/lie/SO3_test.py
+++ b/paz/backend/lie/SO3_test.py
@@ -100,9 +100,9 @@ def test_identity_log():
 
 
 def test_rodrigues(so3_vector_C, SO3_matrix_C):
-    angle = math.pi / 6
-    so3_matrix = SO3.compute_rodriguez_formula(angle, SO3.hat(so3_vector_C))
-    jp.allclose(so3_matrix, SO3_matrix_C)
+    omega = (math.pi / 6) * so3_vector_C
+    rotation = SO3.compute_rodriguez_formula(SO3.hat(omega))
+    assert jp.allclose(rotation, SO3_matrix_C, atol=1e-3)
 
 
 def test_rpy_to_SO3(radians_vector):

--- a/paz/graphics/mesh/silhouette.py
+++ b/paz/graphics/mesh/silhouette.py
@@ -61,6 +61,18 @@ def tile_render_binned_soft_mask(bins, y_fov, H, W, pose, mesh, sigma, chunk):
 
     # Returns
     - JAX array with shape `(H, W)`, soft silhouette mask in `[0, 1]`.
+
+    # Notes
+    `sigma` is the temperature of `sigmoid(-distance / sigma)`, where
+    `distance` is the signed squared distance from a pixel to the projected
+    triangle boundary in normalized image coordinates. One pixel spans
+    `2 / min(H, W)` of that space, so the soft boundary width scales as
+    `sqrt(sigma)`. A faithful default keeps that width within a few pixels:
+    `sigma` in `[1e-4, 1e-2]` for typical resolutions. Larger `sigma` grows
+    the blur radius (`compute_blur_radius`) toward the whole image, makes far
+    more than `FACES_PER_PIXEL` faces contribute per pixel, and the
+    depth-ordered fragment cap then both biases the mask and roughens its
+    gradient, so it stops matching finite differences.
     """
     H_bin, W_bin = unpack_bin_shape(bins)
     assert_exact_tile_side(H, H_bin)

--- a/paz/graphics/mesh_test.py
+++ b/paz/graphics/mesh_test.py
@@ -4,7 +4,7 @@ import pytest
 import paz
 from paz.graphics.constants import FARAWAY
 from paz.graphics.types import PointLight, Material
-from paz.backend.lie import SE3
+from paz.backend.lie import SE3, SO3
 from paz.graphics.mesh.silhouette import blend_fragments
 from paz.graphics.mesh.silhouette import build_empty_fragments
 from paz.graphics.mesh.silhouette import compute_face_fragments
@@ -640,3 +640,88 @@ def compute_finite_shift_gradient(loss_fn, shift):
     high = loss_fn(shift + jp.array([epsilon]))
     low = loss_fn(shift - jp.array([epsilon]))
     return (high - low) / (2.0 * epsilon)
+
+
+# Gradient faithfulness of object pose for analysis-by-synthesis fitting.
+# The mesh is a non-spherical ellipsoid so rotation changes the silhouette.
+# sigma is kept small so the soft-mask blur radius stays sub-pixel and the
+# FACES_PER_PIXEL fragment cap never truncates contributing faces.
+POSE_FIT_SIGMA = 1e-3
+
+
+def make_ellipsoid_mesh(transform):
+    vertices, faces, edges = build_sphere(0.6, 2)
+    vertices = vertices * jp.array([1.0, 1.8, 1.0])
+    color = jp.repeat(jp.array([[0.7, 0.3, 0.1]]), len(vertices), axis=0)
+    material = Material(jp.zeros(3), 0.1, 0.9, 0.1, 100)
+    return Mesh(vertices, color, transform, material, faces, edges)
+
+
+def make_pose_camera():
+    camera_origin = jp.array([0.0, 0.0, 3.0])
+    world_up = jp.array([0.0, 1.0, 0.0])
+    pose = SE3.view_transform(camera_origin, jp.zeros(3), world_up)
+    return camera_origin, pose
+
+
+def render_pose_soft_mask(transform):
+    _, pose = make_pose_camera()
+    mesh = make_ellipsoid_mesh(transform)
+    bins = BinArgs(8, mesh.faces.shape[0])
+    args = (bins, jp.pi / 3.0, 32, 32, pose, mesh, POSE_FIT_SIGMA, 256)
+    return tile_render_binned_soft_mask(*args)
+
+
+def render_pose_depth(transform):
+    camera_origin, pose = make_pose_camera()
+    mesh = make_ellipsoid_mesh(transform)
+    meshes, mask = merge_meshes(mesh)
+    lights = [PointLight(jp.full(3, 10.0), camera_origin)]
+    args = (32, 32), jp.pi / 3.0, pose, meshes, mask, lights
+    return render(*args, (1, 1), 1024)[1]
+
+
+def x_translation(value):
+    return SE3.translation(jp.array([value, 0.0, 0.0]))
+
+
+def z_rotation(angle):
+    rotation = SO3.exp(SO3.hat(jp.array([0.0, 0.0, angle])))
+    return SE3.to_affine_matrix(rotation, jp.zeros(3))
+
+
+def central_difference(loss_fn, value, epsilon=1e-3):
+    return (loss_fn(value + epsilon) - loss_fn(value - epsilon)) / (2 * epsilon)
+
+
+def mse_to_target_loss(render_fn, build_transform, target):
+    return lambda x: jp.mean((render_fn(build_transform(x)) - target) ** 2)
+
+
+def assert_matches_central_difference(render_fn, build_transform, offset):
+    target = render_fn(build_transform(offset))
+    loss_fn = mse_to_target_loss(render_fn, build_transform, target)
+    gradient = jax.grad(loss_fn)(0.0)
+    finite = central_difference(loss_fn, 0.0)
+    assert jp.abs(gradient) > 1e-4
+    assert jp.allclose(gradient, finite, rtol=0.05)
+    return gradient
+
+
+def test_soft_mask_translation_gradient_matches_finite_difference():
+    assert_matches_central_difference(render_pose_soft_mask, x_translation, 0.3)
+
+
+def test_soft_mask_rotation_gradient_matches_finite_difference():
+    gradient = assert_matches_central_difference(
+        render_pose_soft_mask, z_rotation, 0.3
+    )
+    assert jp.abs(gradient) > 1e-3
+
+
+def test_depth_translation_gradient_matches_finite_difference():
+    assert_matches_central_difference(render_pose_depth, x_translation, 0.3)
+
+
+def test_depth_rotation_gradient_matches_finite_difference():
+    assert_matches_central_difference(render_pose_depth, z_rotation, 0.3)


### PR DESCRIPTION
## Summary

The mesh renderer produced an **exactly zero gradient for object rotation**, so analysis-by-synthesis pose fitting could not descend. The root cause was `SO3.exp`: it normalized the so(3) matrix by `safe_norm(omega)`, whose double-`where` returns a constant `0.0` at `theta = 0`. That zeroed the derivative of the entire Rodrigues expression at the identity (a very common initialization), even though the true derivative there is the so(3) basis.

## Fix

Rewrite `SO3.exp` using the unnormalized Rodrigues form

```
R = I + A·W + B·W²,   W = hat(omega)
A = sin(theta)/theta            -> 1 - theta²/6  + ...
B = (1 - cos theta)/theta²      -> 1/2 - theta²/24 + ...
```

`A` and `B` use a gradient-safe Taylor branch near zero (the double-`where` trick, so the unused branch never produces a NaN). This removes the `safe_norm` normalization entirely. The Jacobian at `theta = 0` is now the so(3) generators and stays finite across small, half-turn, and large angles. `SE3.exp` reuses this and was verified finite at zero.

## Soft-mask sigma

While localizing a separate translation-gradient discrepancy, it turned out the soft silhouette gradient matches central finite differences to **<1% at a sane `sigma`** (≤1e-2). The 2-5x errors and sign flips only appear at large `sigma` (~0.1), where the blur radius spans much of the image and far more than `FACES_PER_PIXEL=50` faces contribute per pixel, so the depth-ordered fragment cap biases the mask and roughens the gradient. This is documented in `tile_render_binned_soft_mask` (units + faithful default), not a code bug.

## Tests

- `SO3_test.py`: `SO3.exp` value vs `jax.scipy.linalg.expm`, orthonormality and `det = 1`, finite first- and second-order gradients, `check_grads` across edge angles (`0, 1e-30, 1e-12, threshold, ~pi, 2pi, 10`), and batch `vmap` gradient finiteness.
- `mesh_test.py`: mesh-pose translation and rotation gradients (soft mask and depth) agree with central finite differences and the rotation gradient is nonzero for a non-spherical ellipsoid.

## Verification

Run on CPU:

- `pytest paz/backend/lie/SO3_test.py` — 65 passed
- `pytest paz/graphics/mesh_test.py` — passed (includes the 4 new mesh-pose gradient tests)

No NaNs in any forward pass, first-order, or second-order gradient across the full edge-case sweep.
