### PR TITLE
Fix GPU OOM in DescribeImageGemma4 on 16 GB GPU

### DIFF
--- a/examples/gemma4/demo.py
+++ b/examples/gemma4/demo.py
@@ -1,6 +1,6 @@
 import os
 
-os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 os.environ["KERAS_BACKEND"] = "jax"
 
 import argparse

--- a/examples/gemma4/demo_image.py
+++ b/examples/gemma4/demo_image.py
@@ -1,6 +1,6 @@
 import os
 
-os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 os.environ["KERAS_BACKEND"] = "jax"
 
 import argparse

--- a/paz/applications/generators.py
+++ b/paz/applications/generators.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import jax
 import numpy as np
 from keras import ops
 
@@ -62,7 +63,9 @@ def encode_image(image, models, vision):
     if image.max() > 1.0:
         image = image / 255.0
     inputs = preprocess_images(image[None], vision)
-    embeddings = np.asarray(models.vision_encoder(inputs))[0]
+    cpu = jax.devices("cpu")[0]
+    with jax.default_device(cpu):
+        embeddings = np.asarray(models.vision_encoder(inputs))[0]
     positions = np.asarray(inputs["pixel_position_ids"])[0]
     pool = vision.pool_size
     width = (int(positions[:, 0].max()) + 1) // pool


### PR DESCRIPTION
## Problem

`DescribeImageGemma4` OOMs on a 16 GB GPU (RTX A4000). Two issues:

1. **Decoder weight load** — XLA's BFC allocator (capped at 75% of GPU
   memory ~12 GB) cannot satisfy the 4.38 GiB single-tensor allocation
   for the decoder weights even with `XLA_PYTHON_CLIENT_PREALLOCATE=false`.

2. **Vision encoder forward pass** — once the decoder (~10 GB) is loaded,
   XLA JIT-compiles the 16-layer float32 vision encoder and pre-allocates
   buffers for all layers simultaneously (~5.7 GB), exhausting the
   remaining 6 GB.

## Fix

- Switch both demos from `XLA_PYTHON_CLIENT_PREALLOCATE=false` to
  `XLA_PYTHON_CLIENT_ALLOCATOR=platform`, which uses CUDA malloc
  directly with no BFC cap. Fixes issue 1.

- Run the vision encoder forward pass on CPU via
  `jax.default_device(jax.devices("cpu")[0])`. The one-shot image
  embedding is fast on CPU; the resulting array moves to GPU for the
  decoder step. Fixes issue 2.

## Verification

```
# text demo (RTX A4000, 16 GB)
printf 'The capital of Germany is\n\n' | python3 examples/gemma4/demo.py \
  --models_path examples/gemma4/weights --max_tokens 12
# gemma> The capital of Germany is **Berlin**.

# image demo
printf 'What objects can you see?\n\n' | python3 examples/gemma4/demo_image.py \
  --models_path examples/gemma4/weights --max_tokens 20
# gemma> Based on the image, here are the objects I can see:
```

Both run without error on the 16 GB RTX A4000.