### PR TITLE
Fix the AAE example cube/scene and add an orientation eval

### DIFF
--- a/examples/implicit_orientation_learning/README.md
+++ b/examples/implicit_orientation_learning/README.md
@@ -14,9 +14,11 @@ Synthetic views are produced with `paz.graphics` (the built-in renderer) — no
 external rasterizer. Views are rendered once and cached to
 `experiments/views.npz`, since ray tracing is the slow step; training then
 augments the cached views each epoch (random background, occlusions,
-brightness). `scenes.build_mesh` normalizes any mesh to unit extent, so the
-default camera distance frames any object. With no `--mesh`, a colored cube is
-used so the example runs offline.
+brightness). `scenes.build_mesh` normalizes any mesh to unit extent and the
+camera is framed (distance 2.5) with an off-axis point light, so the object is
+centered with margin and its faces are distinctly shaded. With no `--mesh`, a
+solid per-face colored cube (six plain face colors) is used so the example runs
+offline.
 
 Camera poses are sampled with `paz.SO3.sample` (uniform rotations), and domain
 randomization reuses the `paz.backend.image` pipeline:
@@ -52,6 +54,24 @@ KERAS_BACKEND=jax python demo.py --weights experiments/aae.weights.h5
 Builds a 10x10 pose codebook from the same mesh, encodes each camera frame,
 and shows the nearest codebook view (the implicit orientation). No weights are
 hosted — train first to produce the checkpoint.
+
+## Evaluate
+
+```bash
+KERAS_BACKEND=jax python eval.py --weights experiments/aae.weights.h5
+```
+
+Renders a dense codebook and a held-out set of random orientations, retrieves
+the nearest codebook pose for each (clean and domain-randomized), and reports
+the geodesic angular error against the codebook-resolution oracle floor. It also
+writes a `[clean | augmented | true axes / predicted axes]` montage to
+`experiments/eval.png`. On the solid-color cube the augmented retrieval reaches
+a **median of ~7 deg**, matching the clean result and the oracle floor.
+
+A uniform-colored face is rotationally symmetric, so near face-on views cannot
+resolve the in-plane rotation; those rare views form a high-error tail (mean
+~20 deg) while typical two/three-face views are recovered exactly. Breaking each
+face's symmetry (a small per-face accent) would remove the tail.
 
 ## Notes
 

--- a/examples/implicit_orientation_learning/demo.py
+++ b/examples/implicit_orientation_learning/demo.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     parser.add_argument("--weights", default=WEIGHTS)
     parser.add_argument("--mesh", default=None)
     parser.add_argument("--image_size", default=128, type=int)
-    parser.add_argument("--distance", default=0.9, type=float)
+    parser.add_argument("--distance", default=2.5, type=float)
     parser.add_argument("--camera", default=0, type=int)
     parser.add_argument("--H", default=480, type=int)
     parser.add_argument("--W", default=640, type=int)

--- a/examples/implicit_orientation_learning/eval.py
+++ b/examples/implicit_orientation_learning/eval.py
@@ -1,0 +1,135 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+from functools import partial
+
+import numpy as np
+import cv2
+import jax
+import jax.numpy as jp
+
+import paz
+import scenes
+import codebook
+
+AXIS_COLORS = [(255, 40, 40), (40, 255, 40), (60, 120, 255)]
+
+
+def rotations_of(poses):
+    return jp.stack([jp.asarray(pose)[:3, :3] for pose in poses])
+
+
+def pairwise_degrees(query_rotations, codebook_rotations):
+    query = query_rotations.reshape(len(query_rotations), 9)
+    keys = codebook_rotations.reshape(len(codebook_rotations), 9)
+    cosine = (query @ keys.T - 1.0) / 2.0
+    return jp.degrees(jp.arccos(jp.clip(cosine, -1.0, 1.0)))
+
+
+def encode_views(encoder, views):
+    images = jp.asarray(views, jp.float32) / 255.0
+    return codebook.unit_rows(jp.asarray(encoder.predict(images, verbose=0)))
+
+
+def augment_views(views, key, occlusion_scale=0.25):
+    masks = jp.asarray((np.asarray(views) < 230).any(axis=-1))
+    randomize = partial(paz.image.randomize_rendered_image,
+                        max_radius_scale=occlusion_scale)
+    randomize = jax.jit(jax.vmap(randomize, in_axes=(0, 0, 0)))
+    keys = jax.random.split(key, len(views))
+    return np.asarray(randomize(keys, jp.asarray(views), masks), "uint8")
+
+
+def retrieve_errors(latents, book_latents, angles):
+    args = jp.argmax(latents @ book_latents.T, axis=1)
+    return np.asarray(angles[jp.arange(len(args)), args]), np.asarray(args)
+
+
+def report(name, errors, oracle):
+    median = np.median(errors)
+    mean = np.mean(errors)
+    accuracy = [np.mean(errors < t) for t in (5, 10, 20)]
+    print(f"{name:>18}: median {median:5.1f} deg  mean {mean:5.1f} deg  "
+          f"acc@5/10/20 {accuracy[0]:.2f}/{accuracy[1]:.2f}/{accuracy[2]:.2f}")
+    return median
+
+
+def project_camera_points(points, focal, half):
+    depth = jp.maximum(-points[:, 2], 1e-6)
+    column = half + focal * points[:, 0] / depth
+    row = half - focal * points[:, 1] / depth
+    return np.asarray(jp.stack([column, row], axis=-1)).astype("int32")
+
+
+def draw_pose(image, pose, focal, half, length, thickness):
+    center = jp.asarray(pose)[:3, 3]
+    rotation = jp.asarray(pose)[:3, :3]
+    tips = center[None, :] + length * rotation.T
+    points = project_camera_points(jp.concatenate([center[None], tips]),
+                                   focal, half)
+    for axis_arg in range(3):
+        start, end = tuple(points[0]), tuple(points[axis_arg + 1])
+        cv2.line(image, start, end, AXIS_COLORS[axis_arg], thickness)
+    return image
+
+
+def build_montage(clean, augmented, true_poses, pred_poses, focal, size):
+    half, length, rows = size / 2.0, 0.4, []
+    for index in range(len(clean)):
+        overlay = np.ascontiguousarray(clean[index])
+        draw_pose(overlay, true_poses[index], focal, half, length, 3)
+        draw_pose(overlay, pred_poses[index], focal, half, length, 1)
+        triple = [clean[index], augmented[index], overlay]
+        rows.append(np.concatenate(triple, axis=1))
+    return np.concatenate(rows, axis=0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Implicit orientation eval")
+    parser.add_argument("--weights", default="experiments/aae.weights.h5")
+    parser.add_argument("--mesh", default=None)
+    parser.add_argument("--image_size", default=128, type=int)
+    parser.add_argument("--distance", default=2.5, type=float)
+    parser.add_argument("--num_codebook", default=2000, type=int)
+    parser.add_argument("--num_test", default=300, type=int)
+    parser.add_argument("--output", default="experiments/eval.png")
+    args = parser.parse_args()
+
+    model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
+    model.load_weights(args.weights)
+    encoder = paz.models.extract_encoder(model)
+    mesh = scenes.build_mesh(args.mesh)
+    render = scenes.build_renderer(mesh, args.image_size, args.distance)
+
+    book_poses = scenes.random_poses(jax.random.PRNGKey(1), args.num_codebook,
+                                     args.distance)
+    book = codebook.build_codebook(encoder, render, book_poses)
+    book_rotations = rotations_of(book_poses)
+
+    test_poses = scenes.random_poses(jax.random.PRNGKey(7), args.num_test,
+                                     args.distance)
+    test_views = scenes.render_views(render, test_poses)
+    angles = pairwise_degrees(rotations_of(test_poses), book_rotations)
+    oracle = np.asarray(jp.min(angles, axis=1))
+
+    clean, _ = retrieve_errors(encode_views(encoder, test_views),
+                               book.latents, angles)
+    augmented = augment_views(test_views, jax.random.PRNGKey(3))
+    noisy, args_noisy = retrieve_errors(encode_views(encoder, augmented),
+                                        book.latents, angles)
+
+    print(f"codebook {args.num_codebook} poses, {args.num_test} test views")
+    report("oracle floor", oracle, oracle)
+    report("clean retrieval", clean, oracle)
+    report("augmented retrieval", noisy, oracle)
+
+    focal = float(1.0 / jp.tan(jp.pi / 8.0)) * (args.image_size / 2.0)
+    true_poses = [test_poses[index] for index in range(8)]
+    pred_poses = [book.poses[int(args_noisy[index])] for index in range(8)]
+    montage = build_montage(test_views[:8], augmented[:8], true_poses,
+                            pred_poses, focal, args.image_size)
+    paz.image.write(args.output, montage)
+    print("saved", args.output, "(columns: clean | augmented | "
+          "true axes thick / predicted axes thin)")

--- a/examples/implicit_orientation_learning/scenes.py
+++ b/examples/implicit_orientation_learning/scenes.py
@@ -3,9 +3,20 @@ import jax
 import jax.numpy as jp
 
 import paz
-from paz.graphics.mesh import Mesh, load_mesh, build_cube, merge_meshes
+from paz.graphics.mesh import Mesh, load_mesh, merge_meshes
 from paz.graphics.types import Material, PointLight
 from paz.graphics.viewer import mesh_renderer
+
+FACE_QUADS = [
+    [[1, 0, 0], [1, 1, 0], [1, 1, 1], [1, 0, 1]],
+    [[0, 0, 1], [0, 1, 1], [0, 1, 0], [0, 0, 0]],
+    [[0, 1, 0], [0, 1, 1], [1, 1, 1], [1, 1, 0]],
+    [[0, 0, 1], [0, 0, 0], [1, 0, 0], [1, 0, 1]],
+    [[0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1]],
+    [[1, 0, 0], [0, 0, 0], [0, 1, 0], [1, 1, 0]],
+]
+FACE_COLORS = [[1, 0, 0], [0, 1, 0], [0, 0, 1],
+               [1, 1, 0], [1, 0, 1], [0, 1, 1]]
 
 
 def normalize_vertices(vertices):
@@ -20,9 +31,31 @@ def build_face_edges(faces):
 
 
 def colored_cube():
-    vertices, faces, edges = build_cube(1.0)
-    colors = (normalize_vertices(vertices) + 0.5)
-    return vertices, faces, edges, jp.clip(colors, 0.0, 1.0)
+    vertices, faces, colors = [], [], []
+    for face_arg, quad in enumerate(FACE_QUADS):
+        corners = np.asarray(quad, "float32") - 0.5
+        vertices.extend(corners.tolist())
+        faces.extend(orient_outward(corners, 4 * face_arg))
+        colors.extend([FACE_COLORS[face_arg]] * 4)
+    vertices, faces = jp.asarray(vertices), jp.asarray(faces)
+    return vertices, faces, cube_edges(), jp.asarray(colors)
+
+
+def orient_outward(corners, base):
+    triangles = [[base, base + 1, base + 2], [base, base + 2, base + 3]]
+    normal = np.cross(corners[1] - corners[0], corners[2] - corners[0])
+    if np.dot(normal, corners.mean(axis=0)) < 0:
+        triangles = [triangle[::-1] for triangle in triangles]
+    return triangles
+
+
+def cube_edges():
+    edges = []
+    for face_arg in range(len(FACE_QUADS)):
+        ring = [4 * face_arg + offset for offset in range(4)]
+        for corner in range(4):
+            edges.append([ring[corner], ring[(corner + 1) % 4]])
+    return jp.asarray(edges)
 
 
 def build_mesh(mesh_path=None):
@@ -32,14 +65,15 @@ def build_mesh(mesh_path=None):
         vertices, faces, colors = load_mesh(mesh_path)
         edges = build_face_edges(faces)
     vertices = normalize_vertices(vertices)
-    material = Material(jp.zeros(3), 0.6, 0.0, 0.3, 32.0)
+    material = Material(jp.ones(3), 0.3, 0.8, 0.2, 32.0)
     transform = paz.SE3.identity()
     return Mesh(vertices, colors, transform, material, faces, edges)
 
 
 def build_renderer(mesh, image_size, distance, y_FOV=jp.pi / 4.0):
     meshes, mask = merge_meshes(mesh)
-    lights = [PointLight(jp.ones(3) * 1.6, jp.array([distance, distance, distance]))]  # fmt: skip
+    position = jp.array([1.5, 2.0, 2.5]) * distance
+    lights = [PointLight(jp.ones(3) * 1.6, position)]
     H = W = image_size
     return mesh_renderer(meshes, mask, H, W, y_FOV, lights, 1024 * 8, (2, 2))
 

--- a/examples/implicit_orientation_learning/train.py
+++ b/examples/implicit_orientation_learning/train.py
@@ -15,14 +15,16 @@ import scenes
 
 
 class OrientationSequence(keras.utils.PyDataset):
-    def __init__(self, views, masks, batch_size, backgrounds=None, seed=0):
+    def __init__(self, views, masks, batch_size, backgrounds=None, seed=0,
+                 occlusion_scale=0.25):
         super().__init__()
         self.views = jp.asarray(views)
         self.masks = jp.asarray(masks)
         self.batch_size = batch_size
         self.key = jax.random.PRNGKey(seed)
         randomize = partial(paz.image.randomize_rendered_image,
-                            backgrounds=backgrounds)
+                            backgrounds=backgrounds,
+                            max_radius_scale=occlusion_scale)
         self.randomize = jax.jit(jax.vmap(randomize, in_axes=(0, 0, 0)))
 
     def __len__(self):
@@ -65,16 +67,18 @@ if __name__ == "__main__":
     parser.add_argument("--backgrounds", default=None)
     parser.add_argument("--root", default="experiments")
     parser.add_argument("--image_size", default=128, type=int)
-    parser.add_argument("--distance", default=0.9, type=float)
+    parser.add_argument("--distance", default=2.5, type=float)
     parser.add_argument("--num_views", default=2000, type=int)
-    parser.add_argument("--batch_size", default=32, type=int)
+    parser.add_argument("--batch_size", default=64, type=int)
     parser.add_argument("--epochs", default=300, type=int)
+    parser.add_argument("--occlusion_scale", default=0.25, type=float)
     args = parser.parse_args()
     os.makedirs(args.root, exist_ok=True)
     pack = (args.mesh, args.num_views, args.image_size, args.distance)
     views, masks = render_dataset(*pack, args.root, seed=0)
     backgrounds = load_backgrounds(args.backgrounds, args.image_size)
-    sequence = OrientationSequence(views, masks, args.batch_size, backgrounds)
+    sequence = OrientationSequence(views, masks, args.batch_size, backgrounds,
+                                   occlusion_scale=args.occlusion_scale)
     model = paz.models.AutoEncoder((args.image_size, args.image_size, 3))
     optimizer = keras.optimizers.Adam(1e-3, amsgrad=True)
     model.compile(optimizer, "binary_crossentropy")


### PR DESCRIPTION
## Summary
Makes the implicit-orientation (augmented-autoencoder) example actually usable: fixes the offline object, frames and lights the scene, and adds a quantitative orientation evaluation.

### Cube geometry + colors
The offline object was a shared-vertex cube colored per vertex, so every face rendered as a **gradient split along its triangle diagonal**, with colors bleeding across shared corners (looked broken). Rebuilt as a proper per-face cube: **24 un-shared vertices, 12 triangles wound outward, six plain face colors** — each face is now a single solid color. Winding is auto-checked so all normals face out (correct one-sided shading).

### Scene: framing + lighting
- The unit cube sat at distance 0.9 and **overflowed the frame** (you only saw one flat face). Moved the camera back to **distance 2.5** → the whole object is centered with margin.
- The material had **`diffuse=0`** (no directional shading) → flat render. Set real diffuse shading with an **off-axis point light** so faces are distinctly lit and the 3D structure reads.

### Evaluation (new `eval.py`)
Renders a dense SO(3) codebook + held-out random orientations, retrieves the nearest pose by encoder cosine similarity (clean and domain-randomized), and reports **geodesic angular error vs the codebook-resolution oracle floor**, plus a `[clean | augmented | true-pose axes / predicted-pose axes]` montage.

Also exposes `--occlusion_scale` in `train.py` (the previous default occlusions could cover the entire small object).

## Result (solid-color cube, VOC-free, offline)
Augmented retrieval: **median ~7°**, matching the clean result and the oracle floor (6.8°). Reconstruction loss 0.40 → 0.05 after the scene fix.

Known limit: a uniform-colored face is rotationally symmetric, so near face-on views can't resolve in-plane rotation — a small high-error tail (mean ~20°) documented in the README. Typical two/three-face views are recovered exactly.

## Verification
- Cube geometry validated on CPU across the 6 canonical face-on views (one solid color each) and corner views (three solid faces meeting cleanly); all 12 triangle normals outward.
- Trained + evaluated end-to-end on GPU (RTX A4000); numbers above.
- pyflakes clean, ≤80 cols.