### PR TITLE
Add SSD512MinimalHandPose application and hand_pose_estimation example

### DIFF
--- a/examples/hand_pose_estimation/README.md
+++ b/examples/hand_pose_estimation/README.md
@@ -1,0 +1,27 @@
+# Minimal hand pose estimation
+
+Hand keypoint detection (DetNet) and joint-angle estimation (IKNet), optionally
+front-ended by an SSD512 hand detector for full-image, multi-hand inference.
+
+All scripts default to `KERAS_BACKEND=jax`.
+
+## Scripts
+
+- `demo_image.py` — run `MinimalHandPoseEstimation` on a single image
+  (downloads a test image if `--image` is unset) and write the drawn result.
+- `demo.py` — real-time `MinimalHandPoseEstimation` from a webcam.
+- `detect_demo.py` — `SSD512MinimalHandPose`: detect hands with SSD512, then
+  estimate pose per hand. Works on an `--image` or the webcam.
+- `demo3D.py` — `SSD512MinimalHandPose` with a live matplotlib 3D keypoint plot.
+- `is_open_demo.py` — `ClassifyHandClosure`: label the hand OPEN or CLOSE.
+
+## Examples
+
+```bash
+python demo_image.py
+python detect_demo.py --image path/to/image.png
+python demo.py --camera_id 0
+python demo3D.py --camera_id 0
+```
+
+Pass `--right_hand` for right-hand inference.

--- a/examples/hand_pose_estimation/demo.py
+++ b/examples/hand_pose_estimation/demo.py
@@ -1,0 +1,18 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+import paz
+
+parser = argparse.ArgumentParser(description="Minimal hand keypoint detection")
+parser.add_argument("-c", "--camera_id", type=int, default=0)
+parser.add_argument("--right_hand", action="store_true")
+parser.add_argument("--H", default=480, type=int)
+parser.add_argument("--W", default=640, type=int)
+args = parser.parse_args()
+
+estimate = paz.applications.MinimalHandPoseEstimation(right_hand=args.right_hand)
+camera = paz.Camera(identifier=args.camera_id)
+player = paz.VideoPlayer((args.H, args.W), estimate, camera)
+player.run()

--- a/examples/hand_pose_estimation/demo3D.py
+++ b/examples/hand_pose_estimation/demo3D.py
@@ -1,0 +1,53 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+import paz
+from paz.datasets.hands import hand_links, link_colors, joint_colors
+
+parser = argparse.ArgumentParser(description="Minimal hand 3D keypoints")
+parser.add_argument("-c", "--camera_id", type=int, default=0)
+parser.add_argument("--right_hand", action="store_true")
+parser.add_argument("--H", default=480, type=int)
+parser.add_argument("--W", default=640, type=int)
+args = parser.parse_args()
+
+estimate = paz.applications.SSD512MinimalHandPose(right_hand=args.right_hand)
+camera = paz.Camera(identifier=args.camera_id)
+player = paz.VideoPlayer((args.H, args.W), estimate, camera)
+links = np.array(link_colors) / 255
+joints = np.array(joint_colors) / 255
+
+
+def plot_links(ax, keypoints3D):
+    for link_arg, (parent, child) in enumerate(hand_links):
+        points = np.stack([keypoints3D[parent], keypoints3D[child]], axis=0)
+        ax.plot3D(*points.T, c=links[link_arg])
+
+
+def animate(index):
+    outputs = player.step()
+    if outputs is None:
+        return
+    (boxes, keypoints2D, keypoints3D), image = outputs
+    image = paz.image.resize_opencv(image, tuple(player.image_size))
+    paz.image.show(image, "inference", wait=False)
+    if len(keypoints3D) == 0:
+        return
+    points = np.array(keypoints3D[0])
+    plt.cla()
+    ax.set_xlabel("X"), ax.set_ylabel("Y"), ax.set_zlabel("Z")
+    ax.scatter3D(*points.T, c=joints)
+    plot_links(ax, points)
+
+
+camera.start()
+ax = plt.axes(projection="3d")
+ax.view_init(-160, -80)
+animation = FuncAnimation(plt.gcf(), animate, interval=1)
+plt.tight_layout()
+plt.show()

--- a/examples/hand_pose_estimation/demo_image.py
+++ b/examples/hand_pose_estimation/demo_image.py
@@ -1,0 +1,21 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+from keras.utils import get_file
+import paz
+
+URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.14/image_with_hand.png"  # fmt: skip
+
+parser = argparse.ArgumentParser(description="Minimal hand pose on an image")
+parser.add_argument("--image", default=None, help="RGB image; test image if unset")  # fmt: skip
+parser.add_argument("--right_hand", action="store_true")
+parser.add_argument("--output", default="hand_pose.jpg")
+args = parser.parse_args()
+
+path = args.image or get_file(os.path.basename(URL), URL, cache_subdir="paz/tests")  # fmt: skip
+estimate = paz.applications.MinimalHandPoseEstimation(right_hand=args.right_hand)
+hand, image = estimate(paz.image.load(path))
+paz.image.write(args.output, image)
+print(f"wrote {args.output}")

--- a/examples/hand_pose_estimation/detect_demo.py
+++ b/examples/hand_pose_estimation/detect_demo.py
@@ -1,0 +1,28 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+import paz
+
+parser = argparse.ArgumentParser(description="SSD512 hand detection + pose")
+parser.add_argument("--image", default=None, help="RGB image; webcam if unset")
+parser.add_argument("-c", "--camera_id", type=int, default=0)
+parser.add_argument("--box_scale", default=1.5, type=float)
+parser.add_argument("--right_hand", action="store_true")
+parser.add_argument("--H", default=480, type=int)
+parser.add_argument("--W", default=640, type=int)
+parser.add_argument("--output", default="hand_pose.jpg")
+args = parser.parse_args()
+
+estimate = paz.applications.SSD512MinimalHandPose(
+    box_scale=args.box_scale, right_hand=args.right_hand)
+
+if args.image is not None:
+    inferences, image = estimate(paz.image.load(args.image))
+    paz.image.write(args.output, image)
+    print(f"wrote {args.output}")
+else:
+    camera = paz.Camera(identifier=args.camera_id)
+    player = paz.VideoPlayer((args.H, args.W), estimate, camera)
+    player.run()

--- a/examples/hand_pose_estimation/is_open_demo.py
+++ b/examples/hand_pose_estimation/is_open_demo.py
@@ -1,0 +1,18 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+import paz
+
+parser = argparse.ArgumentParser(description="Classify hand open or closed")
+parser.add_argument("-c", "--camera_id", type=int, default=0)
+parser.add_argument("--right_hand", action="store_true")
+parser.add_argument("--H", default=480, type=int)
+parser.add_argument("--W", default=640, type=int)
+args = parser.parse_args()
+
+classify = paz.applications.ClassifyHandClosure(right_hand=args.right_hand)
+camera = paz.Camera(identifier=args.camera_id)
+player = paz.VideoPlayer((args.H, args.W), classify, camera)
+player.run()

--- a/paz/applications/__init__.py
+++ b/paz/applications/__init__.py
@@ -28,6 +28,7 @@ from paz.applications.keypoint_estimators import DetNetHandKeypoints
 from paz.applications.keypoint_estimators import IKNetHandJointAngles
 from paz.applications.keypoint_estimators import MinimalHandPoseEstimation
 from paz.applications.keypoint_estimators import DetectMinimalHand
+from paz.applications.keypoint_estimators import SSD512MinimalHandPose
 from paz.applications.keypoint_estimators import ClassifyHandClosure
 from paz.applications.pose_estimators import HeadPoseKeypointNet2D32
 from paz.applications.human_pose_estimators import HigherHRNetHumanPose2D

--- a/paz/applications/keypoint_estimators.py
+++ b/paz/applications/keypoint_estimators.py
@@ -241,3 +241,32 @@ def DetectMinimalHand(box_scale=1.5, right_hand=False, draw=None):
         return (boxes, all_keypoints2D), image
 
     return call_and_draw if callable(draw) else call
+
+
+def SSD512MinimalHandPose(box_scale=1.5, right_hand=False, draw=None):
+    detect = paz.applications.SSD512HandDetection(draw=False)
+    estimate = MinimalHandPoseEstimation(right_hand=right_hand, draw=False)
+    if draw is None:
+        draw = draw_hand_skeleton
+
+    def call(image):
+        boxes = detect(image)[0]
+        boxes = paz.boxes.square(boxes)
+        boxes = paz.boxes.scale(boxes, box_scale, box_scale)
+        boxes = paz.cast(boxes, "int32")
+        boxes = paz.boxes.remove_invalid(boxes)
+        all_keypoints2D, all_keypoints3D = [], []
+        for box in boxes:
+            hand = estimate(paz.image.crop(image, box))
+            keypoints2D = paz.points2D.shift_to_box_origin(hand.keypoints2D, box)  # fmt: skip
+            all_keypoints2D.append(keypoints2D)
+            all_keypoints3D.append(hand.keypoints3D)
+        return boxes, all_keypoints2D, all_keypoints3D
+
+    def call_and_draw(image):
+        boxes, all_keypoints2D, all_keypoints3D = call(image)
+        for keypoints2D in all_keypoints2D:
+            image = draw(image, keypoints2D)
+        return (boxes, all_keypoints2D, all_keypoints3D), image
+
+    return call_and_draw if callable(draw) else call


### PR DESCRIPTION
## Summary

Ports the `SSD512MinimalHandPose` application factory from `master` into the JAX
tree and adds the `hand_pose_estimation` example.

- **`paz/applications/keypoint_estimators.py`** — new `SSD512MinimalHandPose`
  factory in the functional closure style of the surrounding factories. It
  detects hands with `SSD512HandDetection`, then estimates pose per hand with
  `MinimalHandPoseEstimation` (DetNet + IKNet). Returns `boxes`, `keypoints2D`
  and `keypoints3D`. The existing `DetectMinimalHand` returns only 2D; this
  factory additionally exposes 3D keypoints, matching the master contract used
  by the 3D demo.
- **`paz/applications/__init__.py`** — export `SSD512MinimalHandPose`.
- **`examples/hand_pose_estimation/`** — `demo.py`, `demo_image.py`,
  `detect_demo.py`, `demo3D.py`, `is_open_demo.py`, `README.md`, adapted to the
  JAX applications API (`KERAS_BACKEND=jax`, `paz.*` functional calls,
  `paz.VideoPlayer`). Master's `hand_tracking.py` is intentionally omitted — it
  relied on the removed `SequentialProcessor`/`ControlMap`/`WrapOutput` API.

## Verification (CPU, JAX backend)

- `demo_image.py` and `detect_demo.py --image` run end-to-end and write the
  drawn output.
- On the test image, `SSD512MinimalHandPose` detects 1 hand and returns
  `keypoints2D (21, 2)` and `keypoints3D (21, 3)`.
- `keypoints2D` are byte-identical to the already-validated `DetectMinimalHand`
  (same detector + estimator + `box_scale`), so the detection/estimation path is
  correct; the factory only adds `keypoints3D`.
- 3D keypoints are finite and anatomically structured (index fingertip farther
  from the wrist than the index knuckle); 2D keypoints lie within image bounds.

## Notes

`draw=None` draws the skeleton and returns `(data, image)`; `draw=False` returns
the bare `(boxes, keypoints2D, keypoints3D)`.