### PR TITLE
Drop keras_hub runtime dependency with an internal ReversibleEmbedding

### DIFF
--- a/paz/models/foundation/gemma4/model.py
+++ b/paz/models/foundation/gemma4/model.py
@@ -8,7 +8,7 @@ from keras import Model, ops
 from keras.initializers import VarianceScaling
 from keras.layers import Embedding, EinsumDense, Input
 from keras.utils import get_file
-from keras_hub.layers import ReversibleEmbedding
+from paz.models.transformers.embeddings.reversible import ReversibleEmbedding
 
 from paz.models.transformers import cache as kv_cache
 from paz.models.transformers.logits import soft_cap as apply_soft_cap

--- a/paz/models/foundation/whisper/model.py
+++ b/paz/models/foundation/whisper/model.py
@@ -7,7 +7,7 @@ from keras.activations import gelu
 from keras.layers import Input, Conv1D, Dropout, Add, Lambda
 from keras.layers import LayerNormalization
 from keras.utils import get_file
-from keras_hub.layers import ReversibleEmbedding
+from paz.models.transformers.embeddings.reversible import ReversibleEmbedding
 
 from paz.backend.audio import log_mel_spectrogram, build_mel_filters
 from paz.models.transformers.attention import build_cache, kernel

--- a/paz/models/transformers/embeddings/__init__.py
+++ b/paz/models/transformers/embeddings/__init__.py
@@ -1,2 +1,3 @@
 from paz.models.transformers.embeddings import rotary
 from paz.models.transformers.embeddings import absolute
+from paz.models.transformers.embeddings import reversible

--- a/paz/models/transformers/embeddings/reversible.py
+++ b/paz/models/transformers/embeddings/reversible.py
@@ -1,0 +1,49 @@
+from keras import KerasTensor
+from keras import ops
+from keras.layers import Embedding
+
+
+class ReversibleEmbedding(Embedding):
+    """Embedding that can also project hidden states back to the vocabulary.
+
+    Called normally it looks up token embeddings. Called with ``reverse=True``
+    it projects from ``output_dim`` back to ``input_dim``. With tied weights
+    (the default) the reverse projection reuses the transposed embedding
+    matrix; otherwise it uses a separate ``reverse_embeddings`` weight.
+    """
+
+    def __init__(self, input_dim, output_dim, tie_weights=True, **kwargs):
+        super().__init__(input_dim, output_dim, **kwargs)
+        self.tie_weights = tie_weights
+
+    def build(self, inputs_shape=None):
+        super().build(inputs_shape)
+        if self.tie_weights:
+            return
+        kwargs = dict(name="reverse_embeddings", dtype=self.dtype)
+        kwargs["shape"] = (self.output_dim, self.input_dim)
+        kwargs["initializer"] = self.embeddings_initializer
+        self.reverse_embeddings = self.add_weight(**kwargs)
+
+    def call(self, inputs, reverse=False):
+        if not reverse:
+            return super().call(inputs)
+        return ops.matmul(inputs, self.reverse_kernel())
+
+    def reverse_kernel(self):
+        if self.tie_weights:
+            return ops.transpose(ops.convert_to_tensor(self.embeddings))
+        return self.reverse_embeddings
+
+    def compute_output_spec(self, inputs, reverse=False):
+        shape = list(inputs.shape)
+        if reverse:
+            shape[-1] = self.input_dim
+        else:
+            shape.append(self.output_dim)
+        return KerasTensor(shape, dtype=self.compute_dtype)
+
+    def get_config(self):
+        config = super().get_config()
+        config["tie_weights"] = self.tie_weights
+        return config

--- a/paz/models/transformers/embeddings/reversible_test.py
+++ b/paz/models/transformers/embeddings/reversible_test.py
@@ -1,0 +1,29 @@
+import numpy as np
+from keras import ops
+
+from paz.models.transformers.embeddings.reversible import ReversibleEmbedding
+
+
+def test_forward_looks_up_embeddings():
+    layer = ReversibleEmbedding(10, 4)
+    layer.build(None)
+    tokens = ops.convert_to_tensor([[1, 2, 3]])
+    hidden = layer(tokens)
+    assert tuple(hidden.shape) == (1, 3, 4)
+
+
+def test_reverse_projects_back_to_vocabulary():
+    layer = ReversibleEmbedding(10, 4)
+    layer.build(None)
+    hidden = ops.ones((2, 5, 4))
+    logits = layer(hidden, reverse=True)
+    assert tuple(logits.shape) == (2, 5, 10)
+
+
+def test_tied_reverse_uses_transposed_embeddings():
+    layer = ReversibleEmbedding(10, 4)
+    layer.build(None)
+    hidden = ops.convert_to_tensor(np.random.default_rng(0).standard_normal((2, 5, 4)), dtype="float32")  # fmt: skip
+    logits = np.asarray(layer(hidden, reverse=True))
+    expected = np.asarray(hidden) @ np.asarray(layer.embeddings).T
+    assert np.allclose(logits, expected, atol=1e-5)


### PR DESCRIPTION
## What

`ReversibleEmbedding` from `keras_hub` was the only runtime use of keras_hub in
paz — imported by the Whisper and Gemma4 foundation models. This adds an
internal equivalent in `paz.models.transformers.embeddings.reversible` and
points both models at it.

After this, importing and running Whisper/Gemma4 no longer requires keras_hub.
It stays an optional dependency only for the offline weight-conversion tool
(`gemma4/conversion.py`) and the opt-in parity tests, which already
`pytest.importorskip` it and skip cleanly when it is absent.

## Scope

Only the ReversibleEmbedding dependency. TFP and Keras 3 are untouched.

The internal layer reproduces the non-quantized behavior both models actually
use: forward embedding lookup and a reverse projection to the vocabulary, tied
(default) or untied. The quantization / soft-cap / reverse-dtype machinery from
keras_hub is dropped as unused — Gemma applies its soft-cap externally via the
existing `logits.soft_cap`.

## Verification

- Bit-for-bit parity against `keras_hub.layers.ReversibleEmbedding`: forward
  exact, reverse max abs diff `0.0`, for both tied and untied weights.
- New co-located `reversible_test.py` (self-contained, no keras_hub).
- `pytest paz/models/transformers/embeddings/ whisper_test.py
  gemma4/model_test.py`: 16 passed, 3 skipped (weights-only), on
  `KERAS_BACKEND=jax`. Models build, save, and load with the internal layer.
- pyflakes clean.