### PR TITLE
Add structure-from-motion example (combines master + structure_from_motion branch)

### DIFF
--- a/examples/structure_from_motion/backend.py
+++ b/examples/structure_from_motion/backend.py
@@ -1,0 +1,77 @@
+import cv2
+import numpy as np
+from scipy.optimize import least_squares
+import paz
+
+
+def detect_SIFT_features(image):
+    """Detects SIFT keypoints. No JAX equivalent exists, so this stays cv2."""
+    sift = cv2.SIFT_create()
+    keypoints, descriptors = sift.detectAndCompute(image, None)
+    return np.array(keypoints), descriptors
+
+
+def match_features(descriptors1, descriptors2, ratio=0.75):
+    matcher = cv2.FlannBasedMatcher()
+    descriptors1 = np.asarray(descriptors1, np.float32)
+    descriptors2 = np.asarray(descriptors2, np.float32)
+    knn_matches = matcher.knnMatch(descriptors1, descriptors2, k=2)
+    return [best for best, second in knn_matches
+            if best.distance < ratio * second.distance]
+
+
+def get_match_points(keypoints1, keypoints2, matches):
+    points1 = np.array([keypoints1[match.queryIdx].pt for match in matches])
+    points2 = np.array([keypoints2[match.trainIdx].pt for match in matches])
+    return points1, points2
+
+
+def get_match_indices(matches):
+    query_indices = np.array([match.queryIdx for match in matches])
+    train_indices = np.array([match.trainIdx for match in matches])
+    return query_indices, train_indices
+
+
+def solve_PnP_RANSAC(points3D, points2D, camera_intrinsics, inlier_thresh=5):
+    points2D = np.array(points2D, np.float64).reshape(-1, 1, 2)
+    points3D = np.array(points3D, np.float64)
+    args = (points3D, points2D, camera_intrinsics, None)
+    _, rotation_vector, translation, _ = cv2.solvePnPRansac(
+        *args, reprojectionError=inlier_thresh)
+    return rotation_vector.ravel(), translation.ravel()
+
+
+def refine_camera_pose(rotation, translation, points3D, points2D,
+                       camera_intrinsics):
+    """Refines a camera pose from reprojection error against fixed points3D.
+
+    Only the 6 pose parameters are optimized (not the point positions): with
+    scipy's default dense finite-difference Jacobian, adding one 3D point's
+    coordinates as free parameters costs 3 extra residual evaluations per
+    solver step, which becomes impractically slow at the hundreds of points
+    a real correspondence set has. Refining the pose, then re-triangulating
+    with it, still improves the point cloud without that cost.
+    """
+    axis_angle = paz.angles.rotation_matrix_to_compact_axis_angle(rotation)
+    pose = np.concatenate([axis_angle, translation.reshape(-1)])
+    args = (points3D, points2D, camera_intrinsics)
+    result = least_squares(compute_reprojection_residuals, pose, args=args)
+    return cv2.Rodrigues(result.x[:3])[0], result.x[3:6]
+
+
+def compute_reprojection_residuals(pose, points3D, points2D, camera_intrinsics):
+    rotation = cv2.Rodrigues(pose[:3])[0]
+    projected = paz.poses.project_to_image(
+        rotation, pose[3:6], points3D, camera_intrinsics)
+    return np.linalg.norm(points2D - projected, axis=1)
+
+
+def extract_keypoints_RGB(image, points):
+    return np.array([image[int(y), int(x)] for x, y in points])
+
+
+def remove_outliers(points, threshold=10):
+    mean = np.mean(points, axis=0)
+    distances = np.linalg.norm(points - mean, axis=1)
+    inliers = distances < threshold
+    return points[inliers], inliers

--- a/examples/structure_from_motion/demo.py
+++ b/examples/structure_from_motion/demo.py
@@ -1,0 +1,48 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+import jax
+import matplotlib.pyplot as plt
+import paz
+
+import backend
+import pipeline
+
+parser = argparse.ArgumentParser(description="Structure from motion")
+parser.add_argument("--images_path", type=str, default="datasets/images",
+                    help="Directory with an ordered sequence of images")
+parser.add_argument("--HFOV", type=float, default=70,
+                    help="Horizontal field of view in degrees")
+parser.add_argument("--match_ratio", type=float, default=0.75)
+parser.add_argument("--residual_thresh", type=float, default=0.5,
+                    help="Sampson-distance RANSAC threshold between frames")
+parser.add_argument("--correspondence_thresh", type=float, default=0.5,
+                    help="Sampson-distance RANSAC threshold for PnP tracking")
+parser.add_argument("--seed", type=int, default=0)
+args = parser.parse_args()
+
+
+def plot_3D_keypoints(points3D_list, colors_list, outlier_thresh=80):
+    axis = plt.axes(projection="3d")
+    axis.view_init(-160, -80)
+    axis.set_xlabel("X"), axis.set_ylabel("Y"), axis.set_zlabel("Z")
+    for points3D, colors in zip(points3D_list, colors_list):
+        points3D, inliers = backend.remove_outliers(points3D, outlier_thresh)
+        axis.scatter(*points3D.T, s=5, c=colors[inliers] / 255.0)
+    plt.show()
+
+
+image_names = sorted(os.listdir(args.images_path))
+images = [paz.to_numpy(paz.image.load(os.path.join(args.images_path, name)))
+         for name in image_names]
+H, W = images[0].shape[:2]
+camera_intrinsics = paz.pinhole.intrinsics_from_HFOV(H, W, args.HFOV)
+camera_intrinsics = paz.to_numpy(camera_intrinsics)
+
+key = jax.random.PRNGKey(args.seed)
+reconstruction = pipeline.reconstruct_scene(
+    images, camera_intrinsics, key, args.match_ratio, args.residual_thresh,
+    args.correspondence_thresh)
+plot_3D_keypoints(reconstruction.points3D, reconstruction.colors)

--- a/examples/structure_from_motion/demo_live.py
+++ b/examples/structure_from_motion/demo_live.py
@@ -1,0 +1,86 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"
+
+import argparse
+import shutil
+import cv2
+import jax
+import matplotlib.pyplot as plt
+import paz
+
+import backend
+import pipeline
+
+parser = argparse.ArgumentParser(description="Structure from motion (webcam)")
+parser.add_argument("--camera_id", type=int, default=0)
+parser.add_argument("--HFOV", type=float, default=70,
+                    help="Horizontal field of view in degrees")
+parser.add_argument("--match_ratio", type=float, default=0.75)
+parser.add_argument("--residual_thresh", type=float, default=0.5,
+                    help="Sampson-distance RANSAC threshold between frames")
+parser.add_argument("--correspondence_thresh", type=float, default=0.5,
+                    help="Sampson-distance RANSAC threshold for PnP tracking")
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--frame_skip", type=int, default=20,
+                    help="Keep one out of every this many recorded frames")
+args = parser.parse_args()
+
+IMAGES_PATH = "./images"
+
+
+def plot_3D_keypoints(points3D_list, colors_list, outlier_thresh=80):
+    axis = plt.axes(projection="3d")
+    axis.view_init(-160, -80)
+    axis.set_xlabel("X"), axis.set_ylabel("Y"), axis.set_zlabel("Z")
+    for points3D, colors in zip(points3D_list, colors_list):
+        points3D, inliers = backend.remove_outliers(points3D, outlier_thresh)
+        axis.scatter(*points3D.T, s=5, c=colors[inliers] / 255.0)
+    plt.show()
+
+
+def record_frames(camera, images_path, frame_skip):
+    """Records a sequence of frames while the camera moves around the scene.
+
+    paz.VideoPlayer.record_frames/extract_frames_from_video are currently
+    broken on this branch (they call resize_image/show_image/convert_
+    color_space, which no longer exist), so this records straight to disk
+    with the same paz.Camera/paz.image primitives paz.VideoPlayer.run() uses.
+    """
+    if os.path.exists(images_path):
+        shutil.rmtree(images_path)
+    os.makedirs(images_path)
+    camera.start()
+    print("Press 'q' in the capture window to stop recording.")
+    frame_arg = 0
+    while True:
+        image = camera.read()
+        if image is None:
+            continue
+        paz.image.show(image, "recording", wait=False)
+        if frame_arg % frame_skip == 0:
+            frame_name = f"{frame_arg // frame_skip:03d}.png"
+            paz.image.write(os.path.join(images_path, frame_name), image)
+        frame_arg += 1
+        if cv2.waitKey(1) & 0xFF == ord("q"):
+            break
+    camera.stop()
+    cv2.destroyAllWindows()
+
+
+camera = paz.Camera(identifier=args.camera_id)
+camera_intrinsics = paz.to_numpy(camera.intrinsics_from_HFOV(args.HFOV))
+
+answer = input("Start recording? yes/no: ")
+if answer == "yes":
+    record_frames(camera, IMAGES_PATH, args.frame_skip)
+
+image_names = sorted(os.listdir(IMAGES_PATH))
+images = [paz.to_numpy(paz.image.load(os.path.join(IMAGES_PATH, name)))
+         for name in image_names]
+
+key = jax.random.PRNGKey(args.seed)
+reconstruction = pipeline.reconstruct_scene(
+    images, camera_intrinsics, key, args.match_ratio, args.residual_thresh,
+    args.correspondence_thresh)
+plot_3D_keypoints(reconstruction.points3D, reconstruction.colors)

--- a/examples/structure_from_motion/geometry.py
+++ b/examples/structure_from_motion/geometry.py
@@ -1,0 +1,140 @@
+import jax
+import jax.numpy as jp
+import paz
+
+
+def center_and_normalize_points(points):
+    centroid = jp.mean(points, axis=0)
+    centered = points - centroid
+    rms_distance = jp.sqrt(jp.sum(centered ** 2) / len(points))
+    scale = jp.sqrt(2.0) / rms_distance
+    transform = jp.array([[scale, 0.0, -scale * centroid[0]],
+                         [0.0, scale, -scale * centroid[1]],
+                         [0.0, 0.0, 1.0]])
+    normalized_points = paz.algebra.transform_points(transform, points)
+    return transform, normalized_points
+
+
+def compute_fundamental_matrix(points1, points2):
+    """Normalized eight-point algorithm. Works for any N >= 8 points."""
+    T1, points1 = center_and_normalize_points(points1)
+    T2, points2 = center_and_normalize_points(points2)
+    x1, y1 = points1[:, 0], points1[:, 1]
+    x2, y2 = points2[:, 0], points2[:, 1]
+    ones = jp.ones_like(x1)
+    A = jp.stack([x1*x2, x2*y1, x2, y2*x1, y1*y2, y2, x1, y1, ones], axis=1)
+    _, _, Vt = jp.linalg.svd(A)
+    fundamental_matrix = Vt[-1].reshape(3, 3)
+
+    U, S, Vt = jp.linalg.svd(fundamental_matrix)
+    S = S.at[-1].set(0.0)
+    fundamental_matrix = U @ jp.diag(S) @ Vt
+    return T2.T @ fundamental_matrix @ T1
+
+
+def compute_sampson_distance(fundamental_matrix, points1, points2):
+    points1 = paz.algebra.add_ones(points1)
+    points2 = paz.algebra.add_ones(points2)
+    line1 = fundamental_matrix @ points1.T
+    line2 = fundamental_matrix.T @ points2.T
+    numerator = jp.sum(points2 * line1.T, axis=1)
+    line1_norm = jp.sum(line1[:2] ** 2, axis=0)
+    line2_norm = jp.sum(line2[:2] ** 2, axis=0)
+    return jp.abs(numerator) / jp.sqrt(line1_norm + line2_norm)
+
+
+def sample_correspondences(key, points1, points2, num_points):
+    indices = jax.random.choice(key, len(points1), (num_points,), False)
+    return points1[indices], points2[indices]
+
+
+def estimate_fundamental_matrix_RANSAC(key, points1, points2, num_points=8,
+                                       steps=1000, threshold=0.5):
+    """Fit fundamental matrix using RANSAC, following paz.plane.fit_RANSAC."""
+
+    def find_inliers(fundamental_matrix):
+        distances = compute_sampson_distance(
+            fundamental_matrix, points1, points2)
+        mask = distances < threshold
+        return mask, jp.sum(mask)
+
+    def step(state, key):
+        best_F, best_count, best_mask = state
+        sample1, sample2 = sample_correspondences(
+            key, points1, points2, num_points)
+        F = compute_fundamental_matrix(sample1, sample2)
+        mask, count = find_inliers(F)
+        should_update = count > best_count
+
+        def update():
+            return F, count, mask
+
+        def keep():
+            return state
+
+        return jax.lax.cond(should_update, update, keep), None
+
+    state = jp.eye(3), 0, jp.zeros(len(points1), dtype=bool)
+    keys = jax.random.split(key, steps)
+    (fundamental_matrix, _, inlier_mask), _ = jax.lax.scan(step, state, keys)
+    return fundamental_matrix, inlier_mask
+
+
+def compute_essential_matrix(fundamental_matrix, camera_intrinsics):
+    weighted_fundamental_matrix = camera_intrinsics.T @ fundamental_matrix
+    essential_matrix = weighted_fundamental_matrix @ camera_intrinsics
+    U, S, Vt = jp.linalg.svd(essential_matrix)
+    S = S.at[2].set(0.0)
+    return U @ jp.diag(S) @ Vt
+
+
+def decompose_essential_matrix(essential_matrix):
+    """Decomposes E into the 4 candidate (rotation, translation) poses.
+
+    SVD does not guarantee proper rotations (det=+1), so U and V's last
+    column/row are flipped when their determinant is negative, following
+    Hartley & Zisserman section 9.6.2.
+    """
+    U, _, Vt = jp.linalg.svd(essential_matrix)
+    U = jp.where(jp.linalg.det(U) < 0.0, U.at[:, -1].multiply(-1.0), U)
+    Vt = jp.where(jp.linalg.det(Vt) < 0.0, Vt.at[-1, :].multiply(-1.0), Vt)
+    W = jp.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    rotation1, rotation2 = U @ W @ Vt, U @ W.T @ Vt
+    translation1, translation2 = U[:, 2], -U[:, 2]
+    rotations = jp.stack([rotation1, rotation1, rotation2, rotation2])
+    translations = jp.stack(
+        [translation1, translation2, translation1, translation2])
+    return rotations, translations
+
+
+def build_design_matrix(P1, P2, point1, point2):
+    return jp.stack([point1[0] * P1[2] - P1[0], point1[1] * P1[2] - P1[1],
+                     point2[0] * P2[2] - P2[0], point2[1] * P2[2] - P2[1]])
+
+
+def triangulate_point(P1, P2, point1, point2):
+    design_matrix = build_design_matrix(P1, P2, point1, point2)
+    _, _, Vt = jp.linalg.svd(design_matrix)
+    return Vt[-1, :3] / Vt[-1, 3]
+
+
+def triangulate_points(P1, P2, points1, points2):
+    triangulate = jax.vmap(triangulate_point, in_axes=(None, None, 0, 0))
+    return triangulate(P1, P2, points1, points2)
+
+
+def recover_pose(essential_matrix, camera_intrinsics, points1, points2):
+    """Recovers rotation and translation with the most points in front of
+    both cameras (cheirality check), as in Hartley & Zisserman §9.6.3."""
+    rotations, translations = decompose_essential_matrix(essential_matrix)
+    P1 = paz.pinhole.make_camera_matrix(camera_intrinsics, jp.eye(4))
+
+    def count_points_in_front(rotation, translation):
+        pose = paz.pinhole.to_affine_matrix(rotation, translation)
+        P2 = paz.pinhole.make_camera_matrix(camera_intrinsics, pose)
+        points3D = triangulate_points(P1, P2, points1, points2)
+        return jp.sum(points3D[:, 2] > 0.0)
+
+    counts = jax.vmap(count_points_in_front)(rotations, translations)
+    best = jp.argmax(counts)
+    return rotations[best], translations[best]

--- a/examples/structure_from_motion/geometry_test.py
+++ b/examples/structure_from_motion/geometry_test.py
@@ -1,0 +1,193 @@
+import jax
+import jax.numpy as jp
+import numpy as np
+import pytest
+
+import geometry
+
+
+@pytest.fixture()
+def points2D_a():
+    return jp.array([[254.15909, 98.73111],
+                     [256.721, 152.4705],
+                     [257.11206, 151.94768],
+                     [260.06412, 93.84321],
+                     [260.59418, 81.620544],
+                     [260.6075, 97.16983],
+                     [264.0722, 188.04288],
+                     [265.84265, 205.66505],
+                     [267.15305, 104.23621],
+                     [269.5142, 81.93885],
+                     [269.556, 218.20561],
+                     [270.3138, 112.35374],
+                     [270.3138, 112.35374],
+                     [271.14764, 152.98955],
+                     [271.3865, 122.965096],
+                     [271.3865, 122.965096],
+                     [272.8214, 215.70013],
+                     [273.08545, 216.01633],
+                     [274.14792, 230.95091],
+                     [274.8084, 101.72618]])
+
+
+@pytest.fixture()
+def points2D_b():
+    return jp.array([[255.07156, 96.87035],
+                     [257.68927, 150.35327],
+                     [258.06985, 149.83197],
+                     [260.89386, 92.202354],
+                     [263.41153, 79.403946],
+                     [260.8904, 95.524796],
+                     [264.363, 185.93474],
+                     [266.23245, 203.72972],
+                     [267.07404, 102.7987],
+                     [272.90857, 80.90839],
+                     [269.43213, 216.02907],
+                     [270.06955, 110.855736],
+                     [270.06955, 110.855736],
+                     [271.70123, 151.29602],
+                     [271.3043, 121.69999],
+                     [271.3043, 121.69999],
+                     [272.57043, 213.67328],
+                     [272.86646, 214.09387],
+                     [273.72516, 229.03004],
+                     [274.39767, 100.53689]])
+
+
+@pytest.fixture()
+def projection_matrix_a():
+    return jp.array([[-4.20287334e+02, 1.41314313e+01,
+                     3.13622161e+02, -1.56568189e+03],
+                    [-1.73641572e+01, -4.15146145e+02,
+                     2.40316799e+02, -1.56288895e+03],
+                    [-1.52172269e-02, 1.33204805e-03,
+                     9.99883324e-01, -6.05387478e+00]])
+
+
+@pytest.fixture()
+def projection_matrix_b():
+    return jp.array([[4.13949583e+02, -1.54984249e+01,
+                     3.21878147e+02, -4.94474030e+02],
+                    [1.17554868e+01, 4.13547166e+02,
+                     2.43393817e+02, -6.92859534e+00],
+                    [-4.80418501e-03, -8.04420366e-03,
+                     9.99956104e-01, -4.25253707e-01]])
+
+
+@pytest.fixture()
+def normalization_matrix():
+    return np.array([[0.02804047, 0., -7.47952541],
+                     [0., 0.02804047, -4.01244017],
+                     [0., 0., 1.]])
+
+
+@pytest.fixture()
+def normalized_points2D_a():
+    return np.array([[-0.35278509, -1.24397345],
+                     [-0.28094793, 0.2629043],
+                     [-0.26998242, 0.24824418],
+                     [-0.18720527, -1.38103247],
+                     [-0.17234214, -1.72376176],
+                     [-0.17196864, -1.28775248],
+                     [-0.07481682, 1.26037055],
+                     [-0.02517257, 1.75450448],
+                     [0.01157166, -1.08960786],
+                     [0.07777941, -1.71483631],
+                     [0.0789515, 2.10614767],
+                     [0.10020057, -0.86198851],
+                     [0.10020057, -0.86198851],
+                     [0.12358184, 0.2774587],
+                     [0.13027958, -0.5644411],
+                     [0.13027958, -0.5644411],
+                     [0.17051485, 2.03589284],
+                     [0.17791894, 2.04475923],
+                     [0.2077111, 2.46353187],
+                     [0.22623127, -1.15999028]])
+
+
+@pytest.fixture()
+def sampson_distance():
+    return np.array([0.96611682, 0.04510975, 0.04155349, 0.69784303,
+                     0.62368629, 0.71403622, 0.08400111, 0.05026199,
+                     0.45053696, 0.74617261, 0.08947246, 0.26966316,
+                     0.26966316, 0.21738575, 0.32017698, 0.32017698,
+                     0.08169278, 0.07368215, 0.15867713, 0.04266424])
+
+
+@pytest.fixture()
+def fundamental_matrix():
+    return jp.array([[3.00833632e-05, 2.74238112e-04, -3.28646028e-02],
+                    [-2.69686680e-04, 8.95293926e-07, 6.12415044e-02],
+                    [1.70345263e-02, -6.27958463e-02, 2.08534501e+00]])
+
+
+@pytest.fixture()
+def projected_points3D():
+    return np.array([[0.36264373, -1.23625341, 3.23886064],
+                     [0.39209754, -0.87272199, 3.24149991],
+                     [0.39459755, -0.87635155, 3.24132408],
+                     [0.40132782, -1.27008061, 3.2400428],
+                     [0.40888761, -1.35549116, 3.2404476],
+                     [0.40391208, -1.24753678, 3.2383663],
+                     [0.4475146, -0.63285506, 3.24035431],
+                     [0.46367861, -0.51320109, 3.24930376],
+                     [0.44865327, -1.20027067, 3.23935538],
+                     [0.47149026, -1.35147047, 3.25064579],
+                     [0.48992536, -0.42969631, 3.24058443],
+                     [0.47132829, -1.14601123, 3.23854366],
+                     [0.47132829, -1.14601123, 3.23854366],
+                     [0.48862281, -0.87095875, 3.24227053],
+                     [0.48149337, -1.07339978, 3.24183318],
+                     [0.48149337, -1.07339978, 3.24183318],
+                     [0.51110751, -0.44686137, 3.23777487],
+                     [0.51306254, -0.44443822, 3.23999546],
+                     [0.52286043, -0.34340138, 3.2406254],
+                     [0.49890469, -1.21821233, 3.24087723]])
+
+
+def test_center_and_normalize_points(points2D_a, normalization_matrix,
+                                     normalized_points2D_a):
+    T, normalized_points2D = geometry.center_and_normalize_points(points2D_a)
+    assert np.allclose(T, normalization_matrix, atol=1e-5)
+    assert np.allclose(normalized_points2D, normalized_points2D_a, atol=1e-5)
+
+
+def test_compute_fundamental_matrix(points2D_a, points2D_b, fundamental_matrix):
+    F = geometry.compute_fundamental_matrix(points2D_a, points2D_b)
+    assert np.allclose(F, fundamental_matrix, atol=1e-4)
+
+
+def test_compute_sampson_distance(points2D_a, points2D_b, fundamental_matrix,
+                                  sampson_distance):
+    distances = geometry.compute_sampson_distance(
+        fundamental_matrix, points2D_a, points2D_b)
+    assert np.allclose(distances, sampson_distance, rtol=1e-3)
+
+
+def test_triangulate_points(projection_matrix_a, projection_matrix_b,
+                           points2D_a, points2D_b, projected_points3D):
+    points3D = geometry.triangulate_points(
+        projection_matrix_a, projection_matrix_b, points2D_a, points2D_b)
+    assert np.allclose(points3D, projected_points3D, atol=1e-5)
+
+
+def test_estimate_fundamental_matrix_RANSAC_rejects_outliers():
+    key = jax.random.PRNGKey(0)
+    rotation = jp.eye(3)
+    points3D = jp.array(np.random.default_rng(0).uniform(-1, 1, (60, 3)))
+    points3D = points3D + jp.array([0.0, 0.0, 5.0])
+    intrinsics = jp.array([[500.0, 0, 320], [0, 500.0, 240], [0, 0, 1]])
+
+    def project(translation, points3D):
+        camera_points = (rotation @ points3D.T).T + translation
+        pixels = (intrinsics @ camera_points.T).T
+        return pixels[:, :2] / pixels[:, 2:3]
+
+    points1 = project(jp.zeros(3), points3D)
+    points2 = project(jp.array([0.5, 0.0, 0.0]), points3D)
+    points2 = points2.at[:5].add(80.0)
+
+    _, inliers = geometry.estimate_fundamental_matrix_RANSAC(
+        key, points1, points2, threshold=1.0)
+    assert not bool(jp.any(inliers[:5]))
+    assert int(jp.sum(inliers)) >= 50

--- a/examples/structure_from_motion/pipeline.py
+++ b/examples/structure_from_motion/pipeline.py
@@ -1,0 +1,147 @@
+import cv2
+import jax
+import jax.numpy as jp
+import paz
+
+import backend
+import geometry
+
+
+def reconstruct_scene(images, camera_intrinsics, key, match_ratio=0.75,
+                      residual_thresh=0.5, correspondence_thresh=0.5):
+    num_images = len(images)
+    print(f"Processing image 1/{num_images}")
+    print(f"Processing image 2/{num_images}")
+    key, init_key = jax.random.split(key)
+    init = initialize_two_view(init_key, images[0], images[1],
+                               camera_intrinsics, match_ratio, residual_thresh)
+    points3D, colors = init.points3D, init.colors
+    base_feature, P_prev = init.base_feature, init.P2
+    keypoints_prev, descriptors_prev = init.keypoints2, init.descriptors2
+    all_points3D, all_colors = [points3D], [colors]
+
+    for index in range(2, num_images):
+        print(f"Processing image {index + 1}/{num_images}")
+        key, pnp_key, ransac_key = jax.random.split(key, 3)
+        keypoints_next, descriptors_next = backend.detect_SIFT_features(
+            images[index])
+
+        rotation_vector, translation = register_camera_pose(
+            pnp_key, base_feature, keypoints_next, descriptors_next, points3D,
+            camera_intrinsics, match_ratio, correspondence_thresh)
+        rotation = cv2.Rodrigues(rotation_vector)[0]
+
+        step = triangulate_new_points(
+            ransac_key, images[index - 1], keypoints_prev, descriptors_prev,
+            keypoints_next, descriptors_next, P_prev, rotation, translation,
+            camera_intrinsics, match_ratio, residual_thresh)
+        points3D, colors, base_feature, P_prev = step
+        all_points3D.append(points3D)
+        all_colors.append(colors)
+        keypoints_prev, descriptors_prev = keypoints_next, descriptors_next
+
+    return paz.NamedTuple(
+        "Reconstruction", points3D=all_points3D, colors=all_colors)
+
+
+def initialize_two_view(key, image1, image2, camera_intrinsics, match_ratio,
+                        residual_thresh):
+    keypoints1, descriptors1 = backend.detect_SIFT_features(image1)
+    keypoints2, descriptors2 = backend.detect_SIFT_features(image2)
+    matches = backend.match_features(descriptors1, descriptors2, match_ratio)
+    points1, points2 = backend.get_match_points(keypoints1, keypoints2, matches)
+    points1, points2, inliers = filter_matches(
+        key, points1, points2, residual_thresh)
+    colors = backend.extract_keypoints_RGB(image1, points1)
+
+    fundamental_matrix = geometry.compute_fundamental_matrix(
+        jp.asarray(points1), jp.asarray(points2))
+    essential_matrix = geometry.compute_essential_matrix(
+        fundamental_matrix, camera_intrinsics)
+    rotation, translation = geometry.recover_pose(
+        essential_matrix, camera_intrinsics, jp.asarray(points1),
+        jp.asarray(points2))
+
+    P1 = paz.pinhole.make_camera_matrix(camera_intrinsics, jp.eye(4))
+    P2 = build_camera_matrix(camera_intrinsics, rotation, translation)
+    points3D = geometry.triangulate_points(
+        P1, P2, jp.asarray(points1), jp.asarray(points2))
+
+    rotation, translation = backend.refine_camera_pose(
+        paz.to_numpy(rotation), paz.to_numpy(translation),
+        paz.to_numpy(points3D), points2, paz.to_numpy(camera_intrinsics))
+    P2 = build_camera_matrix(camera_intrinsics, rotation, translation)
+    points3D = paz.to_numpy(geometry.triangulate_points(
+        P1, P2, jp.asarray(points1), jp.asarray(points2)))
+
+    _, train_indices = backend.get_match_indices(matches)
+    base_indices = train_indices[inliers]
+    base_keypoints = keypoints2[base_indices]
+    base_descriptors = descriptors2[base_indices]
+    base_feature = (base_keypoints, base_descriptors)
+    return paz.NamedTuple(
+        "TwoView", points3D=points3D, colors=colors, base_feature=base_feature,
+        P2=P2, keypoints2=keypoints2, descriptors2=descriptors2)
+
+
+def register_camera_pose(key, base_feature, keypoints_next, descriptors_next,
+                         points3D_prev, camera_intrinsics, match_ratio,
+                         correspondence_thresh):
+    """Solves PnP-RANSAC for the new camera using the *new* frame's own 2D
+    observations (not the previous frame's), matched against 2D keypoints
+    that are already tied to a triangulated 3D point."""
+    base_keypoints, base_descriptors = base_feature
+    matches = backend.match_features(
+        base_descriptors, descriptors_next, match_ratio)
+    points_prev, points_next = backend.get_match_points(
+        base_keypoints, keypoints_next, matches)
+    points_prev, points_next, inliers = filter_matches(
+        key, points_prev, points_next, correspondence_thresh)
+    query_indices, _ = backend.get_match_indices(matches)
+    matched_indices = query_indices[inliers]
+    return backend.solve_PnP_RANSAC(
+        points3D_prev[matched_indices], points_next, camera_intrinsics)
+
+
+def triangulate_new_points(key, image_prev, keypoints_prev, descriptors_prev,
+                           keypoints_next, descriptors_next, P_prev, rotation,
+                           translation, camera_intrinsics, match_ratio,
+                           residual_thresh):
+    matches = backend.match_features(
+        descriptors_prev, descriptors_next, match_ratio)
+    points_prev, points_next = backend.get_match_points(
+        keypoints_prev, keypoints_next, matches)
+    points_prev, points_next, inliers = filter_matches(
+        key, points_prev, points_next, residual_thresh)
+    colors = backend.extract_keypoints_RGB(image_prev, points_prev)
+
+    P_next = build_camera_matrix(camera_intrinsics, rotation, translation)
+    points3D = geometry.triangulate_points(
+        P_prev, P_next, jp.asarray(points_prev), jp.asarray(points_next))
+
+    rotation, translation = backend.refine_camera_pose(
+        rotation, translation, paz.to_numpy(points3D), points_next,
+        paz.to_numpy(camera_intrinsics))
+    P_next = build_camera_matrix(camera_intrinsics, rotation, translation)
+    points3D = paz.to_numpy(geometry.triangulate_points(
+        P_prev, P_next, jp.asarray(points_prev), jp.asarray(points_next)))
+
+    train_indices = backend.get_match_indices(matches)[1][inliers]
+    base_keypoints = keypoints_next[train_indices]
+    base_descriptors = descriptors_next[train_indices]
+    base_feature = (base_keypoints, base_descriptors)
+    return points3D, colors, base_feature, P_next
+
+
+def build_camera_matrix(camera_intrinsics, rotation, translation):
+    pose = paz.pinhole.to_affine_matrix(
+        jp.asarray(rotation), jp.asarray(translation))
+    return paz.pinhole.make_camera_matrix(camera_intrinsics, pose)
+
+
+def filter_matches(key, points1, points2, threshold):
+    """RANSAC-filters correspondences, keeping fundamental-matrix inliers."""
+    _, mask = geometry.estimate_fundamental_matrix_RANSAC(
+        key, jp.asarray(points1), jp.asarray(points2), threshold=threshold)
+    mask = paz.to_numpy(mask)
+    return points1[mask], points2[mask], mask


### PR DESCRIPTION
## Summary
- Combines master's `examples/structure_from_motion` (SIFT/FLANN/RANSAC/PnP/bundle-adjustment pipeline) with the incremental multi-view tracking design from `origin/structure_from_motion`, ported entirely into `examples/structure_from_motion/` using current jax-branch style — no changes to `paz/`.
- `geometry.py`: fundamental/essential matrix, RANSAC, and triangulation in `jax.numpy`, following `paz.backend.plane.fit_RANSAC`'s scan/cond pattern.
- `backend.py`: SIFT/FLANN/PnP-RANSAC/pose-refinement — the pieces with no JAX path, using cv2/scipy.
- `pipeline.py`: plain-function incremental reconstruction (no `Processor` classes, which no longer exist on this branch).
- `demo.py` / `demo_live.py`: offline and webcam CLI reconstruction + 3D plot.
- `geometry_test.py`: ported numeric fixtures plus a RANSAC outlier-rejection test.
- Fixes two correctness bugs present in both source branches: PnP was solved against the previous frame's 2D points instead of the new frame's, and "bundle adjustment" packed 3D points as free parameters the residual function never read back (they never moved) — scoped to pose-only refinement + re-triangulation instead, since jointly optimizing hundreds of point positions with scipy's dense finite-difference Jacobian was impractically slow (a demo run went from seconds to 45+ minutes).

## Test plan
- [x] `pytest examples/structure_from_motion/geometry_test.py` — 5 passed
- [x] `demo.py` smoke-tested end to end against a synthetic 4-image multi-view sequence (no NaNs, positive depth throughout, correct RANSAC outlier rejection, rotation/translation recovered exactly against known ground truth)
- [x] `demo_live.py` verified for imports/argparse; the live camera capture path needs real hardware to verify further