### PR TITLE
Add fused-QKV self-attention primitives to transformers.attention

### DIFF
--- a/paz/models/transformers/attention.py
+++ b/paz/models/transformers/attention.py
@@ -2,7 +2,7 @@ import string
 
 import keras
 from keras import ops
-from keras.layers import Dropout, EinsumDense
+from keras.layers import Dense, Dropout, EinsumDense, Reshape
 
 from paz.models.transformers import cache as kv_cache
 
@@ -172,3 +172,31 @@ def merge_heads(tensor):
 
 def kernel(stddev=0.02):
     return keras.initializers.TruncatedNormal(stddev=stddev)
+
+
+def project_query_key_value(tokens, hidden_size, use_bias, name):
+    units = hidden_size * 3
+    layer = Dense(units, use_bias=use_bias, kernel_initializer=kernel(),
+                  name=f"{name}_qkv")
+    return layer(tokens)
+
+
+def split_query_key_value(fused, num_heads, head_dim):
+    heads = Reshape((-1, 3, num_heads, head_dim))(fused)
+    heads = ops.transpose(heads, (2, 0, 3, 1, 4))
+    return heads[0], heads[1], heads[2]
+
+
+def compute_attention(query, key, value):
+    head_dim = query.shape[-1]
+    scale = head_dim ** -0.5
+    scores = ops.matmul(query, ops.transpose(key, (0, 1, 3, 2))) * scale
+    probabilities = ops.softmax(scores, axis=-1)
+    return ops.matmul(probabilities, value)
+
+
+def merge_attention_heads(context):
+    transposed = ops.transpose(context, (0, 2, 1, 3))
+    num_heads = transposed.shape[2]
+    head_dim = transposed.shape[3]
+    return Reshape((-1, num_heads * head_dim))(transposed)

--- a/paz/models/transformers/attention_test.py
+++ b/paz/models/transformers/attention_test.py
@@ -1,6 +1,11 @@
+import numpy as np
 from keras import ops
 
 from paz.models.transformers.attention import attend, kv_attend, build_cache
+from paz.models.transformers.attention import project_query_key_value
+from paz.models.transformers.attention import split_query_key_value
+from paz.models.transformers.attention import compute_attention
+from paz.models.transformers.attention import merge_attention_heads
 
 
 def test_attend_preserves_query_shape():
@@ -22,3 +27,50 @@ def test_kv_attend_cross_attention_shape():
     args = (query, cache, None, None, None, 2, 16, 0.0, "cross_test")
     output, updated = kv_attend(*args)
     assert tuple(output.shape) == (1, 1, 16)
+
+
+def test_project_query_key_value_triples_last_axis():
+    tokens = ops.zeros((1, 4, 16))
+    fused = project_query_key_value(tokens, 16, True, "qkv_test")
+    assert tuple(fused.shape) == (1, 4, 48)
+
+
+def test_split_query_key_value_shapes():
+    fused = ops.zeros((1, 4, 48))
+    query, key, value = split_query_key_value(fused, 2, 8)
+    assert tuple(query.shape) == (1, 2, 4, 8)
+    assert tuple(key.shape) == (1, 2, 4, 8)
+    assert tuple(value.shape) == (1, 2, 4, 8)
+
+
+def test_split_recovers_fused_qkv_layout():
+    num_heads, head_dim = 2, 4
+    hidden = num_heads * head_dim
+    ramp = np.arange(3 * hidden, dtype="float32").reshape(1, 1, 3 * hidden)
+    query, key, value = split_query_key_value(ops.array(ramp), num_heads, head_dim)
+    expected = ramp.reshape(3, num_heads, head_dim)
+    assert np.allclose(np.array(query)[0, :, 0, :], expected[0])
+    assert np.allclose(np.array(key)[0, :, 0, :], expected[1])
+    assert np.allclose(np.array(value)[0, :, 0, :], expected[2])
+
+
+def test_compute_attention_matches_numpy():
+    rng = np.random.default_rng(0)
+    shape = (1, 2, 4, 8)
+    query = rng.standard_normal(shape).astype("float32")
+    key = rng.standard_normal(shape).astype("float32")
+    value = rng.standard_normal(shape).astype("float32")
+    output = np.array(compute_attention(*map(ops.array, (query, key, value))))
+    scale = shape[-1] ** -0.5
+    scores = query @ np.swapaxes(key, -1, -2) * scale
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    probabilities = np.exp(scores)
+    probabilities /= probabilities.sum(axis=-1, keepdims=True)
+    assert np.allclose(output, probabilities @ value, atol=1e-5)
+
+
+def test_merge_attention_heads_inverts_split_layout():
+    num_heads, head_dim = 2, 8
+    context = ops.zeros((1, num_heads, 4, head_dim))
+    merged = merge_attention_heads(context)
+    assert tuple(merged.shape) == (1, 4, num_heads * head_dim)


### PR DESCRIPTION
## What

Milestone 2 of the canonical DINOv2 / Depth Anything 3 project. Adds general,
reusable fused-QKV self-attention functions to `paz.models.transformers.attention`:

- `project_query_key_value(tokens, hidden_size, use_bias, name)` — single fused
  Dense producing `3 * hidden_size`.
- `split_query_key_value(fused, num_heads, head_dim)` — returns `(query, key,
  value)`, each `(batch, num_heads, seq, head_dim)`.
- `compute_attention(query, key, value)` — scaled dot-product attention from
  already-projected Q, K, V.
- `merge_attention_heads(context)` — `(batch, heads, seq, head_dim)` →
  `(batch, seq, heads*head_dim)`.

These are the exact primitives canonical DINOv2 self-attention composes, and the
shared DA3 base attention will reuse the same project/split/merge (inserting its
own steps between split and `compute_attention`).

## Why these boundaries

The functions are separate, switch-free, and composed explicitly (per the plan:
no boolean-flag mega-attention). The `split_query_key_value` layout reproduces
the parity-proven legacy DINOv2 fused-QKV ordering, so the later weight
converter stays valid.

## Scope decision (deviation from the plan's M2 list)

The plan lists DA3-only primitives (query/key normalization, 2D RoPE,
patch-token position construction) under this milestone. I deferred those to the
DA3 milestone (M4): they are unused by canonical DINOv2 (the immediate next
consumer), and their exact numerical convention (rotate-half vs interleaved
RoPE, qk-norm form, position layout) must be verified against the pinned DA3
reference, which is not yet established. Building them now would be unverifiable
and likely reworked. Added there, tested against the reference, they compose
cleanly on top of these primitives.

## Verification

- `KERAS_BACKEND=jax pytest paz/models/transformers` — **41 passed**.
- New tests cover: fused output width, split shapes, a convention-lock test that
  the fused axis splits as `(3, heads, head_dim)`, a NumPy parity check for the
  attention math, and head-merge shape.
- Functional-model smoke: primitives build a `keras.Model` and JIT output
  matches eager (`allclose`, atol 1e-5).
- Existing `attend`/`kv_attend`/`build_cache`/`kernel` untouched; whisper imports
  and all consumer tests pass. pyflakes clean.