### PR TITLE
Canonical DINOv2 + Depth Anything 3 (consolidated)

### DIFF
--- a/examples/depth_anything3/estimate_metric.py
+++ b/examples/depth_anything3/estimate_metric.py
@@ -1,6 +1,6 @@
 """Metric monocular depth in meters with Depth Anything 3.
 
-Convert the Apache-2.0 DA3METRIC-LARGE checkpoint first:
+Convert the DA3METRIC-LARGE checkpoint first:
 
     DA3_MODEL=metric python -m paz.models.foundation.depth_anything3.convert
 

--- a/examples/depth_anything3/estimate_metric.py
+++ b/examples/depth_anything3/estimate_metric.py
@@ -9,9 +9,9 @@ explicitly; it is never inferred.
 """
 import argparse
 
-import cv2
 import numpy as np
 
+import paz
 from paz.applications import EstimateDepthAnything3MetricLarge
 
 if __name__ == "__main__":
@@ -22,12 +22,12 @@ if __name__ == "__main__":
     parser.add_argument("--image_size", type=int, default=518)
     args = parser.parse_args()
 
-    estimate = EstimateDepthAnything3MetricLarge(
-        args.weights, args.focal_length, args.image_size)
-    image = cv2.cvtColor(cv2.imread(args.image), cv2.COLOR_BGR2RGB)
-    depth_meters, sky = estimate(image)
+    settings = args.weights, args.focal_length, args.image_size
+    estimate = EstimateDepthAnything3MetricLarge(*settings)
+    depth_meters, sky = estimate(paz.image.load(args.image))
 
     depth_meters = np.array(depth_meters)[0]
+    lowest = round(float(depth_meters.min()), 3)
+    highest = round(float(depth_meters.max()), 3)
     print("median depth (m):", round(float(np.median(depth_meters)), 3))
-    print("range (m):", round(float(depth_meters.min()), 3),
-          round(float(depth_meters.max()), 3))
+    print("range (m):", lowest, highest)

--- a/examples/depth_anything3/estimate_metric.py
+++ b/examples/depth_anything3/estimate_metric.py
@@ -1,0 +1,33 @@
+"""Metric monocular depth in meters with Depth Anything 3.
+
+Convert the Apache-2.0 DA3METRIC-LARGE checkpoint first:
+
+    DA3_MODEL=metric python -m paz.models.foundation.depth_anything3.convert
+
+Focal length is in pixels at the processed resolution and must be given
+explicitly; it is never inferred.
+"""
+import argparse
+
+import cv2
+import numpy as np
+
+from paz.applications import EstimateDepthAnything3MetricLarge
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", required=True)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--focal_length", type=float, required=True)
+    parser.add_argument("--image_size", type=int, default=518)
+    args = parser.parse_args()
+
+    estimate = EstimateDepthAnything3MetricLarge(
+        args.weights, args.focal_length, args.image_size)
+    image = cv2.cvtColor(cv2.imread(args.image), cv2.COLOR_BGR2RGB)
+    depth_meters, sky = estimate(image)
+
+    depth_meters = np.array(depth_meters)[0]
+    print("median depth (m):", round(float(np.median(depth_meters)), 3))
+    print("range (m):", round(float(depth_meters.min()), 3),
+          round(float(depth_meters.max()), 3))

--- a/examples/depth_anything3/estimate_multi_view.py
+++ b/examples/depth_anything3/estimate_multi_view.py
@@ -1,0 +1,30 @@
+"""Any-view depth, rays, and recovered cameras with Depth Anything 3.
+
+Convert the Apache-2.0 DA3-SMALL checkpoint first:
+
+    python -m paz.models.foundation.depth_anything3.convert
+"""
+import argparse
+
+import cv2
+import numpy as np
+
+from paz.applications import EstimateDepthAnything3Small
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", required=True)
+    parser.add_argument("--images", nargs="+", required=True)
+    parser.add_argument("--image_size", type=int, default=518)
+    args = parser.parse_args()
+
+    estimate = EstimateDepthAnything3Small(args.weights, args.image_size)
+    images = [cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
+              for path in args.images]
+    depth, confidence, extrinsics, intrinsics, rays, ray_confidence = estimate(images)
+
+    print("depth", tuple(depth.shape))
+    for view, (extrinsic, intrinsic) in enumerate(zip(np.array(extrinsics)[0],
+                                                      np.array(intrinsics)[0])):
+        print(f"view {view} focal", round(float(intrinsic[0, 0]), 1),
+              "translation", extrinsic[:, 3].round(3).tolist())

--- a/examples/depth_anything3/estimate_multi_view.py
+++ b/examples/depth_anything3/estimate_multi_view.py
@@ -6,9 +6,9 @@ Convert the Apache-2.0 DA3-SMALL checkpoint first:
 """
 import argparse
 
-import cv2
 import numpy as np
 
+import paz
 from paz.applications import EstimateDepthAnything3Small
 
 if __name__ == "__main__":
@@ -19,12 +19,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     estimate = EstimateDepthAnything3Small(args.weights, args.image_size)
-    images = [cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
-              for path in args.images]
-    depth, confidence, extrinsics, intrinsics, rays, ray_confidence = estimate(images)
+    images = [paz.image.load(path) for path in args.images]
+    outputs = estimate(images)
+    depth, confidence, extrinsics, intrinsics, rays, ray_confidence = outputs
 
     print("depth", tuple(depth.shape))
-    for view, (extrinsic, intrinsic) in enumerate(zip(np.array(extrinsics)[0],
-                                                      np.array(intrinsics)[0])):
-        print(f"view {view} focal", round(float(intrinsic[0, 0]), 1),
-              "translation", extrinsic[:, 3].round(3).tolist())
+    extrinsics = np.array(extrinsics)[0]
+    intrinsics = np.array(intrinsics)[0]
+    for view in range(len(extrinsics)):
+        focal = round(float(intrinsics[view][0, 0]), 1)
+        translation = extrinsics[view][:, 3].round(3).tolist()
+        print(f"view {view} focal", focal, "translation", translation)

--- a/examples/depth_anything3/estimate_multi_view.py
+++ b/examples/depth_anything3/estimate_multi_view.py
@@ -1,6 +1,6 @@
 """Any-view depth, rays, and recovered cameras with Depth Anything 3.
 
-Convert the Apache-2.0 DA3-SMALL checkpoint first:
+Convert the DA3-SMALL checkpoint first:
 
     python -m paz.models.foundation.depth_anything3.convert
 """

--- a/examples/depth_anything3/estimate_single_view.py
+++ b/examples/depth_anything3/estimate_single_view.py
@@ -6,9 +6,9 @@ Convert the Apache-2.0 DA3MONO-LARGE checkpoint first:
 """
 import argparse
 
-import cv2
 import numpy as np
 
+import paz
 from paz.applications import EstimateDepthAnything3MonoLarge
 
 if __name__ == "__main__":
@@ -20,10 +20,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     estimate = EstimateDepthAnything3MonoLarge(args.weights, args.image_size)
-    image = cv2.cvtColor(cv2.imread(args.image), cv2.COLOR_BGR2RGB)
-    depth, sky = estimate(image)
+    depth, sky = estimate(paz.image.load(args.image))
 
     depth = np.array(depth)[0]
     scaled = (depth - depth.min()) / (depth.max() - depth.min() + 1e-8)
-    cv2.imwrite(args.output, (scaled * 255).astype("uint8"))
+    gray = (scaled[..., None] * np.ones(3) * 255).astype("uint8")
+    paz.image.write(args.output, gray)
     print("saved", args.output)

--- a/examples/depth_anything3/estimate_single_view.py
+++ b/examples/depth_anything3/estimate_single_view.py
@@ -1,0 +1,29 @@
+"""Monocular relative depth with Depth Anything 3.
+
+Convert the Apache-2.0 DA3MONO-LARGE checkpoint first:
+
+    DA3_MODEL=mono python -m paz.models.foundation.depth_anything3.convert
+"""
+import argparse
+
+import cv2
+import numpy as np
+
+from paz.applications import EstimateDepthAnything3MonoLarge
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", required=True)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--image_size", type=int, default=518)
+    parser.add_argument("--output", default="depth.png")
+    args = parser.parse_args()
+
+    estimate = EstimateDepthAnything3MonoLarge(args.weights, args.image_size)
+    image = cv2.cvtColor(cv2.imread(args.image), cv2.COLOR_BGR2RGB)
+    depth, sky = estimate(image)
+
+    depth = np.array(depth)[0]
+    scaled = (depth - depth.min()) / (depth.max() - depth.min() + 1e-8)
+    cv2.imwrite(args.output, (scaled * 255).astype("uint8"))
+    print("saved", args.output)

--- a/examples/depth_anything3/estimate_single_view.py
+++ b/examples/depth_anything3/estimate_single_view.py
@@ -1,6 +1,6 @@
 """Monocular relative depth with Depth Anything 3.
 
-Convert the Apache-2.0 DA3MONO-LARGE checkpoint first:
+Convert the DA3MONO-LARGE checkpoint first:
 
     DA3_MODEL=mono python -m paz.models.foundation.depth_anything3.convert
 """

--- a/paz/__init__.py
+++ b/paz/__init__.py
@@ -53,6 +53,8 @@ from paz import losses
 from paz.abstract import Model, Node, Input, Sequential, Tree
 from paz.models.decomposition import pca as PCA
 from paz.models import transformers
+from paz.models.foundation import dinov2
+from paz.models.foundation import depth_anything3
 from paz import applications
 from paz import utils
 from paz.utils import pytree

--- a/paz/applications/__init__.py
+++ b/paz/applications/__init__.py
@@ -46,3 +46,7 @@ from paz.applications.generators import DescribeImageGemma4
 from paz.applications.generators import DescribeImageGemma42B
 from paz.applications.generators import DescribeImageGemma44B
 from paz.applications.feature_matchers import MatchXFeat
+from paz.applications.depth_estimators import EstimateDepthAnything3Small
+from paz.applications.depth_estimators import EstimateDepthAnything3Base
+from paz.applications.depth_estimators import EstimateDepthAnything3MonoLarge
+from paz.applications.depth_estimators import EstimateDepthAnything3MetricLarge

--- a/paz/applications/depth_estimators.py
+++ b/paz/applications/depth_estimators.py
@@ -10,73 +10,67 @@ Any-view estimators return, in order:
 Monocular estimators return ``depth, sky``; the metric estimator returns
 ``depth_meters, sky``.
 """
-import cv2
 import numpy as np
 from keras import ops
 
-from paz.models.foundation.depth_anything3.models import build_da3_small
-from paz.models.foundation.depth_anything3.models import build_da3_base
-from paz.models.foundation.depth_anything3.models import build_da3_mono_large
-from paz.models.foundation.depth_anything3.models import build_da3_metric_large
-
-IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], "float32")
-IMAGENET_STD = np.array([0.229, 0.224, 0.225], "float32")
-METRIC_DIVISOR = 300.0
+from paz.backend.image import resize_opencv, standardize
+from paz.models import DepthAnything3Small, DepthAnything3Base
+from paz.models import DepthAnything3MonoLarge, DepthAnything3MetricLarge
 
 
 def EstimateDepthAnything3Small(weights_path, image_size=518):
-    return build_any_view_estimator(build_da3_small, weights_path, image_size)
+    args = DepthAnything3Small, weights_path, image_size
+    return build_any_view_estimator(*args)
 
 
 def EstimateDepthAnything3Base(weights_path, image_size=518):
-    return build_any_view_estimator(build_da3_base, weights_path, image_size)
+    args = DepthAnything3Base, weights_path, image_size
+    return build_any_view_estimator(*args)
 
 
 def build_any_view_estimator(builder, weights_path, image_size):
-    models = {}
+    cache = {}
 
     def estimate(images):
         views = preprocess_views(images, image_size)
-        model = load_for_views(models, builder, views.shape[1], image_size,
-                               weights_path)
-        depth, confidence, extrinsics, intrinsics, rays, ray_confidence = model(views)
-        return depth, confidence, extrinsics, intrinsics, rays, ray_confidence
+        args = cache, builder, views.shape[1], image_size, weights_path
+        return load_view_model(*args)(views)
 
     return estimate
 
 
 def EstimateDepthAnything3MonoLarge(weights_path, image_size=518):
-    model = build_mono_model(build_da3_mono_large, weights_path, image_size)
+    model = load_mono_model(DepthAnything3MonoLarge, weights_path, image_size)
 
     def estimate(image):
-        depth, sky = model(preprocess_batch(image, image_size))
-        return depth, sky
+        return model(preprocess_batch(image, image_size))
 
     return estimate
 
 
-def EstimateDepthAnything3MetricLarge(weights_path, focal_length, image_size=518):
-    model = build_mono_model(build_da3_metric_large, weights_path, image_size)
+def EstimateDepthAnything3MetricLarge(weights_path, focal_length,
+                                      image_size=518):
+    model = load_mono_model(DepthAnything3MetricLarge, weights_path, image_size)
 
     def estimate(image):
         depth, sky = model(preprocess_batch(image, image_size))
-        return focal_length * depth / METRIC_DIVISOR, sky
+        return focal_length * depth / 300.0, sky
 
     return estimate
 
 
-def build_mono_model(builder, weights_path, image_size):
+def load_mono_model(builder, weights_path, image_size):
     model = builder((image_size, image_size, 3))
     model.load_weights(weights_path)
     return model
 
 
-def load_for_views(models, builder, num_views, image_size, weights_path):
-    if num_views not in models:
+def load_view_model(cache, builder, num_views, image_size, weights_path):
+    if num_views not in cache:
         model = builder(num_views, (image_size, image_size, 3))
         model.load_weights(weights_path)
-        models[num_views] = model
-    return models[num_views]
+        cache[num_views] = model
+    return cache[num_views]
 
 
 def preprocess_views(images, image_size):
@@ -89,10 +83,15 @@ def preprocess_batch(image, image_size):
 
 
 def preprocess_image(image, image_size):
+    mean = np.array([0.485, 0.456, 0.406], "float32")
+    std = np.array([0.229, 0.224, 0.225], "float32")
+    array = ops.convert_to_tensor(to_float(image))
+    resized = resize_opencv(array, (image_size, image_size))
+    return standardize(resized, mean, std)
+
+
+def to_float(image):
     image = np.asarray(image)
     if image.dtype == np.uint8:
-        image = image.astype("float32") / 255.0
-    resized = cv2.resize(image.astype("float32"), (image_size, image_size),
-                         interpolation=cv2.INTER_AREA)
-    normalized = (resized - IMAGENET_MEAN) / IMAGENET_STD
-    return ops.convert_to_tensor(normalized, dtype="float32")
+        return image.astype("float32") / 255.0
+    return image.astype("float32")

--- a/paz/applications/depth_estimators.py
+++ b/paz/applications/depth_estimators.py
@@ -1,0 +1,98 @@
+"""High-level Depth Anything 3 estimators.
+
+Preprocessing happens outside the compiled model: images are resized to a
+fixed square resolution (a multiple of the patch size), scaled to [0, 1], and
+ImageNet-normalized. Weights come from a converted ``.weights.h5`` file; pass
+its path explicitly until hosting is available.
+
+Any-view estimators return, in order:
+``depth, depth_confidence, extrinsics, intrinsics, rays, ray_confidence``.
+Monocular estimators return ``depth, sky``; the metric estimator returns
+``depth_meters, sky``.
+"""
+import cv2
+import numpy as np
+from keras import ops
+
+from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3.models import build_da3_base
+from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+from paz.models.foundation.depth_anything3.models import build_da3_metric_large
+
+IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], "float32")
+IMAGENET_STD = np.array([0.229, 0.224, 0.225], "float32")
+METRIC_DIVISOR = 300.0
+
+
+def EstimateDepthAnything3Small(weights_path, image_size=518):
+    return build_any_view_estimator(build_da3_small, weights_path, image_size)
+
+
+def EstimateDepthAnything3Base(weights_path, image_size=518):
+    return build_any_view_estimator(build_da3_base, weights_path, image_size)
+
+
+def build_any_view_estimator(builder, weights_path, image_size):
+    models = {}
+
+    def estimate(images):
+        views = preprocess_views(images, image_size)
+        model = load_for_views(models, builder, views.shape[1], image_size,
+                               weights_path)
+        depth, confidence, extrinsics, intrinsics, rays, ray_confidence = model(views)
+        return depth, confidence, extrinsics, intrinsics, rays, ray_confidence
+
+    return estimate
+
+
+def EstimateDepthAnything3MonoLarge(weights_path, image_size=518):
+    model = build_mono_model(build_da3_mono_large, weights_path, image_size)
+
+    def estimate(image):
+        depth, sky = model(preprocess_batch(image, image_size))
+        return depth, sky
+
+    return estimate
+
+
+def EstimateDepthAnything3MetricLarge(weights_path, focal_length, image_size=518):
+    model = build_mono_model(build_da3_metric_large, weights_path, image_size)
+
+    def estimate(image):
+        depth, sky = model(preprocess_batch(image, image_size))
+        return focal_length * depth / METRIC_DIVISOR, sky
+
+    return estimate
+
+
+def build_mono_model(builder, weights_path, image_size):
+    model = builder((image_size, image_size, 3))
+    model.load_weights(weights_path)
+    return model
+
+
+def load_for_views(models, builder, num_views, image_size, weights_path):
+    if num_views not in models:
+        model = builder(num_views, (image_size, image_size, 3))
+        model.load_weights(weights_path)
+        models[num_views] = model
+    return models[num_views]
+
+
+def preprocess_views(images, image_size):
+    views = [preprocess_image(image, image_size) for image in images]
+    return ops.expand_dims(ops.stack(views, axis=0), axis=0)
+
+
+def preprocess_batch(image, image_size):
+    return ops.expand_dims(preprocess_image(image, image_size), axis=0)
+
+
+def preprocess_image(image, image_size):
+    image = np.asarray(image)
+    if image.dtype == np.uint8:
+        image = image.astype("float32") / 255.0
+    resized = cv2.resize(image.astype("float32"), (image_size, image_size),
+                         interpolation=cv2.INTER_AREA)
+    normalized = (resized - IMAGENET_MEAN) / IMAGENET_STD
+    return ops.convert_to_tensor(normalized, dtype="float32")

--- a/paz/applications/depth_estimators_test.py
+++ b/paz/applications/depth_estimators_test.py
@@ -5,8 +5,8 @@ import numpy as np
 from paz.applications.depth_estimators import EstimateDepthAnything3Small
 from paz.applications.depth_estimators import EstimateDepthAnything3MonoLarge
 from paz.applications.depth_estimators import preprocess_image
-from paz.models.foundation.depth_anything3.models import build_da3_small
-from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+from paz.models.foundation.depth_anything3.models import DepthAnything3Small
+from paz.models.foundation.depth_anything3.models import DepthAnything3MonoLarge
 
 IMAGE_SIZE = 70
 
@@ -23,7 +23,7 @@ def test_preprocess_image_shape_and_normalization():
 
 def test_any_view_estimator_returns_six_tensors(tmp_path):
     weights = os.path.join(tmp_path, "small.weights.h5")
-    build_da3_small(2, (IMAGE_SIZE, IMAGE_SIZE, 3)).save_weights(weights)
+    DepthAnything3Small(2, (IMAGE_SIZE, IMAGE_SIZE, 3)).save_weights(weights)
     estimate = EstimateDepthAnything3Small(weights, image_size=IMAGE_SIZE)
     outputs = estimate([random_image(), random_image()])
     assert len(outputs) == 6
@@ -35,7 +35,7 @@ def test_any_view_estimator_returns_six_tensors(tmp_path):
 
 def test_mono_estimator_returns_depth_and_sky(tmp_path):
     weights = os.path.join(tmp_path, "mono.weights.h5")
-    build_da3_mono_large((IMAGE_SIZE, IMAGE_SIZE, 3)).save_weights(weights)
+    DepthAnything3MonoLarge((IMAGE_SIZE, IMAGE_SIZE, 3)).save_weights(weights)
     estimate = EstimateDepthAnything3MonoLarge(weights, image_size=IMAGE_SIZE)
     depth, sky = estimate(random_image())
     assert tuple(depth.shape) == (1, IMAGE_SIZE, IMAGE_SIZE)

--- a/paz/applications/depth_estimators_test.py
+++ b/paz/applications/depth_estimators_test.py
@@ -1,0 +1,42 @@
+import os
+
+import numpy as np
+
+from paz.applications.depth_estimators import EstimateDepthAnything3Small
+from paz.applications.depth_estimators import EstimateDepthAnything3MonoLarge
+from paz.applications.depth_estimators import preprocess_image
+from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+
+IMAGE_SIZE = 70
+
+
+def random_image():
+    return np.random.RandomState(0).randint(0, 256, (48, 64, 3), "uint8")
+
+
+def test_preprocess_image_shape_and_normalization():
+    processed = np.array(preprocess_image(random_image(), IMAGE_SIZE))
+    assert processed.shape == (IMAGE_SIZE, IMAGE_SIZE, 3)
+    assert processed.min() < 0.0 and processed.max() > 0.0
+
+
+def test_any_view_estimator_returns_six_tensors(tmp_path):
+    weights = os.path.join(tmp_path, "small.weights.h5")
+    build_da3_small(2, (IMAGE_SIZE, IMAGE_SIZE, 3)).save_weights(weights)
+    estimate = EstimateDepthAnything3Small(weights, image_size=IMAGE_SIZE)
+    outputs = estimate([random_image(), random_image()])
+    assert len(outputs) == 6
+    depth, confidence, extrinsics, intrinsics, rays, ray_confidence = outputs
+    assert tuple(depth.shape) == (1, 2, IMAGE_SIZE, IMAGE_SIZE)
+    assert tuple(extrinsics.shape) == (1, 2, 3, 4)
+    assert tuple(intrinsics.shape) == (1, 2, 3, 3)
+
+
+def test_mono_estimator_returns_depth_and_sky(tmp_path):
+    weights = os.path.join(tmp_path, "mono.weights.h5")
+    build_da3_mono_large((IMAGE_SIZE, IMAGE_SIZE, 3)).save_weights(weights)
+    estimate = EstimateDepthAnything3MonoLarge(weights, image_size=IMAGE_SIZE)
+    depth, sky = estimate(random_image())
+    assert tuple(depth.shape) == (1, IMAGE_SIZE, IMAGE_SIZE)
+    assert tuple(sky.shape) == (1, IMAGE_SIZE, IMAGE_SIZE)

--- a/paz/backend/image.py
+++ b/paz/backend/image.py
@@ -81,6 +81,39 @@ def resize(image, size, method="linear", antialias=False):
     return jax.image.resize(image, (*size, image.shape[-1]), method, antialias)
 
 
+def resize_bilinear_align_corners(image, size):
+    """Bilinear resize matching torch F.interpolate(align_corners=True).
+
+    Operates on channels-last ``(batch, height, width, channels)`` tensors and
+    uses ``keras.ops`` so it traces inside functional models and runs eagerly.
+    Separable: interpolate rows, then columns.
+    """
+    from keras import ops
+    rows = interpolate_bilinear_axis(image, 1, size[0], ops)
+    return interpolate_bilinear_axis(rows, 2, size[1], ops)
+
+
+def interpolate_bilinear_axis(image, axis, target, ops):
+    source = image.shape[axis]
+    lower, upper, weight = bilinear_sample_positions(source, target, ops)
+    low = ops.take(image, lower, axis=axis)
+    high = ops.take(image, upper, axis=axis)
+    shape = [1] * len(image.shape)
+    shape[axis] = target
+    weight = ops.reshape(weight, shape)
+    return low * (1.0 - weight) + high * weight
+
+
+def bilinear_sample_positions(source, target, ops):
+    if target == 1 or source == 1:
+        positions = ops.zeros((target,))
+    else:
+        positions = ops.arange(target) * ((source - 1) / (target - 1))
+    lower = ops.cast(ops.floor(positions), "int32")
+    upper = ops.minimum(lower + 1, source - 1)
+    return lower, upper, positions - lower
+
+
 def resize_opencv(image: jax.Array, size: tuple[int, int]) -> jax.Array:
     # TODO change to split size into H, W
     data = jax.ShapeDtypeStruct((size[0], size[1], image.shape[2]), image.dtype)

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -36,6 +36,10 @@ from .foundation.dinov2 import DINOv2Large
 from .foundation.dinov2 import DINOv2SmallFeatures
 from .foundation.dinov2 import DINOv2BaseFeatures
 from .foundation.dinov2 import DINOv2LargeFeatures
+from .foundation.depth_anything3 import DepthAnything3Small
+from .foundation.depth_anything3 import DepthAnything3Base
+from .foundation.depth_anything3 import DepthAnything3MonoLarge
+from .foundation.depth_anything3 import DepthAnything3MetricLarge
 from .foundation.dinov3.models.vision_transformer import DINOV3VITS
 from .foundation.dinov3.models.vision_transformer import DINOV3VITB
 from .foundation.dinov3.models.vision_transformer import DINOV3VITL

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -30,6 +30,12 @@ from .segmentation.unet import UNET_VGG19
 from .segmentation.unet import UNET_RESNET50
 from .autoencoder.autoencoder import AutoEncoder
 from .autoencoder.autoencoder import extract_encoder
+from .foundation.dinov2 import DINOv2Small
+from .foundation.dinov2 import DINOv2Base
+from .foundation.dinov2 import DINOv2Large
+from .foundation.dinov2 import DINOv2SmallFeatures
+from .foundation.dinov2 import DINOv2BaseFeatures
+from .foundation.dinov2 import DINOv2LargeFeatures
 from .foundation.dinov3.models.vision_transformer import DINOV3VITS
 from .foundation.dinov3.models.vision_transformer import DINOV3VITB
 from .foundation.dinov3.models.vision_transformer import DINOV3VITL

--- a/paz/models/foundation/depth_anything3/__init__.py
+++ b/paz/models/foundation/depth_anything3/__init__.py
@@ -1,0 +1,1 @@
+"""Depth Anything 3 built from canonical DINOv2 and transformer primitives."""

--- a/paz/models/foundation/depth_anything3/__init__.py
+++ b/paz/models/foundation/depth_anything3/__init__.py
@@ -1,10 +1,11 @@
 """Depth Anything 3 built from canonical DINOv2 and transformer primitives.
 
-``build_da3_small`` returns a Keras model whose outputs are, in order:
+The any-view constructors return a Keras model whose outputs are, in order:
 ``depth, depth_confidence, extrinsics, intrinsics, rays, ray_confidence``.
+The monocular constructors return ``depth, sky``.
 """
-from paz.models.foundation.depth_anything3.models import build_da3_small
-from paz.models.foundation.depth_anything3.models import build_da3_base
-from paz.models.foundation.depth_anything3.models import build_da3_mono_large
-from paz.models.foundation.depth_anything3.models import build_da3_metric_large
-from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
+from .models import DepthAnything3Small
+from .models import DepthAnything3Base
+from .models import DepthAnything3MonoLarge
+from .models import DepthAnything3MetricLarge
+from .models import build_da3_small_backbone

--- a/paz/models/foundation/depth_anything3/__init__.py
+++ b/paz/models/foundation/depth_anything3/__init__.py
@@ -4,4 +4,5 @@
 ``depth, depth_confidence, extrinsics, intrinsics, rays, ray_confidence``.
 """
 from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3.models import build_da3_base
 from paz.models.foundation.depth_anything3.models import build_da3_small_backbone

--- a/paz/models/foundation/depth_anything3/__init__.py
+++ b/paz/models/foundation/depth_anything3/__init__.py
@@ -1,1 +1,7 @@
-"""Depth Anything 3 built from canonical DINOv2 and transformer primitives."""
+"""Depth Anything 3 built from canonical DINOv2 and transformer primitives.
+
+``build_da3_small`` returns a Keras model whose outputs are, in order:
+``depth, depth_confidence, extrinsics, intrinsics, rays, ray_confidence``.
+"""
+from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3.models import build_da3_small_backbone

--- a/paz/models/foundation/depth_anything3/__init__.py
+++ b/paz/models/foundation/depth_anything3/__init__.py
@@ -5,4 +5,6 @@
 """
 from paz.models.foundation.depth_anything3.models import build_da3_small
 from paz.models.foundation.depth_anything3.models import build_da3_base
+from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+from paz.models.foundation.depth_anything3.models import build_da3_metric_large
 from paz.models.foundation.depth_anything3.models import build_da3_small_backbone

--- a/paz/models/foundation/depth_anything3/backbone.py
+++ b/paz/models/foundation/depth_anything3/backbone.py
@@ -1,82 +1,86 @@
 from keras import ops
 from keras.layers import LayerNormalization
 
-from paz.models.foundation.dinov2.blocks import build_dinov2_block
+from paz.models.foundation.dinov2 import blocks as dinov2_blocks
 from paz.models.foundation.depth_anything3 import routing
-from paz.models.foundation.depth_anything3.blocks import build_da3_block
-from paz.models.foundation.depth_anything3.embeddings import insert_camera_tokens
-
-LAYER_NORM_EPSILON = 1e-6
+from paz.models.foundation.depth_anything3 import blocks
+from paz.models.foundation.depth_anything3 import embeddings
 
 
-def build_da3_backbone(tokens, num_views, grid, hidden_size, depth, num_heads,
-                       mlp_ratio, layer_scale_init, out_layers, alt_start):
-    positions = build_positions(num_views, grid)
-    collected = run_da3_encoder(tokens, num_views, positions, hidden_size,
-                                depth, num_heads, mlp_ratio, layer_scale_init,
-                                out_layers, alt_start)
-    return finalize_features(collected, hidden_size)
+def build(tokens, num_views, grid, args, depth, out_layers, alternation_start):
+    positions = build_grid_positions(num_views, grid)
+    context = num_views, positions, args, alternation_start
+    collected = encode(tokens, context, depth, out_layers)
+    return finalize_features(collected, args[0])
 
 
-def run_da3_encoder(tokens, num_views, positions, hidden_size, depth,
-                    num_heads, mlp_ratio, layer_scale_init, out_layers,
-                    alt_start):
-    local_positions, global_positions = positions
-    local_tokens = tokens
-    collected = []
-    for index in range(depth):
-        if index == alt_start:
-            tokens = insert_camera_tokens(tokens, hidden_size)
-        args = (hidden_size, num_heads, mlp_ratio, layer_scale_init, index)
-        if is_global_block(index, alt_start):
-            tokens = apply_global_block(tokens, num_views, global_positions, *args)
-        else:
-            tokens = apply_local_block(tokens, num_views, local_positions,
-                                       *args, alt_start)
+def encode(tokens, context, depth, out_layers):
+    num_views, positions, args, alternation_start = context
+    local_tokens, collected = tokens, []
+    for arg in range(depth):
+        tokens = apply_block(tokens, arg, context)
+        if not is_global(arg, alternation_start):
             local_tokens = tokens
-        if index in out_layers:
-            collected.append(ops.concatenate([local_tokens, tokens], axis=-1))
+        collect_feature(collected, local_tokens, tokens, arg, out_layers)
     return collected
 
 
-def apply_local_block(tokens, num_views, positions, hidden_size, num_heads,
-                      mlp_ratio, layer_scale_init, index, alt_start):
+def apply_block(tokens, arg, context):
+    num_views, positions, args, alternation_start = context
+    if arg == alternation_start:
+        tokens = embeddings.insert_camera_tokens(tokens, args[0])
+    if is_global(arg, alternation_start):
+        return apply_global(tokens, arg, context)
+    return apply_local(tokens, arg, context)
+
+
+def apply_local(tokens, arg, context):
+    num_views, positions, args, alternation_start = context
     folded = routing.fold_views_into_batch(tokens)
-    name = f"block_{index}"
-    if index < alt_start:
-        folded = build_dinov2_block(folded, hidden_size, num_heads, mlp_ratio,
-                                    layer_scale_init, name)
+    name = f"block_{arg}"
+    if arg < alternation_start:
+        folded = dinov2_blocks.build(folded, *args, name)
     else:
-        folded = build_da3_block(folded, positions, hidden_size, num_heads,
-                                 mlp_ratio, layer_scale_init, name)
+        folded = blocks.build(folded, positions[0], args, name)
     return routing.restore_view_dimension(folded, num_views)
 
 
-def apply_global_block(tokens, num_views, positions, hidden_size, num_heads,
-                       mlp_ratio, layer_scale_init, index):
+def apply_global(tokens, arg, context):
+    num_views, positions, args, alternation_start = context
     merged = routing.merge_views_into_sequence(tokens)
-    merged = build_da3_block(merged, positions, hidden_size, num_heads,
-                             mlp_ratio, layer_scale_init, f"block_{index}")
+    merged = blocks.build(merged, positions[1], args, f"block_{arg}")
     return routing.split_sequence_into_views(merged, num_views)
 
 
-def is_global_block(index, alt_start):
-    return index >= alt_start and index % 2 == 1
+def is_global(arg, alternation_start):
+    reached_alternation = arg >= alternation_start
+    is_odd = arg % 2 == 1
+    return reached_alternation and is_odd
+
+
+def collect_feature(collected, local_tokens, tokens, arg, out_layers):
+    if arg in out_layers:
+        feature = ops.concatenate([local_tokens, tokens], axis=-1)
+        collected.append(feature)
 
 
 def finalize_features(collected, hidden_size):
-    norm = LayerNormalization(epsilon=LAYER_NORM_EPSILON, name="norm")
+    norm = LayerNormalization(epsilon=1e-6, name="norm")
     features, camera_tokens = [], []
     for feature in collected:
         camera_tokens.append(feature[:, :, 0])
-        local_half = feature[..., :hidden_size]
-        global_half = norm(feature[..., hidden_size:])
-        normed = ops.concatenate([local_half, global_half], axis=-1)
+        normed = normalize_global_half(feature, hidden_size, norm)
         features.append(normed[:, :, 1:, :])
     return features, camera_tokens
 
 
-def build_positions(num_views, grid):
+def normalize_global_half(feature, hidden_size, norm):
+    local_half = feature[..., :hidden_size]
+    global_half = norm(feature[..., hidden_size:])
+    return ops.concatenate([local_half, global_half], axis=-1)
+
+
+def build_grid_positions(num_views, grid):
     local = routing.build_local_positions(*grid)
-    global_positions = routing.build_global_positions(num_views, *grid)
-    return local, global_positions
+    cross_view = routing.build_global_positions(num_views, *grid)
+    return local, cross_view

--- a/paz/models/foundation/depth_anything3/backbone.py
+++ b/paz/models/foundation/depth_anything3/backbone.py
@@ -1,0 +1,82 @@
+from keras import ops
+from keras.layers import LayerNormalization
+
+from paz.models.foundation.dinov2.blocks import build_dinov2_block
+from paz.models.foundation.depth_anything3 import routing
+from paz.models.foundation.depth_anything3.blocks import build_da3_block
+from paz.models.foundation.depth_anything3.embeddings import insert_camera_tokens
+
+LAYER_NORM_EPSILON = 1e-6
+
+
+def build_da3_backbone(tokens, num_views, grid, hidden_size, depth, num_heads,
+                       mlp_ratio, layer_scale_init, out_layers, alt_start):
+    positions = build_positions(num_views, grid)
+    collected = run_da3_encoder(tokens, num_views, positions, hidden_size,
+                                depth, num_heads, mlp_ratio, layer_scale_init,
+                                out_layers, alt_start)
+    return finalize_features(collected, hidden_size)
+
+
+def run_da3_encoder(tokens, num_views, positions, hidden_size, depth,
+                    num_heads, mlp_ratio, layer_scale_init, out_layers,
+                    alt_start):
+    local_positions, global_positions = positions
+    local_tokens = tokens
+    collected = []
+    for index in range(depth):
+        if index == alt_start:
+            tokens = insert_camera_tokens(tokens, hidden_size)
+        args = (hidden_size, num_heads, mlp_ratio, layer_scale_init, index)
+        if is_global_block(index, alt_start):
+            tokens = apply_global_block(tokens, num_views, global_positions, *args)
+        else:
+            tokens = apply_local_block(tokens, num_views, local_positions,
+                                       *args, alt_start)
+            local_tokens = tokens
+        if index in out_layers:
+            collected.append(ops.concatenate([local_tokens, tokens], axis=-1))
+    return collected
+
+
+def apply_local_block(tokens, num_views, positions, hidden_size, num_heads,
+                      mlp_ratio, layer_scale_init, index, alt_start):
+    folded = routing.fold_views_into_batch(tokens)
+    name = f"block_{index}"
+    if index < alt_start:
+        folded = build_dinov2_block(folded, hidden_size, num_heads, mlp_ratio,
+                                    layer_scale_init, name)
+    else:
+        folded = build_da3_block(folded, positions, hidden_size, num_heads,
+                                 mlp_ratio, layer_scale_init, name)
+    return routing.restore_view_dimension(folded, num_views)
+
+
+def apply_global_block(tokens, num_views, positions, hidden_size, num_heads,
+                       mlp_ratio, layer_scale_init, index):
+    merged = routing.merge_views_into_sequence(tokens)
+    merged = build_da3_block(merged, positions, hidden_size, num_heads,
+                             mlp_ratio, layer_scale_init, f"block_{index}")
+    return routing.split_sequence_into_views(merged, num_views)
+
+
+def is_global_block(index, alt_start):
+    return index >= alt_start and index % 2 == 1
+
+
+def finalize_features(collected, hidden_size):
+    norm = LayerNormalization(epsilon=LAYER_NORM_EPSILON, name="norm")
+    features, camera_tokens = [], []
+    for feature in collected:
+        camera_tokens.append(feature[:, :, 0])
+        local_half = feature[..., :hidden_size]
+        global_half = norm(feature[..., hidden_size:])
+        normed = ops.concatenate([local_half, global_half], axis=-1)
+        features.append(normed[:, :, 1:, :])
+    return features, camera_tokens
+
+
+def build_positions(num_views, grid):
+    local = routing.build_local_positions(*grid)
+    global_positions = routing.build_global_positions(num_views, *grid)
+    return local, global_positions

--- a/paz/models/foundation/depth_anything3/blocks.py
+++ b/paz/models/foundation/depth_anything3/blocks.py
@@ -1,37 +1,31 @@
-from keras.layers import Add
-
-from paz.models.transformers import attention
 from paz.models.transformers.embeddings import rotary
+from paz.models.transformers.attention import project_query_key_value
+from paz.models.transformers.attention import split_query_key_value
+from paz.models.transformers.attention import normalize_query_key
+from paz.models.transformers.attention import compute_attention
+from paz.models.transformers.attention import merge_attention_heads
+from paz.models.foundation.dinov2.blocks import add_residual
 from paz.models.foundation.dinov2.blocks import apply_feedforward
-from paz.models.foundation.dinov2.blocks import apply_layer_scale
 from paz.models.foundation.dinov2.blocks import normalize
 from paz.models.foundation.dinov2.blocks import project_output
 
-QK_NORM_EPSILON = 1e-5
+
+def build(tokens, positions, args, name):
+    hidden_size, num_heads, MLP_ratio, scale_init = args
+    attended = apply_attention(tokens, positions, hidden_size, num_heads, name)
+    tokens = add_residual(tokens, attended, hidden_size, scale_init, name, 1)
+    forwarded = apply_feedforward(tokens, hidden_size, MLP_ratio, name)
+    return add_residual(tokens, forwarded, hidden_size, scale_init, name, 2)
 
 
-def build_da3_block(tokens, positions, hidden_size, num_heads, mlp_ratio,
-                    layer_scale_init, name):
-    attended = apply_da3_attention(tokens, positions, hidden_size, num_heads,
-                                   name)
-    scaled = apply_layer_scale(attended, hidden_size, layer_scale_init,
-                               f"{name}_ls1")
-    tokens = Add(name=f"{name}_add1")([tokens, scaled])
-    forwarded = apply_feedforward(tokens, hidden_size, mlp_ratio, name)
-    scaled = apply_layer_scale(forwarded, hidden_size, layer_scale_init,
-                               f"{name}_ls2")
-    return Add(name=f"{name}_add2")([tokens, scaled])
-
-
-def apply_da3_attention(tokens, positions, hidden_size, num_heads, name):
+def apply_attention(tokens, positions, hidden_size, num_heads, name):
     normed = normalize(tokens, f"{name}_norm1")
-    fused = attention.project_query_key_value(normed, hidden_size, True, name)
+    fused = project_query_key_value(normed, hidden_size, True, name)
     head_dim = hidden_size // num_heads
-    query, key, value = attention.split_query_key_value(fused, num_heads,
-                                                        head_dim)
-    query, key = attention.normalize_query_key(query, key, QK_NORM_EPSILON, name)
-    query = rotary.apply_2d(query, positions)
-    key = rotary.apply_2d(key, positions)
-    context = attention.compute_attention(query, key, value)
-    merged = attention.merge_attention_heads(context)
+    query, key, value = split_query_key_value(fused, num_heads, head_dim)
+    query, key = normalize_query_key(query, key, 1e-5, name)
+    query = rotary.apply_2D(query, positions)
+    key = rotary.apply_2D(key, positions)
+    context = compute_attention(query, key, value)
+    merged = merge_attention_heads(context)
     return project_output(merged, hidden_size, f"{name}_proj")

--- a/paz/models/foundation/depth_anything3/blocks.py
+++ b/paz/models/foundation/depth_anything3/blocks.py
@@ -1,0 +1,37 @@
+from keras.layers import Add
+
+from paz.models.transformers import attention
+from paz.models.transformers.embeddings import rotary
+from paz.models.foundation.dinov2.blocks import apply_feedforward
+from paz.models.foundation.dinov2.blocks import apply_layer_scale
+from paz.models.foundation.dinov2.blocks import normalize
+from paz.models.foundation.dinov2.blocks import project_output
+
+QK_NORM_EPSILON = 1e-5
+
+
+def build_da3_block(tokens, positions, hidden_size, num_heads, mlp_ratio,
+                    layer_scale_init, name):
+    attended = apply_da3_attention(tokens, positions, hidden_size, num_heads,
+                                   name)
+    scaled = apply_layer_scale(attended, hidden_size, layer_scale_init,
+                               f"{name}_ls1")
+    tokens = Add(name=f"{name}_add1")([tokens, scaled])
+    forwarded = apply_feedforward(tokens, hidden_size, mlp_ratio, name)
+    scaled = apply_layer_scale(forwarded, hidden_size, layer_scale_init,
+                               f"{name}_ls2")
+    return Add(name=f"{name}_add2")([tokens, scaled])
+
+
+def apply_da3_attention(tokens, positions, hidden_size, num_heads, name):
+    normed = normalize(tokens, f"{name}_norm1")
+    fused = attention.project_query_key_value(normed, hidden_size, True, name)
+    head_dim = hidden_size // num_heads
+    query, key, value = attention.split_query_key_value(fused, num_heads,
+                                                        head_dim)
+    query, key = attention.normalize_query_key(query, key, QK_NORM_EPSILON, name)
+    query = rotary.apply_2d(query, positions)
+    key = rotary.apply_2d(key, positions)
+    context = attention.compute_attention(query, key, value)
+    merged = attention.merge_attention_heads(context)
+    return project_output(merged, hidden_size, f"{name}_proj")

--- a/paz/models/foundation/depth_anything3/camera.py
+++ b/paz/models/foundation/depth_anything3/camera.py
@@ -1,14 +1,15 @@
 """Camera decoder: camera token to world-to-camera extrinsics and intrinsics.
 
 Quaternions are scalar-last (xyzw). The decoder predicts a camera-to-world
-pose encoding; extrinsics are returned as the world-to-camera inverse.
+pose encoding; extrinsics are returned as the world-to-camera inverse. The
+quaternion-to-matrix and rigid-inverse math is kept here in keras.ops because
+the paz.angles / paz.SE3 equivalents are unbatched jax and cannot run inside
+this batched functional graph.
 """
 from keras import ops
 from keras.layers import Dense, ReLU
 
 from paz.models.transformers.attention import kernel
-
-FOCAL_EPSILON = 1e-6
 
 
 def build_camera_decoder(camera_token, hidden_size, image_shape):
@@ -17,23 +18,23 @@ def build_camera_decoder(camera_token, hidden_size, image_shape):
 
 
 def decode_pose_encoding(camera_token, hidden_size):
-    hidden = dense(camera_token, hidden_size, "cam_dec_fc1")
+    dense_kwargs = dict(use_bias=True, kernel_initializer=kernel())
+    hidden = camera_token
+    hidden = Dense(hidden_size, name="cam_dec_fc1", **dense_kwargs)(hidden)
     hidden = ReLU()(hidden)
-    hidden = dense(hidden, hidden_size, "cam_dec_fc2")
+    hidden = Dense(hidden_size, name="cam_dec_fc2", **dense_kwargs)(hidden)
     hidden = ReLU()(hidden)
-    translation = dense(hidden, 3, "cam_dec_t")
-    quaternion = dense(hidden, 4, "cam_dec_qvec")
-    field_of_view = ReLU()(dense(hidden, 2, "cam_dec_fov"))
+    translation = Dense(3, name="cam_dec_t", **dense_kwargs)(hidden)
+    quaternion = Dense(4, name="cam_dec_qvec", **dense_kwargs)(hidden)
+    field_of_view = ReLU()(Dense(2, name="cam_dec_fov", **dense_kwargs)(hidden))
     return ops.concatenate([translation, quaternion, field_of_view], axis=-1)
 
 
 def pose_encoding_to_camera(pose_encoding, image_shape):
-    translation = pose_encoding[..., :3]
-    quaternion = pose_encoding[..., 3:7]
-    field_of_view = pose_encoding[..., 7:]
+    parts = ops.split(pose_encoding, [3, 7], axis=-1)
+    translation, quaternion, field_of_view = parts
     rotation = quaternion_to_matrix(quaternion)
-    camera_to_world = ops.concatenate([rotation, translation[..., None]],
-                                      axis=-1)
+    camera_to_world = ops.concatenate([rotation, translation[..., None]], -1)
     extrinsics = invert_transform(camera_to_world)
     intrinsics = intrinsics_from_field_of_view(field_of_view, image_shape)
     return extrinsics, intrinsics
@@ -60,10 +61,10 @@ def invert_transform(camera_to_world):
 
 
 def intrinsics_from_field_of_view(field_of_view, image_shape):
-    height, width = image_shape[0], image_shape[1]
-    focal_y = (height / 2.0) / clamp_tan(field_of_view[..., 0])
-    focal_x = (width / 2.0) / clamp_tan(field_of_view[..., 1])
-    return stack_intrinsics(focal_x, focal_y, width / 2.0, height / 2.0)
+    H, W = image_shape[0], image_shape[1]
+    focal_y = (H / 2.0) / clamp_tan(field_of_view[..., 0])
+    focal_x = (W / 2.0) / clamp_tan(field_of_view[..., 1])
+    return stack_intrinsics(focal_x, focal_y, W / 2.0, H / 2.0)
 
 
 def stack_intrinsics(focal_x, focal_y, center_x, center_y):
@@ -76,9 +77,4 @@ def stack_intrinsics(focal_x, focal_y, center_x, center_y):
 
 
 def clamp_tan(angle):
-    return ops.maximum(ops.tan(angle / 2.0), FOCAL_EPSILON)
-
-
-def dense(tokens, units, name):
-    return Dense(units, use_bias=True, kernel_initializer=kernel(),
-                 name=name)(tokens)
+    return ops.maximum(ops.tan(angle / 2.0), 1e-6)

--- a/paz/models/foundation/depth_anything3/camera.py
+++ b/paz/models/foundation/depth_anything3/camera.py
@@ -1,0 +1,84 @@
+"""Camera decoder: camera token to world-to-camera extrinsics and intrinsics.
+
+Quaternions are scalar-last (xyzw). The decoder predicts a camera-to-world
+pose encoding; extrinsics are returned as the world-to-camera inverse.
+"""
+from keras import ops
+from keras.layers import Dense, ReLU
+
+from paz.models.transformers.attention import kernel
+
+FOCAL_EPSILON = 1e-6
+
+
+def build_camera_decoder(camera_token, hidden_size, image_shape):
+    pose_encoding = decode_pose_encoding(camera_token, hidden_size)
+    return pose_encoding_to_camera(pose_encoding, image_shape)
+
+
+def decode_pose_encoding(camera_token, hidden_size):
+    hidden = dense(camera_token, hidden_size, "cam_dec_fc1")
+    hidden = ReLU()(hidden)
+    hidden = dense(hidden, hidden_size, "cam_dec_fc2")
+    hidden = ReLU()(hidden)
+    translation = dense(hidden, 3, "cam_dec_t")
+    quaternion = dense(hidden, 4, "cam_dec_qvec")
+    field_of_view = ReLU()(dense(hidden, 2, "cam_dec_fov"))
+    return ops.concatenate([translation, quaternion, field_of_view], axis=-1)
+
+
+def pose_encoding_to_camera(pose_encoding, image_shape):
+    translation = pose_encoding[..., :3]
+    quaternion = pose_encoding[..., 3:7]
+    field_of_view = pose_encoding[..., 7:]
+    rotation = quaternion_to_matrix(quaternion)
+    camera_to_world = ops.concatenate([rotation, translation[..., None]],
+                                      axis=-1)
+    extrinsics = invert_transform(camera_to_world)
+    intrinsics = intrinsics_from_field_of_view(field_of_view, image_shape)
+    return extrinsics, intrinsics
+
+
+def quaternion_to_matrix(quaternion):
+    i, j, k, r = ops.unstack(quaternion, axis=-1)
+    two_s = 2.0 / ops.sum(quaternion * quaternion, axis=-1)
+    row0 = ops.stack([1 - two_s * (j * j + k * k), two_s * (i * j - k * r),
+                      two_s * (i * k + j * r)], axis=-1)
+    row1 = ops.stack([two_s * (i * j + k * r), 1 - two_s * (i * i + k * k),
+                      two_s * (j * k - i * r)], axis=-1)
+    row2 = ops.stack([two_s * (i * k - j * r), two_s * (j * k + i * r),
+                      1 - two_s * (i * i + j * j)], axis=-1)
+    return ops.stack([row0, row1, row2], axis=-2)
+
+
+def invert_transform(camera_to_world):
+    rotation = camera_to_world[..., :3, :3]
+    translation = camera_to_world[..., :3, 3:]
+    transposed = ops.swapaxes(rotation, -1, -2)
+    inverse_translation = -ops.matmul(transposed, translation)
+    return ops.concatenate([transposed, inverse_translation], axis=-1)
+
+
+def intrinsics_from_field_of_view(field_of_view, image_shape):
+    height, width = image_shape[0], image_shape[1]
+    focal_y = (height / 2.0) / clamp_tan(field_of_view[..., 0])
+    focal_x = (width / 2.0) / clamp_tan(field_of_view[..., 1])
+    return stack_intrinsics(focal_x, focal_y, width / 2.0, height / 2.0)
+
+
+def stack_intrinsics(focal_x, focal_y, center_x, center_y):
+    zero = ops.zeros_like(focal_x)
+    one = ops.ones_like(focal_x)
+    row0 = ops.stack([focal_x, zero, zero + center_x], axis=-1)
+    row1 = ops.stack([zero, focal_y, zero + center_y], axis=-1)
+    row2 = ops.stack([zero, zero, one], axis=-1)
+    return ops.stack([row0, row1, row2], axis=-2)
+
+
+def clamp_tan(angle):
+    return ops.maximum(ops.tan(angle / 2.0), FOCAL_EPSILON)
+
+
+def dense(tokens, units, name):
+    return Dense(units, use_bias=True, kernel_initializer=kernel(),
+                 name=name)(tokens)

--- a/paz/models/foundation/depth_anything3/convert.py
+++ b/paz/models/foundation/depth_anything3/convert.py
@@ -1,4 +1,4 @@
-"""Development-only weight conversion for Depth Anything 3 (Apache-2.0).
+"""Development-only weight conversion for Depth Anything 3.
 
 Downloads the official checkpoint, ports it into the Keras model, saves a
 ``.weights.h5`` next to a metadata file, and verifies save/reload. Requires
@@ -17,7 +17,6 @@ from paz.models.foundation.depth_anything3 import port_weights
 
 UPSTREAM = "https://github.com/ByteDance-Seed/Depth-Anything-3"
 UPSTREAM_COMMIT = "e74fd796e96b7e781a5506fd8503b6bd7232513c"
-LICENSE = "Apache-2.0"
 IMAGE_SHAPE = (518, 518, 3)
 SMALL = ("depth-anything/DA3-SMALL", models.DepthAnything3Small, 384,
          "da3_small_paz_jax")
@@ -81,7 +80,7 @@ def verify_reload(model, reloaded, path, image_shape, views):
 def write_metadata(output_directory, repository, stem, state, path):
     checkpoint = find_checkpoint(repository)
     metadata = dict(repository=repository, upstream=UPSTREAM,
-                    upstream_commit=UPSTREAM_COMMIT, license=LICENSE,
+                    upstream_commit=UPSTREAM_COMMIT,
                     source_sha256=sha256(checkpoint),
                     converted_sha256=sha256(path))
     with open(os.path.join(output_directory, f"{stem}.json"), "w") as opened:

--- a/paz/models/foundation/depth_anything3/convert.py
+++ b/paz/models/foundation/depth_anything3/convert.py
@@ -13,29 +13,32 @@ import hashlib
 import numpy as np
 
 from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3.models import build_da3_base
 from paz.models.foundation.depth_anything3 import port_weights
 
-REPOSITORY = "depth-anything/DA3-SMALL"
 UPSTREAM = "https://github.com/ByteDance-Seed/Depth-Anything-3"
 UPSTREAM_COMMIT = "e74fd796e96b7e781a5506fd8503b6bd7232513c"
 LICENSE = "Apache-2.0"
 IMAGE_SHAPE = (518, 518, 3)
+SMALL = ("depth-anything/DA3-SMALL", build_da3_small, 384, "da3_small_paz_jax")
+BASE = ("depth-anything/DA3-BASE", build_da3_base, 768, "da3_base_paz_jax")
 
 
-def convert(output_directory, image_shape=IMAGE_SHAPE, views=2):
-    checkpoint = download_checkpoint()
+def convert(size, output_directory, image_shape=IMAGE_SHAPE, views=2):
+    repository, builder, hidden_size, stem = size
+    checkpoint = download_checkpoint(repository)
     state = load_state(checkpoint)
-    model = build_and_port(state, image_shape, views)
-    weights_path = os.path.join(output_directory, "da3_small_paz_jax.weights.h5")
+    model = build_and_port(builder, hidden_size, state, image_shape, views)
+    weights_path = os.path.join(output_directory, f"{stem}.weights.h5")
     model.save_weights(weights_path)
-    verify_reload(weights_path, state, image_shape, views)
-    write_metadata(output_directory, checkpoint, weights_path)
+    verify_reload(builder, hidden_size, weights_path, state, image_shape, views)
+    write_metadata(output_directory, repository, stem, checkpoint, weights_path)
     return weights_path
 
 
-def download_checkpoint():
+def download_checkpoint(repository):
     from huggingface_hub import hf_hub_download
-    return hf_hub_download(REPOSITORY, "model.safetensors")
+    return hf_hub_download(repository, "model.safetensors")
 
 
 def load_state(checkpoint):
@@ -43,30 +46,30 @@ def load_state(checkpoint):
     return load_file(checkpoint)
 
 
-def build_and_port(state, image_shape, views):
-    model = build_da3_small(views, image_shape)
+def build_and_port(builder, hidden_size, state, image_shape, views):
+    model = builder(views, image_shape)
     positions = count_positions(image_shape)
-    port_weights.port_backbone_weights(model, state, 12, positions, 384)
+    port_weights.port_backbone_weights(model, state, 12, positions, hidden_size)
     port_weights.port_head_weights(model, state)
     port_weights.port_camera_decoder_weights(model, state)
     return model
 
 
-def verify_reload(weights_path, state, image_shape, views):
-    model = build_and_port(state, image_shape, views)
-    reloaded = build_da3_small(views, image_shape)
+def verify_reload(builder, hidden_size, weights_path, state, image_shape, views):
+    model = build_and_port(builder, hidden_size, state, image_shape, views)
+    reloaded = builder(views, image_shape)
     reloaded.load_weights(weights_path)
     data = np.zeros((1, views, *image_shape), "float32")
     for expected, actual in zip(model(data), reloaded(data)):
         assert np.allclose(np.array(expected), np.array(actual), atol=1e-5)
 
 
-def write_metadata(output_directory, checkpoint, weights_path):
-    metadata = {"model": "DA3-SMALL", "repository": REPOSITORY,
-                "upstream": UPSTREAM, "upstream_commit": UPSTREAM_COMMIT,
-                "license": LICENSE, "source_sha256": sha256(checkpoint),
+def write_metadata(output_directory, repository, stem, checkpoint, weights_path):
+    metadata = {"repository": repository, "upstream": UPSTREAM,
+                "upstream_commit": UPSTREAM_COMMIT, "license": LICENSE,
+                "source_sha256": sha256(checkpoint),
                 "converted_sha256": sha256(weights_path)}
-    path = os.path.join(output_directory, "da3_small_paz_jax.json")
+    path = os.path.join(output_directory, f"{stem}.json")
     with open(path, "w") as metadata_file:
         json.dump(metadata, metadata_file, indent=2)
 
@@ -85,4 +88,5 @@ def count_positions(image_shape):
 
 if __name__ == "__main__":
     directory = os.environ.get("DA3_OUTPUT", ".")
-    print("saved:", convert(directory))
+    size = BASE if os.environ.get("DA3_MODEL") == "base" else SMALL
+    print("saved:", convert(size, directory))

--- a/paz/models/foundation/depth_anything3/convert.py
+++ b/paz/models/foundation/depth_anything3/convert.py
@@ -1,4 +1,4 @@
-"""Development-only weight conversion for DA3-SMALL (Apache-2.0).
+"""Development-only weight conversion for Depth Anything 3 (Apache-2.0).
 
 Downloads the official checkpoint, ports it into the Keras model, saves a
 ``.weights.h5`` next to a metadata file, and verifies save/reload. Requires
@@ -12,69 +12,43 @@ import hashlib
 
 import numpy as np
 
-from paz.models.foundation.depth_anything3.models import build_da3_small
-from paz.models.foundation.depth_anything3.models import build_da3_base
-from paz.models.foundation.depth_anything3.models import build_da3_mono_large
-from paz.models.foundation.depth_anything3.models import build_da3_metric_large
+from paz.models.foundation.depth_anything3 import models
 from paz.models.foundation.depth_anything3 import port_weights
 
 UPSTREAM = "https://github.com/ByteDance-Seed/Depth-Anything-3"
 UPSTREAM_COMMIT = "e74fd796e96b7e781a5506fd8503b6bd7232513c"
 LICENSE = "Apache-2.0"
 IMAGE_SHAPE = (518, 518, 3)
-SMALL = ("depth-anything/DA3-SMALL", build_da3_small, 384, "da3_small_paz_jax")
-BASE = ("depth-anything/DA3-BASE", build_da3_base, 768, "da3_base_paz_jax")
-MONO = ("depth-anything/DA3MONO-LARGE", build_da3_mono_large,
+SMALL = ("depth-anything/DA3-SMALL", models.DepthAnything3Small, 384,
+         "da3_small_paz_jax")
+BASE = ("depth-anything/DA3-BASE", models.DepthAnything3Base, 768,
+        "da3_base_paz_jax")
+MONO = ("depth-anything/DA3MONO-LARGE", models.DepthAnything3MonoLarge,
         "da3_mono_large_paz_jax")
-METRIC = ("depth-anything/DA3METRIC-LARGE", build_da3_metric_large,
+METRIC = ("depth-anything/DA3METRIC-LARGE", models.DepthAnything3MetricLarge,
           "da3_metric_large_paz_jax")
 
 
 def convert(size, output_directory, image_shape=IMAGE_SHAPE, views=2):
     repository, builder, hidden_size, stem = size
-    checkpoint = download_checkpoint(repository)
-    state = load_state(checkpoint)
+    state = load_checkpoint(repository)
     model = build_and_port(builder, hidden_size, state, image_shape, views)
-    weights_path = os.path.join(output_directory, f"{stem}.weights.h5")
-    model.save_weights(weights_path)
-    verify_reload(builder, hidden_size, weights_path, state, image_shape, views)
-    write_metadata(output_directory, repository, stem, checkpoint, weights_path)
-    return weights_path
+    path = os.path.join(output_directory, f"{stem}.weights.h5")
+    model.save_weights(path)
+    verify_reload(model, builder(views, image_shape), path, image_shape, views)
+    write_metadata(output_directory, repository, stem, state, path)
+    return path
 
 
 def convert_mono(size, output_directory, image_shape=IMAGE_SHAPE):
     repository, builder, stem = size
-    checkpoint = download_checkpoint(repository)
-    state = load_state(checkpoint)
+    state = load_checkpoint(repository)
     model = build_and_port_mono(builder, state, image_shape)
-    weights_path = os.path.join(output_directory, f"{stem}.weights.h5")
-    model.save_weights(weights_path)
-    reloaded = builder(image_shape)
-    reloaded.load_weights(weights_path)
-    data = np.zeros((1, *image_shape), "float32")
-    for expected, actual in zip(model(data), reloaded(data)):
-        assert np.allclose(np.array(expected), np.array(actual), atol=1e-5)
-    write_metadata(output_directory, repository, stem, checkpoint, weights_path)
-    return weights_path
-
-
-def build_and_port_mono(builder, state, image_shape):
-    model = builder(image_shape)
-    positions = count_positions(image_shape)
-    port_weights.port_backbone_weights(model, state, 24, positions, 1024,
-                                       use_camera=False, use_qk_norm=False)
-    port_weights.port_dpt_head_weights(model, state)
-    return model
-
-
-def download_checkpoint(repository):
-    from huggingface_hub import hf_hub_download
-    return hf_hub_download(repository, "model.safetensors")
-
-
-def load_state(checkpoint):
-    from safetensors.numpy import load_file
-    return load_file(checkpoint)
+    path = os.path.join(output_directory, f"{stem}.weights.h5")
+    model.save_weights(path)
+    verify_reload(model, builder(image_shape), path, image_shape, None)
+    write_metadata(output_directory, repository, stem, state, path)
+    return path
 
 
 def build_and_port(builder, hidden_size, state, image_shape, views):
@@ -86,23 +60,42 @@ def build_and_port(builder, hidden_size, state, image_shape, views):
     return model
 
 
-def verify_reload(builder, hidden_size, weights_path, state, image_shape, views):
-    model = build_and_port(builder, hidden_size, state, image_shape, views)
-    reloaded = builder(views, image_shape)
-    reloaded.load_weights(weights_path)
-    data = np.zeros((1, views, *image_shape), "float32")
+def build_and_port_mono(builder, state, image_shape):
+    model = builder(image_shape)
+    positions = count_positions(image_shape)
+    args = model, state, 24, positions, 1024
+    port_weights.port_backbone_weights(*args, use_camera=False,
+                                       use_qk_norm=False)
+    port_weights.port_dpt_head_weights(model, state)
+    return model
+
+
+def verify_reload(model, reloaded, path, image_shape, views):
+    reloaded.load_weights(path)
+    shape = (1, *image_shape) if views is None else (1, views, *image_shape)
+    data = np.zeros(shape, "float32")
     for expected, actual in zip(model(data), reloaded(data)):
         assert np.allclose(np.array(expected), np.array(actual), atol=1e-5)
 
 
-def write_metadata(output_directory, repository, stem, checkpoint, weights_path):
-    metadata = {"repository": repository, "upstream": UPSTREAM,
-                "upstream_commit": UPSTREAM_COMMIT, "license": LICENSE,
-                "source_sha256": sha256(checkpoint),
-                "converted_sha256": sha256(weights_path)}
-    path = os.path.join(output_directory, f"{stem}.json")
-    with open(path, "w") as metadata_file:
-        json.dump(metadata, metadata_file, indent=2)
+def write_metadata(output_directory, repository, stem, state, path):
+    checkpoint = find_checkpoint(repository)
+    metadata = dict(repository=repository, upstream=UPSTREAM,
+                    upstream_commit=UPSTREAM_COMMIT, license=LICENSE,
+                    source_sha256=sha256(checkpoint),
+                    converted_sha256=sha256(path))
+    with open(os.path.join(output_directory, f"{stem}.json"), "w") as opened:
+        json.dump(metadata, opened, indent=2)
+
+
+def load_checkpoint(repository):
+    from safetensors.numpy import load_file
+    return load_file(find_checkpoint(repository))
+
+
+def find_checkpoint(repository):
+    from huggingface_hub import hf_hub_download
+    return hf_hub_download(repository, "model.safetensors")
 
 
 def sha256(path):
@@ -119,12 +112,8 @@ def count_positions(image_shape):
 
 if __name__ == "__main__":
     directory = os.environ.get("DA3_OUTPUT", ".")
-    model = os.environ.get("DA3_MODEL", "small")
-    if model == "mono":
-        print("saved:", convert_mono(MONO, directory))
-    elif model == "metric":
-        print("saved:", convert_mono(METRIC, directory))
-    elif model == "base":
-        print("saved:", convert(BASE, directory))
-    else:
-        print("saved:", convert(SMALL, directory))
+    selection = os.environ.get("DA3_MODEL", "small")
+    table = dict(small=SMALL, base=BASE, mono=MONO, metric=METRIC)
+    size = table[selection]
+    convert_size = convert_mono if selection in ("mono", "metric") else convert
+    print("saved:", convert_size(size, directory))

--- a/paz/models/foundation/depth_anything3/convert.py
+++ b/paz/models/foundation/depth_anything3/convert.py
@@ -14,6 +14,8 @@ import numpy as np
 
 from paz.models.foundation.depth_anything3.models import build_da3_small
 from paz.models.foundation.depth_anything3.models import build_da3_base
+from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+from paz.models.foundation.depth_anything3.models import build_da3_metric_large
 from paz.models.foundation.depth_anything3 import port_weights
 
 UPSTREAM = "https://github.com/ByteDance-Seed/Depth-Anything-3"
@@ -22,6 +24,10 @@ LICENSE = "Apache-2.0"
 IMAGE_SHAPE = (518, 518, 3)
 SMALL = ("depth-anything/DA3-SMALL", build_da3_small, 384, "da3_small_paz_jax")
 BASE = ("depth-anything/DA3-BASE", build_da3_base, 768, "da3_base_paz_jax")
+MONO = ("depth-anything/DA3MONO-LARGE", build_da3_mono_large,
+        "da3_mono_large_paz_jax")
+METRIC = ("depth-anything/DA3METRIC-LARGE", build_da3_metric_large,
+          "da3_metric_large_paz_jax")
 
 
 def convert(size, output_directory, image_shape=IMAGE_SHAPE, views=2):
@@ -34,6 +40,31 @@ def convert(size, output_directory, image_shape=IMAGE_SHAPE, views=2):
     verify_reload(builder, hidden_size, weights_path, state, image_shape, views)
     write_metadata(output_directory, repository, stem, checkpoint, weights_path)
     return weights_path
+
+
+def convert_mono(size, output_directory, image_shape=IMAGE_SHAPE):
+    repository, builder, stem = size
+    checkpoint = download_checkpoint(repository)
+    state = load_state(checkpoint)
+    model = build_and_port_mono(builder, state, image_shape)
+    weights_path = os.path.join(output_directory, f"{stem}.weights.h5")
+    model.save_weights(weights_path)
+    reloaded = builder(image_shape)
+    reloaded.load_weights(weights_path)
+    data = np.zeros((1, *image_shape), "float32")
+    for expected, actual in zip(model(data), reloaded(data)):
+        assert np.allclose(np.array(expected), np.array(actual), atol=1e-5)
+    write_metadata(output_directory, repository, stem, checkpoint, weights_path)
+    return weights_path
+
+
+def build_and_port_mono(builder, state, image_shape):
+    model = builder(image_shape)
+    positions = count_positions(image_shape)
+    port_weights.port_backbone_weights(model, state, 24, positions, 1024,
+                                       use_camera=False, use_qk_norm=False)
+    port_weights.port_dpt_head_weights(model, state)
+    return model
 
 
 def download_checkpoint(repository):
@@ -88,5 +119,12 @@ def count_positions(image_shape):
 
 if __name__ == "__main__":
     directory = os.environ.get("DA3_OUTPUT", ".")
-    size = BASE if os.environ.get("DA3_MODEL") == "base" else SMALL
-    print("saved:", convert(size, directory))
+    model = os.environ.get("DA3_MODEL", "small")
+    if model == "mono":
+        print("saved:", convert_mono(MONO, directory))
+    elif model == "metric":
+        print("saved:", convert_mono(METRIC, directory))
+    elif model == "base":
+        print("saved:", convert(BASE, directory))
+    else:
+        print("saved:", convert(SMALL, directory))

--- a/paz/models/foundation/depth_anything3/convert.py
+++ b/paz/models/foundation/depth_anything3/convert.py
@@ -1,0 +1,88 @@
+"""Development-only weight conversion for DA3-SMALL (Apache-2.0).
+
+Downloads the official checkpoint, ports it into the Keras model, saves a
+``.weights.h5`` next to a metadata file, and verifies save/reload. Requires
+torch, safetensors, and huggingface_hub. Not imported at runtime.
+
+Usage: python -m paz.models.foundation.depth_anything3.convert
+"""
+import os
+import json
+import hashlib
+
+import numpy as np
+
+from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3 import port_weights
+
+REPOSITORY = "depth-anything/DA3-SMALL"
+UPSTREAM = "https://github.com/ByteDance-Seed/Depth-Anything-3"
+UPSTREAM_COMMIT = "e74fd796e96b7e781a5506fd8503b6bd7232513c"
+LICENSE = "Apache-2.0"
+IMAGE_SHAPE = (518, 518, 3)
+
+
+def convert(output_directory, image_shape=IMAGE_SHAPE, views=2):
+    checkpoint = download_checkpoint()
+    state = load_state(checkpoint)
+    model = build_and_port(state, image_shape, views)
+    weights_path = os.path.join(output_directory, "da3_small_paz_jax.weights.h5")
+    model.save_weights(weights_path)
+    verify_reload(weights_path, state, image_shape, views)
+    write_metadata(output_directory, checkpoint, weights_path)
+    return weights_path
+
+
+def download_checkpoint():
+    from huggingface_hub import hf_hub_download
+    return hf_hub_download(REPOSITORY, "model.safetensors")
+
+
+def load_state(checkpoint):
+    from safetensors.numpy import load_file
+    return load_file(checkpoint)
+
+
+def build_and_port(state, image_shape, views):
+    model = build_da3_small(views, image_shape)
+    positions = count_positions(image_shape)
+    port_weights.port_backbone_weights(model, state, 12, positions, 384)
+    port_weights.port_head_weights(model, state)
+    port_weights.port_camera_decoder_weights(model, state)
+    return model
+
+
+def verify_reload(weights_path, state, image_shape, views):
+    model = build_and_port(state, image_shape, views)
+    reloaded = build_da3_small(views, image_shape)
+    reloaded.load_weights(weights_path)
+    data = np.zeros((1, views, *image_shape), "float32")
+    for expected, actual in zip(model(data), reloaded(data)):
+        assert np.allclose(np.array(expected), np.array(actual), atol=1e-5)
+
+
+def write_metadata(output_directory, checkpoint, weights_path):
+    metadata = {"model": "DA3-SMALL", "repository": REPOSITORY,
+                "upstream": UPSTREAM, "upstream_commit": UPSTREAM_COMMIT,
+                "license": LICENSE, "source_sha256": sha256(checkpoint),
+                "converted_sha256": sha256(weights_path)}
+    path = os.path.join(output_directory, "da3_small_paz_jax.json")
+    with open(path, "w") as metadata_file:
+        json.dump(metadata, metadata_file, indent=2)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as opened:
+        for chunk in iter(lambda: opened.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def count_positions(image_shape):
+    return (image_shape[0] // 14) * (image_shape[1] // 14) + 1
+
+
+if __name__ == "__main__":
+    directory = os.environ.get("DA3_OUTPUT", ".")
+    print("saved:", convert(directory))

--- a/paz/models/foundation/depth_anything3/dpt.py
+++ b/paz/models/foundation/depth_anything3/dpt.py
@@ -1,0 +1,46 @@
+"""Standard single-chain DPT head for monocular depth plus sky segmentation.
+
+Reuses the DualDPT fusion pyramid. Unlike DualDPT it has one chain, no
+positional embedding, and an identity input norm; it emits depth (exp) and a
+sky map (relu).
+"""
+from keras import ops
+from keras.layers import Conv2D, ReLU
+
+from paz.backend.image import resize_bilinear_align_corners
+from paz.models.foundation.depth_anything3.dual_dpt import HEAD_FEATURES
+from paz.models.foundation.depth_anything3.dual_dpt import fuse_chain
+from paz.models.foundation.depth_anything3.dual_dpt import reassemble
+from paz.models.foundation.depth_anything3.dual_dpt import resize_stage
+
+
+def build_dpt(feature_maps, grid, image_shape, feature_dim, out_channels,
+              fusion_features):
+    stages = [project_stage(feature_maps[k], k, grid, feature_dim, out_channels)
+              for k in range(4)]
+    lateral = [reassemble(stages[k], k, fusion_features) for k in range(4)]
+    fused = fuse_chain(lateral, "", fusion_features)
+    fused = Conv2D(fusion_features // 2, 3, padding="same", name="head_out1")(fused)
+    fused = resize_bilinear_align_corners(fused, image_shape[:2])
+    return apply_depth(fused), apply_sky(fused)
+
+
+def project_stage(tokens, stage, grid, feature_dim, out_channels):
+    grid_height, grid_width = grid
+    projected = ops.reshape(tokens, (-1, grid_height, grid_width, feature_dim))
+    projected = Conv2D(out_channels[stage], 1, name=f"head_project_{stage}")(projected)
+    return resize_stage(projected, stage, out_channels)
+
+
+def apply_depth(fused):
+    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_out2_conv0")(fused)
+    hidden = ReLU()(hidden)
+    logits = Conv2D(1, 1, name="head_out2_conv1")(hidden)
+    return ops.exp(logits[..., 0])
+
+
+def apply_sky(fused):
+    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_sky_conv0")(fused)
+    hidden = ReLU()(hidden)
+    logits = Conv2D(1, 1, name="head_sky_conv1")(hidden)
+    return ops.relu(logits[..., 0])

--- a/paz/models/foundation/depth_anything3/dpt.py
+++ b/paz/models/foundation/depth_anything3/dpt.py
@@ -1,46 +1,50 @@
 """Standard single-chain DPT head for monocular depth plus sky segmentation.
 
-Reuses the DualDPT fusion pyramid. Unlike DualDPT it has one chain, no
-positional embedding, and an identity input norm; it emits depth (exp) and a
-sky map (relu).
+DPT is the dense prediction transformer head. Unlike DualDPT it has one
+fusion chain, no positional embedding, and an identity input norm; it emits
+depth (exp) and a sky map (relu). The pyramid helpers are reused from DualDPT.
 """
 from keras import ops
 from keras.layers import Conv2D, ReLU
 
 from paz.backend.image import resize_bilinear_align_corners
-from paz.models.foundation.depth_anything3.dual_dpt import HEAD_FEATURES
-from paz.models.foundation.depth_anything3.dual_dpt import fuse_chain
-from paz.models.foundation.depth_anything3.dual_dpt import reassemble
-from paz.models.foundation.depth_anything3.dual_dpt import resize_stage
+from paz.models.foundation.depth_anything3 import dual_dpt
 
 
-def build_dpt(feature_maps, grid, image_shape, feature_dim, out_channels,
-              fusion_features):
-    stages = [project_stage(feature_maps[k], k, grid, feature_dim, out_channels)
-              for k in range(4)]
-    lateral = [reassemble(stages[k], k, fusion_features) for k in range(4)]
-    fused = fuse_chain(lateral, "", fusion_features)
-    fused = Conv2D(fusion_features // 2, 3, padding="same", name="head_out1")(fused)
+def build(feature_maps, grid, image_shape, feature_dim, out_channels,
+          fusion_features):
+    stages = []
+    for arg in range(4):
+        args = feature_maps[arg], arg, grid, feature_dim, out_channels
+        stages.append(project_stage(*args))
+    lateral = dual_dpt.build_lateral(stages, fusion_features)
+    fused = dual_dpt.fuse_chain(lateral, "", fusion_features)
+    fused = conv(fusion_features // 2, 3, "head_out1")(fused)
     fused = resize_bilinear_align_corners(fused, image_shape[:2])
     return apply_depth(fused), apply_sky(fused)
 
 
 def project_stage(tokens, stage, grid, feature_dim, out_channels):
     grid_height, grid_width = grid
-    projected = ops.reshape(tokens, (-1, grid_height, grid_width, feature_dim))
-    projected = Conv2D(out_channels[stage], 1, name=f"head_project_{stage}")(projected)
-    return resize_stage(projected, stage, out_channels)
+    shape = -1, grid_height, grid_width, feature_dim
+    projected = ops.reshape(tokens, shape)
+    projected = conv(out_channels[stage], 1, f"head_project_{stage}")(projected)
+    return dual_dpt.resize_stage(projected, stage, out_channels)
 
 
 def apply_depth(fused):
-    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_out2_conv0")(fused)
+    hidden = conv(32, 3, "head_out2_conv0")(fused)
     hidden = ReLU()(hidden)
-    logits = Conv2D(1, 1, name="head_out2_conv1")(hidden)
+    logits = conv(1, 1, "head_out2_conv1")(hidden)
     return ops.exp(logits[..., 0])
 
 
 def apply_sky(fused):
-    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_sky_conv0")(fused)
+    hidden = conv(32, 3, "head_sky_conv0")(fused)
     hidden = ReLU()(hidden)
-    logits = Conv2D(1, 1, name="head_sky_conv1")(hidden)
+    logits = conv(1, 1, "head_sky_conv1")(hidden)
     return ops.relu(logits[..., 0])
+
+
+def conv(units, kernel_size, name):
+    return Conv2D(units, kernel_size, padding="same", name=name)

--- a/paz/models/foundation/depth_anything3/dual_dpt.py
+++ b/paz/models/foundation/depth_anything3/dual_dpt.py
@@ -1,26 +1,26 @@
 """DualDPT head: dense depth (+confidence) and camera rays (+confidence).
 
-Channels-last throughout. The primary depth chain upsamples to full image
-resolution; the auxiliary (ray) chain stops at the finest fusion scale
-(eight times the patch grid). Depth uses exp, confidences use exp(x)+1.
-Dimensions (feature_dim, out_channels, fusion_features) are size-specific.
+DPT is the dense prediction transformer head. This dual variant runs two
+independent fusion chains: a primary depth chain upsampled to full image
+resolution, and an auxiliary ray chain that stops at the finest fusion scale
+(eight times the patch grid). Channels-last throughout. Depth uses exp,
+confidences use exp(x)+1. Dimensions are size-specific.
 """
 import numpy as np
 from keras import ops
-from keras.layers import Conv2D, Conv2DTranspose, LayerNormalization, ReLU
+from keras.layers import Conv2D, Conv2DTranspose
+from keras.layers import LayerNormalization, ReLU
 
 from paz.backend.image import resize_bilinear_align_corners
 
-HEAD_FEATURES = 32
-POS_RATIO = 0.1
-OMEGA = 100.0
 
-
-def build_dual_dpt(feature_maps, grid, image_shape, feature_dim, out_channels,
-                   fusion_features):
+def build(feature_maps, grid, image_shape, feature_dim, out_channels,
+          fusion_features):
     norm = LayerNormalization(epsilon=1e-5, name="head_norm")
-    stages = [project_stage(feature_maps[k], norm, k, grid, image_shape,
-                            feature_dim, out_channels) for k in range(4)]
+    stages = []
+    for arg in range(4):
+        args = feature_maps[arg], norm, arg, grid, image_shape, feature_dim
+        stages.append(project_stage(*args, out_channels))
     main, aux = fuse_pyramid(stages, fusion_features)
     depth, depth_confidence = depth_head(main, image_shape)
     rays, ray_confidence = ray_head(aux, image_shape)
@@ -30,119 +30,144 @@ def build_dual_dpt(feature_maps, grid, image_shape, feature_dim, out_channels,
 def project_stage(tokens, norm, stage, grid, image_shape, feature_dim,
                   out_channels):
     grid_height, grid_width = grid
-    projected = norm(tokens)
-    projected = ops.reshape(projected, (-1, grid_height, grid_width, feature_dim))
-    projected = Conv2D(out_channels[stage], 1, name=f"head_project_{stage}")(projected)
+    shape = -1, grid_height, grid_width, feature_dim
+    reshaped = ops.reshape(norm(tokens), shape)
+    projected = conv(out_channels[stage], 1, f"head_project_{stage}")(reshaped)
     projected = add_pos_embed(projected, image_shape)
     return resize_stage(projected, stage, out_channels)
 
 
 def resize_stage(features, stage, out_channels):
-    if stage == 0:
-        return Conv2DTranspose(out_channels[0], 4, strides=4,
-                               name="head_resize_0")(features)
-    if stage == 1:
-        return Conv2DTranspose(out_channels[1], 2, strides=2,
-                               name="head_resize_1")(features)
-    if stage == 2:
-        return features
-    return Conv2D(out_channels[3], 3, strides=2, padding="same",
-                  name="head_resize_3")(features)
+    builders = upsample_4x, upsample_2x, keep, downsample_2x
+    return builders[stage](features, out_channels[stage])
+
+
+def upsample_4x(features, channels):
+    layer = Conv2DTranspose(channels, 4, strides=4, name="head_resize_0")
+    return layer(features)
+
+
+def upsample_2x(features, channels):
+    layer = Conv2DTranspose(channels, 2, strides=2, name="head_resize_1")
+    return layer(features)
+
+
+def keep(features, channels):
+    return features
+
+
+def downsample_2x(features, channels):
+    kwargs = dict(strides=2, padding="same", name="head_resize_3")
+    return Conv2D(channels, 3, **kwargs)(features)
 
 
 def fuse_pyramid(stages, fusion_features):
-    lateral = [reassemble(stages[k], k, fusion_features) for k in range(4)]
+    lateral = build_lateral(stages, fusion_features)
     main = fuse_chain(lateral, "", fusion_features)
     aux = fuse_chain(lateral, "_aux", fusion_features)
-    main = Conv2D(fusion_features // 2, 3, padding="same", name="head_out1")(main)
+    main = conv(fusion_features // 2, 3, "head_out1")(main)
     aux = aux_pre_head(aux, fusion_features)
     return main, aux
 
 
+def build_lateral(stages, fusion_features):
+    lateral = []
+    for arg in range(4):
+        lateral.append(reassemble(stages[arg], arg, fusion_features))
+    return lateral
+
+
 def reassemble(features, stage, fusion_features):
     name = f"head_layer{stage + 1}_rn"
-    return Conv2D(fusion_features, 3, padding="same", use_bias=False,
-                  name=name)(features)
+    return conv(fusion_features, 3, name, False)(features)
 
 
 def fuse_chain(lateral, suffix, fusion_features):
+    targets = fuse_targets(lateral)
+    fused = None
+    for step in range(4):
+        name = f"head_refine{4 - step}{suffix}"
+        args = fused, lateral[3 - step], targets[step], name
+        fused = fusion_block(*args, fusion_features)
+    return fused
+
+
+def fuse_targets(lateral):
     sizes = [ops.shape(level)[1:3] for level in lateral]
-    fused = fusion_block(None, lateral[3], sizes[2], f"head_refine4{suffix}", fusion_features)
-    fused = fusion_block(fused, lateral[2], sizes[1], f"head_refine3{suffix}", fusion_features)
-    fused = fusion_block(fused, lateral[1], sizes[0], f"head_refine2{suffix}", fusion_features)
-    double = (sizes[0][0] * 2, sizes[0][1] * 2)
-    return fusion_block(fused, lateral[0], double, f"head_refine1{suffix}", fusion_features)
+    doubled = sizes[0][0] * 2, sizes[0][1] * 2
+    return [sizes[2], sizes[1], sizes[0], doubled]
 
 
 def fusion_block(previous, lateral, size, name, fusion_features):
-    fused = lateral if previous is None else previous + residual_unit(lateral, f"{name}_unit1", fusion_features)
+    fused = fuse_lateral(previous, lateral, name, fusion_features)
     fused = residual_unit(fused, f"{name}_unit2", fusion_features)
     fused = resize_bilinear_align_corners(fused, size)
-    return Conv2D(fusion_features, 1, name=f"{name}_out")(fused)
+    return conv(fusion_features, 1, f"{name}_out")(fused)
+
+
+def fuse_lateral(previous, lateral, name, fusion_features):
+    if previous is None:
+        return lateral
+    return previous + residual_unit(lateral, f"{name}_unit1", fusion_features)
 
 
 def residual_unit(features, name, fusion_features):
     hidden = ReLU()(features)
-    hidden = Conv2D(fusion_features, 3, padding="same", name=f"{name}_conv1")(hidden)
+    hidden = conv(fusion_features, 3, f"{name}_conv1")(hidden)
     hidden = ReLU()(hidden)
-    hidden = Conv2D(fusion_features, 3, padding="same", name=f"{name}_conv2")(hidden)
+    hidden = conv(fusion_features, 3, f"{name}_conv2")(hidden)
     return features + hidden
 
 
 def aux_pre_head(features, fusion_features):
     half = fusion_features // 2
-    widths = (half, fusion_features, half, fusion_features, half)
-    for index, width in enumerate(widths):
-        features = Conv2D(width, 3, padding="same",
-                          name=f"head_out1_aux_{index}")(features)
+    widths = half, fusion_features, half, fusion_features, half
+    for arg, width in enumerate(widths):
+        features = conv(width, 3, f"head_out1_aux_{arg}")(features)
     return features
 
 
 def depth_head(features, image_shape):
     upsampled = resize_bilinear_align_corners(features, image_shape[:2])
     upsampled = add_pos_embed(upsampled, image_shape)
-    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_out2_conv0")(upsampled)
-    hidden = ReLU()(hidden)
-    logits = Conv2D(2, 1, name="head_out2_conv1")(hidden)
+    hidden = conv(32, 3, "head_out2_conv0")(upsampled)
+    logits = conv(2, 1, "head_out2_conv1")(ReLU()(hidden))
     depth = ops.exp(logits[..., 0])
-    depth_confidence = ops.exp(logits[..., 1]) + 1.0
-    return depth, depth_confidence
+    return depth, ops.exp(logits[..., 1]) + 1.0
 
 
 def ray_head(features, image_shape):
     features = add_pos_embed(features, image_shape)
-    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_out2_aux_conv0")(features)
+    hidden = conv(32, 3, "head_out2_aux_conv0")(features)
     hidden = LayerNormalization(epsilon=1e-5, name="head_out2_aux_ln")(hidden)
-    hidden = ReLU()(hidden)
-    logits = Conv2D(7, 1, name="head_out2_aux_conv1")(hidden)
-    rays = logits[..., :6]
-    ray_confidence = ops.exp(logits[..., 6]) + 1.0
-    return rays, ray_confidence
+    logits = conv(7, 1, "head_out2_aux_conv1")(ReLU()(hidden))
+    return logits[..., :6], ops.exp(logits[..., 6]) + 1.0
 
 
 def add_pos_embed(features, image_shape):
-    _, height, width, channels = features.shape
-    embedding = build_uv_position_embedding(height, width, channels, image_shape)
+    batch, H, W, channels = features.shape
+    embedding = build_uv_position_embedding(H, W, channels, image_shape)
     return features + ops.array(embedding)
 
 
-def build_uv_position_embedding(height, width, channels, image_shape):
+def build_uv_position_embedding(H, W, channels, image_shape):
     aspect = image_shape[1] / image_shape[0]
-    grid = build_uv_grid(width, height, aspect)
+    grid = build_uv_grid(W, H, aspect)
     embedding = position_grid_to_embedding(grid, channels)
-    return (embedding * POS_RATIO).astype("float32")
+    return (embedding * 0.1).astype("float32")
 
 
-def build_uv_grid(width, height, aspect):
+def build_uv_grid(W, H, aspect):
     diagonal = (aspect ** 2 + 1.0) ** 0.5
-    span_x = aspect / diagonal
-    span_y = 1.0 / diagonal
-    x = np.linspace(-span_x * (width - 1) / width,
-                    span_x * (width - 1) / width, width)
-    y = np.linspace(-span_y * (height - 1) / height,
-                    span_y * (height - 1) / height, height)
+    x = build_axis(aspect / diagonal, W)
+    y = build_axis(1.0 / diagonal, H)
     columns, rows = np.meshgrid(x, y)
     return np.stack([columns, rows], axis=-1)
+
+
+def build_axis(span, count):
+    limit = span * (count - 1) / count
+    return np.linspace(-limit, limit, count)
 
 
 def position_grid_to_embedding(grid, channels):
@@ -155,6 +180,11 @@ def position_grid_to_embedding(grid, channels):
 
 def sincos_embedding(dimension, positions):
     omega = np.arange(dimension // 2) / (dimension / 2.0)
-    omega = 1.0 / (OMEGA ** omega)
+    omega = 1.0 / (100.0 ** omega)
     angles = np.outer(positions, omega)
     return np.concatenate([np.sin(angles), np.cos(angles)], axis=-1)
+
+
+def conv(units, kernel_size, name, use_bias=True):
+    kwargs = dict(padding="same", use_bias=use_bias, name=name)
+    return Conv2D(units, kernel_size, **kwargs)

--- a/paz/models/foundation/depth_anything3/dual_dpt.py
+++ b/paz/models/foundation/depth_anything3/dual_dpt.py
@@ -1,8 +1,9 @@
 """DualDPT head: dense depth (+confidence) and camera rays (+confidence).
 
-Channels-last throughout. The primary chain upsamples to full image
+Channels-last throughout. The primary depth chain upsamples to full image
 resolution; the auxiliary (ray) chain stops at the finest fusion scale
 (eight times the patch grid). Depth uses exp, confidences use exp(x)+1.
+Dimensions (feature_dim, out_channels, fusion_features) are size-specific.
 """
 import numpy as np
 from keras import ops
@@ -10,83 +11,87 @@ from keras.layers import Conv2D, Conv2DTranspose, LayerNormalization, ReLU
 
 from paz.backend.image import resize_bilinear_align_corners
 
-PATCH_SIZE = 14
-FEATURES = 64
-OUT_CHANNELS = (48, 96, 192, 384)
-HEAD_CHANNELS = 32
+HEAD_FEATURES = 32
 POS_RATIO = 0.1
 OMEGA = 100.0
 
 
-def build_dual_dpt(features, grid, image_shape):
+def build_dual_dpt(feature_maps, grid, image_shape, feature_dim, out_channels,
+                   fusion_features):
     norm = LayerNormalization(epsilon=1e-5, name="head_norm")
-    stages = [project_stage(features[k], norm, k, grid, image_shape)
-              for k in range(4)]
-    main, aux = fuse_pyramid(stages)
+    stages = [project_stage(feature_maps[k], norm, k, grid, image_shape,
+                            feature_dim, out_channels) for k in range(4)]
+    main, aux = fuse_pyramid(stages, fusion_features)
     depth, depth_confidence = depth_head(main, image_shape)
     rays, ray_confidence = ray_head(aux, image_shape)
     return depth, depth_confidence, rays, ray_confidence
 
 
-def project_stage(tokens, norm, stage, grid, image_shape):
+def project_stage(tokens, norm, stage, grid, image_shape, feature_dim,
+                  out_channels):
     grid_height, grid_width = grid
     projected = norm(tokens)
-    projected = ops.reshape(projected, (-1, grid_height, grid_width, 768))
-    projected = Conv2D(OUT_CHANNELS[stage], 1, name=f"head_project_{stage}")(projected)
+    projected = ops.reshape(projected, (-1, grid_height, grid_width, feature_dim))
+    projected = Conv2D(out_channels[stage], 1, name=f"head_project_{stage}")(projected)
     projected = add_pos_embed(projected, image_shape)
-    return resize_stage(projected, stage)
+    return resize_stage(projected, stage, out_channels)
 
 
-def resize_stage(features, stage):
+def resize_stage(features, stage, out_channels):
     if stage == 0:
-        return Conv2DTranspose(48, 4, strides=4, name="head_resize_0")(features)
+        return Conv2DTranspose(out_channels[0], 4, strides=4,
+                               name="head_resize_0")(features)
     if stage == 1:
-        return Conv2DTranspose(96, 2, strides=2, name="head_resize_1")(features)
+        return Conv2DTranspose(out_channels[1], 2, strides=2,
+                               name="head_resize_1")(features)
     if stage == 2:
         return features
-    return Conv2D(384, 3, strides=2, padding="same", name="head_resize_3")(features)
+    return Conv2D(out_channels[3], 3, strides=2, padding="same",
+                  name="head_resize_3")(features)
 
 
-def fuse_pyramid(stages):
-    lateral = [reassemble(stages[k], k) for k in range(4)]
-    main = fuse_chain(lateral, "")
-    aux = fuse_chain(lateral, "_aux")
-    main = Conv2D(HEAD_CHANNELS, 3, padding="same", name="head_out1")(main)
-    aux = aux_pre_head(aux)
+def fuse_pyramid(stages, fusion_features):
+    lateral = [reassemble(stages[k], k, fusion_features) for k in range(4)]
+    main = fuse_chain(lateral, "", fusion_features)
+    aux = fuse_chain(lateral, "_aux", fusion_features)
+    main = Conv2D(fusion_features // 2, 3, padding="same", name="head_out1")(main)
+    aux = aux_pre_head(aux, fusion_features)
     return main, aux
 
 
-def reassemble(features, stage):
+def reassemble(features, stage, fusion_features):
     name = f"head_layer{stage + 1}_rn"
-    return Conv2D(FEATURES, 3, padding="same", use_bias=False, name=name)(features)
+    return Conv2D(fusion_features, 3, padding="same", use_bias=False,
+                  name=name)(features)
 
 
-def fuse_chain(lateral, suffix):
+def fuse_chain(lateral, suffix, fusion_features):
     sizes = [ops.shape(level)[1:3] for level in lateral]
-    fused = fusion_block(None, lateral[3], sizes[2], f"head_refine4{suffix}")
-    fused = fusion_block(fused, lateral[2], sizes[1], f"head_refine3{suffix}")
-    fused = fusion_block(fused, lateral[1], sizes[0], f"head_refine2{suffix}")
+    fused = fusion_block(None, lateral[3], sizes[2], f"head_refine4{suffix}", fusion_features)
+    fused = fusion_block(fused, lateral[2], sizes[1], f"head_refine3{suffix}", fusion_features)
+    fused = fusion_block(fused, lateral[1], sizes[0], f"head_refine2{suffix}", fusion_features)
     double = (sizes[0][0] * 2, sizes[0][1] * 2)
-    return fusion_block(fused, lateral[0], double, f"head_refine1{suffix}")
+    return fusion_block(fused, lateral[0], double, f"head_refine1{suffix}", fusion_features)
 
 
-def fusion_block(previous, lateral, size, name):
-    fused = lateral if previous is None else previous + residual_unit(lateral, f"{name}_unit1")
-    fused = residual_unit(fused, f"{name}_unit2")
+def fusion_block(previous, lateral, size, name, fusion_features):
+    fused = lateral if previous is None else previous + residual_unit(lateral, f"{name}_unit1", fusion_features)
+    fused = residual_unit(fused, f"{name}_unit2", fusion_features)
     fused = resize_bilinear_align_corners(fused, size)
-    return Conv2D(FEATURES, 1, name=f"{name}_out")(fused)
+    return Conv2D(fusion_features, 1, name=f"{name}_out")(fused)
 
 
-def residual_unit(features, name):
+def residual_unit(features, name, fusion_features):
     hidden = ReLU()(features)
-    hidden = Conv2D(FEATURES, 3, padding="same", name=f"{name}_conv1")(hidden)
+    hidden = Conv2D(fusion_features, 3, padding="same", name=f"{name}_conv1")(hidden)
     hidden = ReLU()(hidden)
-    hidden = Conv2D(FEATURES, 3, padding="same", name=f"{name}_conv2")(hidden)
+    hidden = Conv2D(fusion_features, 3, padding="same", name=f"{name}_conv2")(hidden)
     return features + hidden
 
 
-def aux_pre_head(features):
-    widths = (32, 64, 32, 64, 32)
+def aux_pre_head(features, fusion_features):
+    half = fusion_features // 2
+    widths = (half, fusion_features, half, fusion_features, half)
     for index, width in enumerate(widths):
         features = Conv2D(width, 3, padding="same",
                           name=f"head_out1_aux_{index}")(features)
@@ -96,7 +101,7 @@ def aux_pre_head(features):
 def depth_head(features, image_shape):
     upsampled = resize_bilinear_align_corners(features, image_shape[:2])
     upsampled = add_pos_embed(upsampled, image_shape)
-    hidden = Conv2D(HEAD_CHANNELS, 3, padding="same", name="head_out2_conv0")(upsampled)
+    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_out2_conv0")(upsampled)
     hidden = ReLU()(hidden)
     logits = Conv2D(2, 1, name="head_out2_conv1")(hidden)
     depth = ops.exp(logits[..., 0])
@@ -106,7 +111,7 @@ def depth_head(features, image_shape):
 
 def ray_head(features, image_shape):
     features = add_pos_embed(features, image_shape)
-    hidden = Conv2D(HEAD_CHANNELS, 3, padding="same", name="head_out2_aux_conv0")(features)
+    hidden = Conv2D(HEAD_FEATURES, 3, padding="same", name="head_out2_aux_conv0")(features)
     hidden = LayerNormalization(epsilon=1e-5, name="head_out2_aux_ln")(hidden)
     hidden = ReLU()(hidden)
     logits = Conv2D(7, 1, name="head_out2_aux_conv1")(hidden)

--- a/paz/models/foundation/depth_anything3/dual_dpt.py
+++ b/paz/models/foundation/depth_anything3/dual_dpt.py
@@ -1,0 +1,155 @@
+"""DualDPT head: dense depth (+confidence) and camera rays (+confidence).
+
+Channels-last throughout. The primary chain upsamples to full image
+resolution; the auxiliary (ray) chain stops at the finest fusion scale
+(eight times the patch grid). Depth uses exp, confidences use exp(x)+1.
+"""
+import numpy as np
+from keras import ops
+from keras.layers import Conv2D, Conv2DTranspose, LayerNormalization, ReLU
+
+from paz.backend.image import resize_bilinear_align_corners
+
+PATCH_SIZE = 14
+FEATURES = 64
+OUT_CHANNELS = (48, 96, 192, 384)
+HEAD_CHANNELS = 32
+POS_RATIO = 0.1
+OMEGA = 100.0
+
+
+def build_dual_dpt(features, grid, image_shape):
+    norm = LayerNormalization(epsilon=1e-5, name="head_norm")
+    stages = [project_stage(features[k], norm, k, grid, image_shape)
+              for k in range(4)]
+    main, aux = fuse_pyramid(stages)
+    depth, depth_confidence = depth_head(main, image_shape)
+    rays, ray_confidence = ray_head(aux, image_shape)
+    return depth, depth_confidence, rays, ray_confidence
+
+
+def project_stage(tokens, norm, stage, grid, image_shape):
+    grid_height, grid_width = grid
+    projected = norm(tokens)
+    projected = ops.reshape(projected, (-1, grid_height, grid_width, 768))
+    projected = Conv2D(OUT_CHANNELS[stage], 1, name=f"head_project_{stage}")(projected)
+    projected = add_pos_embed(projected, image_shape)
+    return resize_stage(projected, stage)
+
+
+def resize_stage(features, stage):
+    if stage == 0:
+        return Conv2DTranspose(48, 4, strides=4, name="head_resize_0")(features)
+    if stage == 1:
+        return Conv2DTranspose(96, 2, strides=2, name="head_resize_1")(features)
+    if stage == 2:
+        return features
+    return Conv2D(384, 3, strides=2, padding="same", name="head_resize_3")(features)
+
+
+def fuse_pyramid(stages):
+    lateral = [reassemble(stages[k], k) for k in range(4)]
+    main = fuse_chain(lateral, "")
+    aux = fuse_chain(lateral, "_aux")
+    main = Conv2D(HEAD_CHANNELS, 3, padding="same", name="head_out1")(main)
+    aux = aux_pre_head(aux)
+    return main, aux
+
+
+def reassemble(features, stage):
+    name = f"head_layer{stage + 1}_rn"
+    return Conv2D(FEATURES, 3, padding="same", use_bias=False, name=name)(features)
+
+
+def fuse_chain(lateral, suffix):
+    sizes = [ops.shape(level)[1:3] for level in lateral]
+    fused = fusion_block(None, lateral[3], sizes[2], f"head_refine4{suffix}")
+    fused = fusion_block(fused, lateral[2], sizes[1], f"head_refine3{suffix}")
+    fused = fusion_block(fused, lateral[1], sizes[0], f"head_refine2{suffix}")
+    double = (sizes[0][0] * 2, sizes[0][1] * 2)
+    return fusion_block(fused, lateral[0], double, f"head_refine1{suffix}")
+
+
+def fusion_block(previous, lateral, size, name):
+    fused = lateral if previous is None else previous + residual_unit(lateral, f"{name}_unit1")
+    fused = residual_unit(fused, f"{name}_unit2")
+    fused = resize_bilinear_align_corners(fused, size)
+    return Conv2D(FEATURES, 1, name=f"{name}_out")(fused)
+
+
+def residual_unit(features, name):
+    hidden = ReLU()(features)
+    hidden = Conv2D(FEATURES, 3, padding="same", name=f"{name}_conv1")(hidden)
+    hidden = ReLU()(hidden)
+    hidden = Conv2D(FEATURES, 3, padding="same", name=f"{name}_conv2")(hidden)
+    return features + hidden
+
+
+def aux_pre_head(features):
+    widths = (32, 64, 32, 64, 32)
+    for index, width in enumerate(widths):
+        features = Conv2D(width, 3, padding="same",
+                          name=f"head_out1_aux_{index}")(features)
+    return features
+
+
+def depth_head(features, image_shape):
+    upsampled = resize_bilinear_align_corners(features, image_shape[:2])
+    upsampled = add_pos_embed(upsampled, image_shape)
+    hidden = Conv2D(HEAD_CHANNELS, 3, padding="same", name="head_out2_conv0")(upsampled)
+    hidden = ReLU()(hidden)
+    logits = Conv2D(2, 1, name="head_out2_conv1")(hidden)
+    depth = ops.exp(logits[..., 0])
+    depth_confidence = ops.exp(logits[..., 1]) + 1.0
+    return depth, depth_confidence
+
+
+def ray_head(features, image_shape):
+    features = add_pos_embed(features, image_shape)
+    hidden = Conv2D(HEAD_CHANNELS, 3, padding="same", name="head_out2_aux_conv0")(features)
+    hidden = LayerNormalization(epsilon=1e-5, name="head_out2_aux_ln")(hidden)
+    hidden = ReLU()(hidden)
+    logits = Conv2D(7, 1, name="head_out2_aux_conv1")(hidden)
+    rays = logits[..., :6]
+    ray_confidence = ops.exp(logits[..., 6]) + 1.0
+    return rays, ray_confidence
+
+
+def add_pos_embed(features, image_shape):
+    _, height, width, channels = features.shape
+    embedding = build_uv_position_embedding(height, width, channels, image_shape)
+    return features + ops.array(embedding)
+
+
+def build_uv_position_embedding(height, width, channels, image_shape):
+    aspect = image_shape[1] / image_shape[0]
+    grid = build_uv_grid(width, height, aspect)
+    embedding = position_grid_to_embedding(grid, channels)
+    return (embedding * POS_RATIO).astype("float32")
+
+
+def build_uv_grid(width, height, aspect):
+    diagonal = (aspect ** 2 + 1.0) ** 0.5
+    span_x = aspect / diagonal
+    span_y = 1.0 / diagonal
+    x = np.linspace(-span_x * (width - 1) / width,
+                    span_x * (width - 1) / width, width)
+    y = np.linspace(-span_y * (height - 1) / height,
+                    span_y * (height - 1) / height, height)
+    columns, rows = np.meshgrid(x, y)
+    return np.stack([columns, rows], axis=-1)
+
+
+def position_grid_to_embedding(grid, channels):
+    flat = grid.reshape(-1, 2)
+    embed_x = sincos_embedding(channels // 2, flat[:, 0])
+    embed_y = sincos_embedding(channels // 2, flat[:, 1])
+    embedding = np.concatenate([embed_x, embed_y], axis=-1)
+    return embedding.reshape(grid.shape[0], grid.shape[1], channels)
+
+
+def sincos_embedding(dimension, positions):
+    omega = np.arange(dimension // 2) / (dimension / 2.0)
+    omega = 1.0 / (OMEGA ** omega)
+    angles = np.outer(positions, omega)
+    return np.concatenate([np.sin(angles), np.cos(angles)], axis=-1)

--- a/paz/models/foundation/depth_anything3/embeddings.py
+++ b/paz/models/foundation/depth_anything3/embeddings.py
@@ -1,0 +1,39 @@
+from keras import ops
+from keras.layers import Embedding, Lambda
+
+from paz.models.transformers.attention import kernel
+from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
+from paz.models.foundation.depth_anything3 import routing
+
+
+def build_view_embeddings(images, patch_size, hidden_size, num_positions,
+                          num_views):
+    folded = routing.fold_view_images(images)
+    tokens = build_dinov2_embeddings(folded, patch_size, hidden_size,
+                                     num_positions, 0)
+    return routing.restore_view_dimension(tokens, num_views)
+
+
+def insert_camera_tokens(tokens, hidden_size):
+    table = build_camera_table(tokens, hidden_size)
+    reference = ops.expand_dims(table[:, 0:1], axis=2)
+    source = broadcast_source(tokens[:, 1:], table[:, 1:2])
+    camera = ops.concatenate([reference, source], axis=1)
+    return ops.concatenate([camera, tokens[:, :, 1:, :]], axis=2)
+
+
+def broadcast_source(view_slice, token):
+    anchor = view_slice[:, :, :1, :]
+    return ops.zeros_like(anchor) + ops.expand_dims(token, axis=2)
+
+
+def build_camera_table(reference, hidden_size):
+    indices = Lambda(batched_pair_indices, output_shape=(2,),
+                     name="camera_token_indices")(reference)
+    return Embedding(2, hidden_size, kernel(), name="camera_token")(indices)
+
+
+def batched_pair_indices(reference):
+    batch = ops.shape(reference)[0]
+    base = ops.arange(2, dtype="int32")[None]
+    return ops.broadcast_to(base, (batch, 2))

--- a/paz/models/foundation/depth_anything3/embeddings.py
+++ b/paz/models/foundation/depth_anything3/embeddings.py
@@ -1,39 +1,26 @@
 from keras import ops
-from keras.layers import Embedding, Lambda
 
-from paz.models.transformers.attention import kernel
-from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
+from paz.models.transformers.embeddings.token import LearnableTokens
+from paz.models.foundation.dinov2 import embeddings as dinov2_embeddings
 from paz.models.foundation.depth_anything3 import routing
 
 
 def build_view_embeddings(images, patch_size, hidden_size, num_positions,
                           num_views):
     folded = routing.fold_view_images(images)
-    tokens = build_dinov2_embeddings(folded, patch_size, hidden_size,
-                                     num_positions, 0)
+    args = folded, patch_size, hidden_size, num_positions, 0
+    tokens = dinov2_embeddings.build(*args)
     return routing.restore_view_dimension(tokens, num_views)
 
 
 def insert_camera_tokens(tokens, hidden_size):
-    table = build_camera_table(tokens, hidden_size)
-    reference = ops.expand_dims(table[:, 0:1], axis=2)
-    source = broadcast_source(tokens[:, 1:], table[:, 1:2])
-    camera = ops.concatenate([reference, source], axis=1)
+    table = LearnableTokens(2, hidden_size, name="camera_token")(tokens[:, 0])
+    reference_view = ops.expand_dims(table[:, 0:1], axis=2)
+    other_views = broadcast_other_views(tokens[:, 1:], table[:, 1:2])
+    camera = ops.concatenate([reference_view, other_views], axis=1)
     return ops.concatenate([camera, tokens[:, :, 1:, :]], axis=2)
 
 
-def broadcast_source(view_slice, token):
+def broadcast_other_views(view_slice, token):
     anchor = view_slice[:, :, :1, :]
     return ops.zeros_like(anchor) + ops.expand_dims(token, axis=2)
-
-
-def build_camera_table(reference, hidden_size):
-    indices = Lambda(batched_pair_indices, output_shape=(2,),
-                     name="camera_token_indices")(reference)
-    return Embedding(2, hidden_size, kernel(), name="camera_token")(indices)
-
-
-def batched_pair_indices(reference):
-    batch = ops.shape(reference)[0]
-    base = ops.arange(2, dtype="int32")[None]
-    return ops.broadcast_to(base, (batch, 2))

--- a/paz/models/foundation/depth_anything3/models.py
+++ b/paz/models/foundation/depth_anything3/models.py
@@ -1,10 +1,17 @@
 from keras import Input, Model, ops
+from keras.layers import LayerNormalization
 
 from paz.models.foundation.depth_anything3 import routing
 from paz.models.foundation.depth_anything3.embeddings import build_view_embeddings
 from paz.models.foundation.depth_anything3.backbone import build_da3_backbone
 from paz.models.foundation.depth_anything3.dual_dpt import build_dual_dpt
+from paz.models.foundation.depth_anything3.dpt import build_dpt
 from paz.models.foundation.depth_anything3.camera import build_camera_decoder
+from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
+from paz.models.foundation.dinov2.encoder import build_dinov2_encoder
+
+LAYER_NORM_EPSILON = 1e-6
+MONO_OUT_LAYERS = (4, 11, 17, 23)
 
 PATCH_SIZE = 14
 MLP_RATIO = 4.0
@@ -34,6 +41,35 @@ def build_da3_backbone_model(num_views, image_shape, hidden_size, depth,
 
 def grid_shape(image_shape, patch_size):
     return image_shape[0] // patch_size, image_shape[1] // patch_size
+
+
+def build_da3_mono_large(image_shape, name="da3_mono_large"):
+    return build_mono(image_shape, name)
+
+
+def build_da3_metric_large(image_shape, name="da3_metric_large"):
+    return build_mono(image_shape, name)
+
+
+def build_mono(image_shape, name):
+    images = Input(image_shape, name="image")
+    grid = grid_shape(image_shape, PATCH_SIZE)
+    num_positions = grid[0] * grid[1] + 1
+    tokens = build_dinov2_embeddings(images, PATCH_SIZE, 1024, num_positions, 0)
+    _, hidden_states = build_dinov2_encoder(tokens, 1024, 24, 16, MLP_RATIO,
+                                            LAYER_SCALE_INIT)
+    features = collect_mono_features(hidden_states)
+    depth, sky = build_dpt(features, grid, image_shape, 1024,
+                           (256, 512, 1024, 1024), 256)
+    return Model(images, [depth, sky], name=name)
+
+
+def collect_mono_features(hidden_states):
+    norm = LayerNormalization(epsilon=LAYER_NORM_EPSILON, name="norm")
+    features = []
+    for layer in MONO_OUT_LAYERS:
+        features.append(norm(hidden_states[layer])[:, 1:])
+    return features
 
 
 def build_da3_small(num_views, image_shape, name="da3_small"):

--- a/paz/models/foundation/depth_anything3/models.py
+++ b/paz/models/foundation/depth_anything3/models.py
@@ -1,0 +1,33 @@
+from keras import Input, Model
+
+from paz.models.foundation.depth_anything3.embeddings import build_view_embeddings
+from paz.models.foundation.depth_anything3.backbone import build_da3_backbone
+
+PATCH_SIZE = 14
+MLP_RATIO = 4.0
+LAYER_SCALE_INIT = 1.0
+OUT_LAYERS = (5, 7, 9, 11)
+ALT_START = 4
+
+
+def build_da3_small_backbone(num_views, image_shape,
+                             name="da3_small_backbone"):
+    args = (num_views, image_shape, 384, 12, 6)
+    return build_da3_backbone_model(*args, name)
+
+
+def build_da3_backbone_model(num_views, image_shape, hidden_size, depth,
+                             num_heads, name):
+    images = Input((num_views, *image_shape), name="views")
+    grid = grid_shape(image_shape, PATCH_SIZE)
+    num_positions = grid[0] * grid[1] + 1
+    tokens = build_view_embeddings(images, PATCH_SIZE, hidden_size,
+                                   num_positions, num_views)
+    features, camera_tokens = build_da3_backbone(
+        tokens, num_views, grid, hidden_size, depth, num_heads, MLP_RATIO,
+        LAYER_SCALE_INIT, OUT_LAYERS, ALT_START)
+    return Model(images, features + camera_tokens, name=name)
+
+
+def grid_shape(image_shape, patch_size):
+    return image_shape[0] // patch_size, image_shape[1] // patch_size

--- a/paz/models/foundation/depth_anything3/models.py
+++ b/paz/models/foundation/depth_anything3/models.py
@@ -6,9 +6,6 @@ from paz.models.foundation.depth_anything3.backbone import build_da3_backbone
 from paz.models.foundation.depth_anything3.dual_dpt import build_dual_dpt
 from paz.models.foundation.depth_anything3.camera import build_camera_decoder
 
-HIDDEN_SIZE = 384
-FEATURE_SIZE = 768
-
 PATCH_SIZE = 14
 MLP_RATIO = 4.0
 LAYER_SCALE_INIT = 1.0
@@ -40,25 +37,40 @@ def grid_shape(image_shape, patch_size):
 
 
 def build_da3_small(num_views, image_shape, name="da3_small"):
+    args = (384, 6, (48, 96, 192, 384), 64)
+    return build_da3(num_views, image_shape, *args, name)
+
+
+def build_da3_base(num_views, image_shape, name="da3_base"):
+    args = (768, 12, (96, 192, 384, 768), 128)
+    return build_da3(num_views, image_shape, *args, name)
+
+
+def build_da3(num_views, image_shape, hidden_size, num_heads, out_channels,
+              fusion_features, name):
     images = Input((num_views, *image_shape), name="views")
     grid = grid_shape(image_shape, PATCH_SIZE)
     num_positions = grid[0] * grid[1] + 1
-    tokens = build_view_embeddings(images, PATCH_SIZE, HIDDEN_SIZE,
+    tokens = build_view_embeddings(images, PATCH_SIZE, hidden_size,
                                    num_positions, num_views)
     features, camera_tokens = build_da3_backbone(
-        tokens, num_views, grid, HIDDEN_SIZE, 12, 6, MLP_RATIO,
+        tokens, num_views, grid, hidden_size, 12, num_heads, MLP_RATIO,
         LAYER_SCALE_INIT, OUT_LAYERS, ALT_START)
-    depth, depth_conf, rays, ray_conf = apply_head(features, num_views, grid,
-                                                   image_shape)
+    feature_dim = 2 * hidden_size
+    depth, depth_conf, rays, ray_conf = apply_head(
+        features, num_views, grid, image_shape, feature_dim, out_channels,
+        fusion_features)
     extrinsics, intrinsics = build_camera_decoder(camera_tokens[-1],
-                                                  FEATURE_SIZE, image_shape)
+                                                  feature_dim, image_shape)
     outputs = [depth, depth_conf, extrinsics, intrinsics, rays, ray_conf]
     return Model(images, outputs, name=name)
 
 
-def apply_head(features, num_views, grid, image_shape):
+def apply_head(features, num_views, grid, image_shape, feature_dim,
+               out_channels, fusion_features):
     folded = [routing.fold_views_into_batch(feature) for feature in features]
-    depth, depth_conf, rays, ray_conf = build_dual_dpt(folded, grid, image_shape)
+    depth, depth_conf, rays, ray_conf = build_dual_dpt(
+        folded, grid, image_shape, feature_dim, out_channels, fusion_features)
     height, width = image_shape[0], image_shape[1]
     ray_height, ray_width = grid[0] * 8, grid[1] * 8
     depth = ops.reshape(depth, (-1, num_views, height, width))

--- a/paz/models/foundation/depth_anything3/models.py
+++ b/paz/models/foundation/depth_anything3/models.py
@@ -1,7 +1,13 @@
-from keras import Input, Model
+from keras import Input, Model, ops
 
+from paz.models.foundation.depth_anything3 import routing
 from paz.models.foundation.depth_anything3.embeddings import build_view_embeddings
 from paz.models.foundation.depth_anything3.backbone import build_da3_backbone
+from paz.models.foundation.depth_anything3.dual_dpt import build_dual_dpt
+from paz.models.foundation.depth_anything3.camera import build_camera_decoder
+
+HIDDEN_SIZE = 384
+FEATURE_SIZE = 768
 
 PATCH_SIZE = 14
 MLP_RATIO = 4.0
@@ -31,3 +37,32 @@ def build_da3_backbone_model(num_views, image_shape, hidden_size, depth,
 
 def grid_shape(image_shape, patch_size):
     return image_shape[0] // patch_size, image_shape[1] // patch_size
+
+
+def build_da3_small(num_views, image_shape, name="da3_small"):
+    images = Input((num_views, *image_shape), name="views")
+    grid = grid_shape(image_shape, PATCH_SIZE)
+    num_positions = grid[0] * grid[1] + 1
+    tokens = build_view_embeddings(images, PATCH_SIZE, HIDDEN_SIZE,
+                                   num_positions, num_views)
+    features, camera_tokens = build_da3_backbone(
+        tokens, num_views, grid, HIDDEN_SIZE, 12, 6, MLP_RATIO,
+        LAYER_SCALE_INIT, OUT_LAYERS, ALT_START)
+    depth, depth_conf, rays, ray_conf = apply_head(features, num_views, grid,
+                                                   image_shape)
+    extrinsics, intrinsics = build_camera_decoder(camera_tokens[-1],
+                                                  FEATURE_SIZE, image_shape)
+    outputs = [depth, depth_conf, extrinsics, intrinsics, rays, ray_conf]
+    return Model(images, outputs, name=name)
+
+
+def apply_head(features, num_views, grid, image_shape):
+    folded = [routing.fold_views_into_batch(feature) for feature in features]
+    depth, depth_conf, rays, ray_conf = build_dual_dpt(folded, grid, image_shape)
+    height, width = image_shape[0], image_shape[1]
+    ray_height, ray_width = grid[0] * 8, grid[1] * 8
+    depth = ops.reshape(depth, (-1, num_views, height, width))
+    depth_conf = ops.reshape(depth_conf, (-1, num_views, height, width))
+    rays = ops.reshape(rays, (-1, num_views, ray_height, ray_width, 6))
+    ray_conf = ops.reshape(ray_conf, (-1, num_views, ray_height, ray_width))
+    return depth, depth_conf, rays, ray_conf

--- a/paz/models/foundation/depth_anything3/models.py
+++ b/paz/models/foundation/depth_anything3/models.py
@@ -2,115 +2,112 @@ from keras import Input, Model, ops
 from keras.layers import LayerNormalization
 
 from paz.models.foundation.depth_anything3 import routing
-from paz.models.foundation.depth_anything3.embeddings import build_view_embeddings
-from paz.models.foundation.depth_anything3.backbone import build_da3_backbone
-from paz.models.foundation.depth_anything3.dual_dpt import build_dual_dpt
-from paz.models.foundation.depth_anything3.dpt import build_dpt
-from paz.models.foundation.depth_anything3.camera import build_camera_decoder
-from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
-from paz.models.foundation.dinov2.encoder import build_dinov2_encoder
-
-LAYER_NORM_EPSILON = 1e-6
-MONO_OUT_LAYERS = (4, 11, 17, 23)
-
-PATCH_SIZE = 14
-MLP_RATIO = 4.0
-LAYER_SCALE_INIT = 1.0
-OUT_LAYERS = (5, 7, 9, 11)
-ALT_START = 4
+from paz.models.foundation.depth_anything3 import embeddings
+from paz.models.foundation.depth_anything3 import backbone
+from paz.models.foundation.depth_anything3 import dual_dpt
+from paz.models.foundation.depth_anything3 import dpt
+from paz.models.foundation.depth_anything3 import camera
+from paz.models.foundation.dinov2 import embeddings as dinov2_embeddings
+from paz.models.foundation.dinov2 import encoder as dinov2_encoder
 
 
-def build_da3_small_backbone(num_views, image_shape,
-                             name="da3_small_backbone"):
-    args = (num_views, image_shape, 384, 12, 6)
-    return build_da3_backbone_model(*args, name)
-
-
-def build_da3_backbone_model(num_views, image_shape, hidden_size, depth,
-                             num_heads, name):
-    images = Input((num_views, *image_shape), name="views")
-    grid = grid_shape(image_shape, PATCH_SIZE)
-    num_positions = grid[0] * grid[1] + 1
-    tokens = build_view_embeddings(images, PATCH_SIZE, hidden_size,
-                                   num_positions, num_views)
-    features, camera_tokens = build_da3_backbone(
-        tokens, num_views, grid, hidden_size, depth, num_heads, MLP_RATIO,
-        LAYER_SCALE_INIT, OUT_LAYERS, ALT_START)
-    return Model(images, features + camera_tokens, name=name)
-
-
-def grid_shape(image_shape, patch_size):
-    return image_shape[0] // patch_size, image_shape[1] // patch_size
-
-
-def build_da3_mono_large(image_shape, name="da3_mono_large"):
-    return build_mono(image_shape, name)
-
-
-def build_da3_metric_large(image_shape, name="da3_metric_large"):
-    return build_mono(image_shape, name)
-
-
-def build_mono(image_shape, name):
-    images = Input(image_shape, name="image")
-    grid = grid_shape(image_shape, PATCH_SIZE)
-    num_positions = grid[0] * grid[1] + 1
-    tokens = build_dinov2_embeddings(images, PATCH_SIZE, 1024, num_positions, 0)
-    _, hidden_states = build_dinov2_encoder(tokens, 1024, 24, 16, MLP_RATIO,
-                                            LAYER_SCALE_INIT)
-    features = collect_mono_features(hidden_states)
-    depth, sky = build_dpt(features, grid, image_shape, 1024,
-                           (256, 512, 1024, 1024), 256)
-    return Model(images, [depth, sky], name=name)
-
-
-def collect_mono_features(hidden_states):
-    norm = LayerNormalization(epsilon=LAYER_NORM_EPSILON, name="norm")
-    features = []
-    for layer in MONO_OUT_LAYERS:
-        features.append(norm(hidden_states[layer])[:, 1:])
-    return features
-
-
-def build_da3_small(num_views, image_shape, name="da3_small"):
-    args = (384, 6, (48, 96, 192, 384), 64)
+def DepthAnything3Small(num_views, image_shape, name="da3_small"):
+    args = 384, 6, (48, 96, 192, 384), 64
     return build_da3(num_views, image_shape, *args, name)
 
 
-def build_da3_base(num_views, image_shape, name="da3_base"):
-    args = (768, 12, (96, 192, 384, 768), 128)
+def DepthAnything3Base(num_views, image_shape, name="da3_base"):
+    args = 768, 12, (96, 192, 384, 768), 128
     return build_da3(num_views, image_shape, *args, name)
 
 
 def build_da3(num_views, image_shape, hidden_size, num_heads, out_channels,
               fusion_features, name):
     images = Input((num_views, *image_shape), name="views")
-    grid = grid_shape(image_shape, PATCH_SIZE)
-    num_positions = grid[0] * grid[1] + 1
-    tokens = build_view_embeddings(images, PATCH_SIZE, hidden_size,
-                                   num_positions, num_views)
-    features, camera_tokens = build_da3_backbone(
-        tokens, num_views, grid, hidden_size, 12, num_heads, MLP_RATIO,
-        LAYER_SCALE_INIT, OUT_LAYERS, ALT_START)
-    feature_dim = 2 * hidden_size
-    depth, depth_conf, rays, ray_conf = apply_head(
-        features, num_views, grid, image_shape, feature_dim, out_channels,
-        fusion_features)
-    extrinsics, intrinsics = build_camera_decoder(camera_tokens[-1],
-                                                  feature_dim, image_shape)
-    outputs = [depth, depth_conf, extrinsics, intrinsics, rays, ray_conf]
+    grid = grid_shape(image_shape, 14)
+    tokens = embed_views(images, hidden_size, num_views, grid)
+    features, cameras = encode_views(tokens, num_views, grid, hidden_size,
+                                     num_heads)
+    args = features, num_views, grid, image_shape, hidden_size
+    head = apply_head(*args, out_channels, fusion_features)
+    extrinsics, intrinsics = decode_cameras(cameras, hidden_size, image_shape)
+    outputs = [head[0], head[1], extrinsics, intrinsics, head[2], head[3]]
     return Model(images, outputs, name=name)
 
 
-def apply_head(features, num_views, grid, image_shape, feature_dim,
+def embed_views(images, hidden_size, num_views, grid):
+    positions = grid[0] * grid[1] + 1
+    args = images, 14, hidden_size, positions, num_views
+    return embeddings.build_view_embeddings(*args)
+
+
+def encode_views(tokens, num_views, grid, hidden_size, num_heads):
+    block_args = hidden_size, num_heads, 4.0, 1.0
+    args = tokens, num_views, grid, block_args, 12, (5, 7, 9, 11), 4
+    return backbone.build(*args)
+
+
+def apply_head(features, num_views, grid, image_shape, hidden_size,
                out_channels, fusion_features):
-    folded = [routing.fold_views_into_batch(feature) for feature in features]
-    depth, depth_conf, rays, ray_conf = build_dual_dpt(
-        folded, grid, image_shape, feature_dim, out_channels, fusion_features)
-    height, width = image_shape[0], image_shape[1]
-    ray_height, ray_width = grid[0] * 8, grid[1] * 8
-    depth = ops.reshape(depth, (-1, num_views, height, width))
-    depth_conf = ops.reshape(depth_conf, (-1, num_views, height, width))
-    rays = ops.reshape(rays, (-1, num_views, ray_height, ray_width, 6))
-    ray_conf = ops.reshape(ray_conf, (-1, num_views, ray_height, ray_width))
+    folded = [routing.fold_views_into_batch(view) for view in features]
+    feature_dim = 2 * hidden_size
+    args = folded, grid, image_shape, feature_dim, out_channels
+    outputs = dual_dpt.build(*args, fusion_features)
+    return restore_views(outputs, num_views, grid, image_shape)
+
+
+def restore_views(outputs, num_views, grid, image_shape):
+    depth, depth_conf, rays, ray_conf = outputs
+    H, W = image_shape[0], image_shape[1]
+    ray_H, ray_W = grid[0] * 8, grid[1] * 8
+    depth = ops.reshape(depth, (-1, num_views, H, W))
+    depth_conf = ops.reshape(depth_conf, (-1, num_views, H, W))
+    rays = ops.reshape(rays, (-1, num_views, ray_H, ray_W, 6))
+    ray_conf = ops.reshape(ray_conf, (-1, num_views, ray_H, ray_W))
     return depth, depth_conf, rays, ray_conf
+
+
+def decode_cameras(cameras, hidden_size, image_shape):
+    args = cameras[-1], 2 * hidden_size, image_shape
+    return camera.build_camera_decoder(*args)
+
+
+def DepthAnything3MonoLarge(image_shape, name="da3_mono_large"):
+    return build_mono(image_shape, name)
+
+
+def DepthAnything3MetricLarge(image_shape, name="da3_metric_large"):
+    return build_mono(image_shape, name)
+
+
+def build_mono(image_shape, name):
+    images = Input(image_shape, name="image")
+    grid = grid_shape(image_shape, 14)
+    positions = grid[0] * grid[1] + 1
+    args = images, 14, 1024, positions, 0
+    tokens = dinov2_embeddings.build(*args)
+    _, hidden_states = dinov2_encoder.build(tokens, 1024, 24, 16, 4.0, 1.0)
+    features = collect_mono_features(hidden_states)
+    channels = 256, 512, 1024, 1024
+    depth, sky = dpt.build(features, grid, image_shape, 1024, channels, 256)
+    return Model(images, [depth, sky], name=name)
+
+
+def collect_mono_features(hidden_states):
+    norm = LayerNormalization(epsilon=1e-6, name="norm")
+    features = []
+    for layer in (4, 11, 17, 23):
+        features.append(norm(hidden_states[layer])[:, 1:])
+    return features
+
+
+def build_da3_small_backbone(num_views, image_shape, name="da3_backbone"):
+    images = Input((num_views, *image_shape), name="views")
+    grid = grid_shape(image_shape, 14)
+    tokens = embed_views(images, 384, num_views, grid)
+    features, cameras = encode_views(tokens, num_views, grid, 384, 6)
+    return Model(images, features + cameras, name=name)
+
+
+def grid_shape(image_shape, patch_size):
+    return image_shape[0] // patch_size, image_shape[1] // patch_size

--- a/paz/models/foundation/depth_anything3/models_test.py
+++ b/paz/models/foundation/depth_anything3/models_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import jax
 
 from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
+from paz.models.foundation.depth_anything3.models import build_da3_small
 from paz.models.foundation.depth_anything3.models import grid_shape
 from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
 
@@ -37,6 +38,31 @@ def test_backbone_feature_and_camera_shapes():
 
 def test_backbone_jit_matches_eager():
     model = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
+    data = make_input()
+    eager = np.array(model(data)[0])
+    jitted = np.array(jax.jit(lambda x: model(x))(data)[0])
+    assert np.allclose(eager, jitted, atol=1e-5)
+
+
+def test_da3_small_output_order_and_shapes():
+    model = build_da3_small(VIEWS, IMAGE_SHAPE)
+    outputs = model(make_input())
+    assert not isinstance(outputs, dict)
+    assert not hasattr(outputs, "_fields")
+    assert len(outputs) == 6
+    depth, depth_conf, extrinsics, intrinsics, rays, ray_conf = outputs
+    grid = grid_shape(IMAGE_SHAPE, 14)
+    ray_size = (grid[0] * 8, grid[1] * 8)
+    assert tuple(depth.shape) == (1, VIEWS, 70, 70)
+    assert tuple(depth_conf.shape) == (1, VIEWS, 70, 70)
+    assert tuple(extrinsics.shape) == (1, VIEWS, 3, 4)
+    assert tuple(intrinsics.shape) == (1, VIEWS, 3, 3)
+    assert tuple(rays.shape) == (1, VIEWS, ray_size[0], ray_size[1], 6)
+    assert tuple(ray_conf.shape) == (1, VIEWS, ray_size[0], ray_size[1])
+
+
+def test_da3_small_jit_runs():
+    model = build_da3_small(VIEWS, IMAGE_SHAPE)
     data = make_input()
     eager = np.array(model(data)[0])
     jitted = np.array(jax.jit(lambda x: model(x))(data)[0])

--- a/paz/models/foundation/depth_anything3/models_test.py
+++ b/paz/models/foundation/depth_anything3/models_test.py
@@ -4,6 +4,7 @@ import jax
 from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
 from paz.models.foundation.depth_anything3.models import build_da3_small
 from paz.models.foundation.depth_anything3.models import build_da3_base
+from paz.models.foundation.depth_anything3.models import build_da3_mono_large
 from paz.models.foundation.depth_anything3.models import grid_shape
 from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
 
@@ -70,6 +71,17 @@ def test_da3_base_output_order_and_shapes():
     assert tuple(depth.shape) == (1, VIEWS, 70, 70)
     assert tuple(extrinsics.shape) == (1, VIEWS, 3, 4)
     assert tuple(rays.shape) == (1, VIEWS, 40, 40, 6)
+
+
+def test_mono_large_returns_depth_and_sky():
+    model = build_da3_mono_large(IMAGE_SHAPE)
+    image = np.random.RandomState(0).randn(1, *IMAGE_SHAPE).astype("float32")
+    outputs = model(image)
+    assert not isinstance(outputs, dict)
+    assert len(outputs) == 2
+    depth, sky = outputs
+    assert tuple(depth.shape) == (1, 70, 70)
+    assert tuple(sky.shape) == (1, 70, 70)
 
 
 def test_da3_small_jit_runs():

--- a/paz/models/foundation/depth_anything3/models_test.py
+++ b/paz/models/foundation/depth_anything3/models_test.py
@@ -3,6 +3,7 @@ import jax
 
 from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
 from paz.models.foundation.depth_anything3.models import build_da3_small
+from paz.models.foundation.depth_anything3.models import build_da3_base
 from paz.models.foundation.depth_anything3.models import grid_shape
 from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
 
@@ -59,6 +60,16 @@ def test_da3_small_output_order_and_shapes():
     assert tuple(intrinsics.shape) == (1, VIEWS, 3, 3)
     assert tuple(rays.shape) == (1, VIEWS, ray_size[0], ray_size[1], 6)
     assert tuple(ray_conf.shape) == (1, VIEWS, ray_size[0], ray_size[1])
+
+
+def test_da3_base_output_order_and_shapes():
+    model = build_da3_base(VIEWS, IMAGE_SHAPE)
+    outputs = model(make_input())
+    assert len(outputs) == 6
+    depth, depth_conf, extrinsics, intrinsics, rays, ray_conf = outputs
+    assert tuple(depth.shape) == (1, VIEWS, 70, 70)
+    assert tuple(extrinsics.shape) == (1, VIEWS, 3, 4)
+    assert tuple(rays.shape) == (1, VIEWS, 40, 40, 6)
 
 
 def test_da3_small_jit_runs():

--- a/paz/models/foundation/depth_anything3/models_test.py
+++ b/paz/models/foundation/depth_anything3/models_test.py
@@ -1,12 +1,12 @@
 import numpy as np
 import jax
 
-from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
-from paz.models.foundation.depth_anything3.models import build_da3_small
-from paz.models.foundation.depth_anything3.models import build_da3_base
-from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+from paz.models.foundation.depth_anything3 import build_da3_small_backbone
+from paz.models.foundation.depth_anything3.models import DepthAnything3Small
+from paz.models.foundation.depth_anything3.models import DepthAnything3Base
+from paz.models.foundation.depth_anything3.models import DepthAnything3MonoLarge
 from paz.models.foundation.depth_anything3.models import grid_shape
-from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
+from paz.models.foundation.depth_anything3 import port_weights
 
 IMAGE_SHAPE = (70, 70, 3)
 VIEWS = 2
@@ -47,7 +47,7 @@ def test_backbone_jit_matches_eager():
 
 
 def test_da3_small_output_order_and_shapes():
-    model = build_da3_small(VIEWS, IMAGE_SHAPE)
+    model = DepthAnything3Small(VIEWS, IMAGE_SHAPE)
     outputs = model(make_input())
     assert not isinstance(outputs, dict)
     assert not hasattr(outputs, "_fields")
@@ -64,7 +64,7 @@ def test_da3_small_output_order_and_shapes():
 
 
 def test_da3_base_output_order_and_shapes():
-    model = build_da3_base(VIEWS, IMAGE_SHAPE)
+    model = DepthAnything3Base(VIEWS, IMAGE_SHAPE)
     outputs = model(make_input())
     assert len(outputs) == 6
     depth, depth_conf, extrinsics, intrinsics, rays, ray_conf = outputs
@@ -74,7 +74,7 @@ def test_da3_base_output_order_and_shapes():
 
 
 def test_mono_large_returns_depth_and_sky():
-    model = build_da3_mono_large(IMAGE_SHAPE)
+    model = DepthAnything3MonoLarge(IMAGE_SHAPE)
     image = np.random.RandomState(0).randn(1, *IMAGE_SHAPE).astype("float32")
     outputs = model(image)
     assert not isinstance(outputs, dict)
@@ -85,7 +85,7 @@ def test_mono_large_returns_depth_and_sky():
 
 
 def test_da3_small_jit_runs():
-    model = build_da3_small(VIEWS, IMAGE_SHAPE)
+    model = DepthAnything3Small(VIEWS, IMAGE_SHAPE)
     data = make_input()
     eager = np.array(model(data)[0])
     jitted = np.array(jax.jit(lambda x: model(x))(data)[0])
@@ -104,7 +104,8 @@ def add_parameters(state, layer):
     weights = layer.get_weights()
     prefix = "model.backbone.pretrained."
     if name == "patch_embed_proj":
-        state[prefix + "patch_embed.proj.weight"] = np.transpose(weights[0], (3, 2, 0, 1))  # noqa: E501
+        kernel = np.transpose(weights[0], (3, 2, 0, 1))
+        state[prefix + "patch_embed.proj.weight"] = kernel
         state[prefix + "patch_embed.proj.bias"] = weights[1]
     elif name == "cls_token":
         state[prefix + "cls_token"] = weights[0].reshape(1, 1, -1)
@@ -142,7 +143,8 @@ def test_converter_reproduces_source_backbone():
     target = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
     num_positions = grid_shape(IMAGE_SHAPE, 14)
     num_positions = num_positions[0] * num_positions[1] + 1
-    port_backbone_weights(target, state, DEPTH, num_positions, HIDDEN)
+    args = target, state, DEPTH, num_positions, HIDDEN
+    port_weights.port_backbone_weights(*args)
     data = make_input()
     expected = np.array(source(data)[0])
     assert np.allclose(np.array(target(data)[0]), expected, atol=1e-5)

--- a/paz/models/foundation/depth_anything3/models_test.py
+++ b/paz/models/foundation/depth_anything3/models_test.py
@@ -1,0 +1,99 @@
+import numpy as np
+import jax
+
+from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
+from paz.models.foundation.depth_anything3.models import grid_shape
+from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
+
+IMAGE_SHAPE = (70, 70, 3)
+VIEWS = 2
+HIDDEN = 384
+DEPTH = 12
+
+
+def make_input(batch=1):
+    shape = (batch, VIEWS, *IMAGE_SHAPE)
+    return np.random.RandomState(0).randn(*shape).astype("float32")
+
+
+def test_backbone_returns_four_features_and_four_camera_tokens():
+    model = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
+    outputs = model(make_input())
+    assert not isinstance(outputs, dict)
+    assert not hasattr(outputs, "_fields")
+    assert len(outputs) == 8
+
+
+def test_backbone_feature_and_camera_shapes():
+    model = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
+    outputs = model(make_input())
+    grid = grid_shape(IMAGE_SHAPE, 14)
+    num_patches = grid[0] * grid[1]
+    for feature_map in outputs[:4]:
+        assert tuple(feature_map.shape) == (1, VIEWS, num_patches, 2 * HIDDEN)
+    for camera_token in outputs[4:]:
+        assert tuple(camera_token.shape) == (1, VIEWS, 2 * HIDDEN)
+
+
+def test_backbone_jit_matches_eager():
+    model = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
+    data = make_input()
+    eager = np.array(model(data)[0])
+    jitted = np.array(jax.jit(lambda x: model(x))(data)[0])
+    assert np.allclose(eager, jitted, atol=1e-5)
+
+
+def build_backbone_state_dict(model):
+    state = {}
+    for layer in model.layers:
+        add_parameters(state, layer)
+    return state
+
+
+def add_parameters(state, layer):
+    name = layer.name
+    weights = layer.get_weights()
+    prefix = "model.backbone.pretrained."
+    if name == "patch_embed_proj":
+        state[prefix + "patch_embed.proj.weight"] = np.transpose(weights[0], (3, 2, 0, 1))  # noqa: E501
+        state[prefix + "patch_embed.proj.bias"] = weights[1]
+    elif name == "cls_token":
+        state[prefix + "cls_token"] = weights[0].reshape(1, 1, -1)
+    elif name == "pos_embed":
+        state[prefix + "pos_embed"] = weights[0].reshape(1, -1, HIDDEN)
+    elif name == "camera_token":
+        state[prefix + "camera_token"] = weights[0].reshape(1, 2, -1)
+    elif name == "norm":
+        state[prefix + "norm.weight"], state[prefix + "norm.bias"] = weights
+    elif name.startswith("block_"):
+        add_block_parameters(state, name, weights, prefix)
+
+
+def add_block_parameters(state, name, weights, prefix):
+    index = name.split("_")[1]
+    suffix = name[len(f"block_{index}_"):]
+    source = f"{prefix}blocks.{index}."
+    linear = {"qkv": "attn.qkv", "proj": "attn.proj", "mlp_fc1": "mlp.fc1",
+              "mlp_fc2": "mlp.fc2"}
+    norms = {"norm1": "norm1", "norm2": "norm2", "q_norm": "attn.q_norm",
+             "k_norm": "attn.k_norm"}
+    if suffix in norms:
+        state[source + norms[suffix] + ".weight"] = weights[0]
+        state[source + norms[suffix] + ".bias"] = weights[1]
+    elif suffix in linear:
+        state[source + linear[suffix] + ".weight"] = weights[0].T
+        state[source + linear[suffix] + ".bias"] = weights[1]
+    elif suffix in ("ls1", "ls2"):
+        state[source + suffix + ".gamma"] = weights[0]
+
+
+def test_converter_reproduces_source_backbone():
+    source = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
+    state = build_backbone_state_dict(source)
+    target = build_da3_small_backbone(VIEWS, IMAGE_SHAPE)
+    num_positions = grid_shape(IMAGE_SHAPE, 14)
+    num_positions = num_positions[0] * num_positions[1] + 1
+    port_backbone_weights(target, state, DEPTH, num_positions, HIDDEN)
+    data = make_input()
+    expected = np.array(source(data)[0])
+    assert np.allclose(np.array(target(data)[0]), expected, atol=1e-5)

--- a/paz/models/foundation/depth_anything3/parity_test.py
+++ b/paz/models/foundation/depth_anything3/parity_test.py
@@ -1,6 +1,6 @@
 """Optional bit-parity check against the official DA3 reference.
 
-Runs only when DA3_REFERENCE is set and the reference package and Apache-2.0
+Runs only when DA3_REFERENCE is set and the reference package and the
 checkpoints are importable. It ports the real checkpoints into the Keras
 models and compares depth, cameras, and rays.
 """

--- a/paz/models/foundation/depth_anything3/parity_test.py
+++ b/paz/models/foundation/depth_anything3/parity_test.py
@@ -74,6 +74,27 @@ def test_da3_base_matches_reference():
     check_da3_reference("DA3-BASE", build_da3_base, 768)
 
 
+@pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
+def test_da3_mono_large_matches_reference():
+    import torch
+    from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+    from paz.models.foundation.depth_anything3 import port_weights
+    net, state = load_reference_backbone("DA3MONO-LARGE")
+    height, width = 154, 154
+    image = np.random.RandomState(8).randn(1, 1, 3, height, width).astype("float32")
+    with torch.no_grad():
+        feats, _ = net.backbone(torch.from_numpy(image))
+        head = net.head(feats, height, width, patch_start_idx=0)
+    model = build_da3_mono_large((height, width, 3))
+    positions = (height // 14) ** 2 + 1
+    port_weights.port_backbone_weights(model, state, 24, positions, 1024,
+                                       use_camera=False, use_qk_norm=False)
+    port_weights.port_dpt_head_weights(model, state)
+    depth, sky = model(np.transpose(image[:, 0], (0, 2, 3, 1)))
+    assert np.allclose(np.array(depth), head["depth"].numpy(), atol=1e-3)
+    assert np.allclose(np.array(sky), head["sky"].numpy(), atol=1e-3)
+
+
 def check_da3_reference(model_name, builder, hidden_size):
     import torch
     from depth_anything_3.model.utils.transform import pose_encoding_to_extri_intri

--- a/paz/models/foundation/depth_anything3/parity_test.py
+++ b/paz/models/foundation/depth_anything3/parity_test.py
@@ -1,8 +1,8 @@
-"""Optional bit-parity check against the official DA3-SMALL reference.
+"""Optional bit-parity check against the official DA3 reference.
 
 Runs only when DA3_REFERENCE is set and the reference package and Apache-2.0
-checkpoint are importable. It ports the real checkpoint into the Keras
-backbone and compares every collected feature and camera token.
+checkpoints are importable. It ports the real checkpoints into the Keras
+models and compares depth, cameras, and rays.
 """
 import os
 import glob
@@ -17,16 +17,17 @@ REFERENCE = os.environ.get("DA3_REFERENCE")
 def load_reference_backbone(model_name="DA3-SMALL"):
     from depth_anything_3.cfg import import_item
     from safetensors.torch import load_file
-    pattern = os.path.expanduser("~/.cache/huggingface/hub/"
-                                 f"models--depth-anything--{model_name}/snapshots/*")
+    base = os.path.expanduser("~/.cache/huggingface/hub")
+    pattern = f"{base}/models--depth-anything--{model_name}/snapshots/*"
     snapshots = glob.glob(pattern)
     if not snapshots:
         pytest.skip(f"{model_name} checkpoint not cached")
-    config = json.load(open(os.path.join(snapshots[0], "config.json")))["config"]
+    config_path = os.path.join(snapshots[0], "config.json")
+    config = json.load(open(config_path))["config"]
     net = build_object(config, import_item).eval()
-    state = load_file(os.path.join(snapshots[0], "model.safetensors"))
-    net.load_state_dict({k[6:]: v for k, v in state.items()}, strict=False)
-    return net, {k: v.numpy() for k, v in state.items()}
+    weights = load_file(os.path.join(snapshots[0], "model.safetensors"))
+    net.load_state_dict({k[6:]: v for k, v in weights.items()}, strict=False)
+    return net, {k: v.numpy() for k, v in weights.items()}
 
 
 def build_object(node, import_item):
@@ -42,18 +43,19 @@ def build_object(node, import_item):
 @pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
 def test_backbone_matches_reference():
     import torch
-    from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
-    from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
+    from paz.models.foundation.depth_anything3 import build_da3_small_backbone
+    from paz.models.foundation.depth_anything3 import port_weights
     net, state = load_reference_backbone()
     views, size = 2, 518
-    image = np.random.RandomState(0).randn(1, views, 3, size, size).astype("float32")
+    shape = 1, views, 3, size, size
+    image = np.random.RandomState(0).randn(*shape).astype("float32")
     with torch.no_grad():
         features = net.backbone(torch.from_numpy(image))[0]
     reference_features = [tensor[0].numpy() for tensor in features]
     reference_cameras = [tensor[1].numpy() for tensor in features]
 
     model = build_da3_small_backbone(views, (size, size, 3))
-    port_backbone_weights(model, state, 12, 1370, 384)
+    port_weights.port_backbone_weights(model, state, 12, 1370, 384)
     outputs = model(np.transpose(image, (0, 1, 3, 4, 2)))
     for index in range(4):
         assert np.allclose(np.array(outputs[index]),
@@ -64,31 +66,33 @@ def test_backbone_matches_reference():
 
 @pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
 def test_da3_small_matches_reference():
-    from paz.models.foundation.depth_anything3.models import build_da3_small
-    check_da3_reference("DA3-SMALL", build_da3_small, 384)
+    from paz.models import DepthAnything3Small
+    check_da3_reference("DA3-SMALL", DepthAnything3Small, 384)
 
 
 @pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
 def test_da3_base_matches_reference():
-    from paz.models.foundation.depth_anything3.models import build_da3_base
-    check_da3_reference("DA3-BASE", build_da3_base, 768)
+    from paz.models import DepthAnything3Base
+    check_da3_reference("DA3-BASE", DepthAnything3Base, 768)
 
 
 @pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
 def test_da3_mono_large_matches_reference():
     import torch
-    from paz.models.foundation.depth_anything3.models import build_da3_mono_large
+    from paz.models import DepthAnything3MonoLarge
     from paz.models.foundation.depth_anything3 import port_weights
     net, state = load_reference_backbone("DA3MONO-LARGE")
     height, width = 154, 154
-    image = np.random.RandomState(8).randn(1, 1, 3, height, width).astype("float32")
+    shape = 1, 1, 3, height, width
+    image = np.random.RandomState(8).randn(*shape).astype("float32")
     with torch.no_grad():
         feats, _ = net.backbone(torch.from_numpy(image))
         head = net.head(feats, height, width, patch_start_idx=0)
-    model = build_da3_mono_large((height, width, 3))
+    model = DepthAnything3MonoLarge((height, width, 3))
     positions = (height // 14) ** 2 + 1
-    port_weights.port_backbone_weights(model, state, 24, positions, 1024,
-                                       use_camera=False, use_qk_norm=False)
+    args = model, state, 24, positions, 1024
+    port_weights.port_backbone_weights(*args, use_camera=False,
+                                       use_qk_norm=False)
     port_weights.port_dpt_head_weights(model, state)
     depth, sky = model(np.transpose(image[:, 0], (0, 2, 3, 1)))
     assert np.allclose(np.array(depth), head["depth"].numpy(), atol=1e-3)
@@ -97,19 +101,20 @@ def test_da3_mono_large_matches_reference():
 
 def check_da3_reference(model_name, builder, hidden_size):
     import torch
-    from depth_anything_3.model.utils.transform import pose_encoding_to_extri_intri
+    from depth_anything_3.model.utils import transform
     from depth_anything_3.utils.geometry import affine_inverse
     from paz.models.foundation.depth_anything3 import port_weights
     net, state = load_reference_backbone(model_name)
     views, height, width = 2, 154, 154
-    image = np.random.RandomState(5).randn(1, views, 3, height, width).astype("float32")
+    shape = 1, views, 3, height, width
+    image = np.random.RandomState(5).randn(*shape).astype("float32")
     with torch.no_grad():
         feats, _ = net.backbone(torch.from_numpy(image))
         head = net.head(feats, height, width, patch_start_idx=0)
-        camera_to_world, intrinsics = pose_encoding_to_extri_intri(
-            net.cam_dec(feats[-1][1]), (height, width))
-        extrinsics = affine_inverse(camera_to_world)
-
+        pose = net.cam_dec(feats[-1][1])
+        c2w, intrinsics = transform.pose_encoding_to_extri_intri(
+            pose, (height, width))
+        extrinsics = affine_inverse(c2w)
     model = builder(views, (height, width, 3))
     positions = (height // 14) * (width // 14) + 1
     port_weights.port_backbone_weights(model, state, 12, positions, hidden_size)

--- a/paz/models/foundation/depth_anything3/parity_test.py
+++ b/paz/models/foundation/depth_anything3/parity_test.py
@@ -1,0 +1,62 @@
+"""Optional bit-parity check against the official DA3-SMALL reference.
+
+Runs only when DA3_REFERENCE is set and the reference package and Apache-2.0
+checkpoint are importable. It ports the real checkpoint into the Keras
+backbone and compares every collected feature and camera token.
+"""
+import os
+import glob
+import json
+
+import numpy as np
+import pytest
+
+REFERENCE = os.environ.get("DA3_REFERENCE")
+
+
+def load_reference_backbone():
+    from depth_anything_3.cfg import import_item
+    from safetensors.torch import load_file
+    pattern = os.path.expanduser("~/.cache/huggingface/hub/"
+                                 "models--depth-anything--DA3-SMALL/snapshots/*")
+    snapshots = glob.glob(pattern)
+    if not snapshots:
+        pytest.skip("DA3-SMALL checkpoint not cached")
+    config = json.load(open(os.path.join(snapshots[0], "config.json")))["config"]
+    net = build_object(config, import_item).eval()
+    state = load_file(os.path.join(snapshots[0], "model.safetensors"))
+    net.load_state_dict({k[6:]: v for k, v in state.items()}, strict=False)
+    return net.backbone, {k: v.numpy() for k, v in state.items()}
+
+
+def build_object(node, import_item):
+    if isinstance(node, dict) and "__object__" in node:
+        specification = node["__object__"]
+        item = import_item(specification["path"], specification["name"])
+        arguments = {key: build_object(value, import_item)
+                     for key, value in node.items() if key != "__object__"}
+        return item(**arguments)
+    return node
+
+
+@pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
+def test_backbone_matches_reference():
+    import torch
+    from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
+    from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
+    backbone, state = load_reference_backbone()
+    views, size = 2, 518
+    image = np.random.RandomState(0).randn(1, views, 3, size, size).astype("float32")
+    with torch.no_grad():
+        features = backbone(torch.from_numpy(image))[0]
+    reference_features = [tensor[0].numpy() for tensor in features]
+    reference_cameras = [tensor[1].numpy() for tensor in features]
+
+    model = build_da3_small_backbone(views, (size, size, 3))
+    port_backbone_weights(model, state, 12, 1370, 384)
+    outputs = model(np.transpose(image, (0, 1, 3, 4, 2)))
+    for index in range(4):
+        assert np.allclose(np.array(outputs[index]),
+                           reference_features[index], atol=2e-3)
+        assert np.allclose(np.array(outputs[4 + index]),
+                           reference_cameras[index], atol=1e-3)

--- a/paz/models/foundation/depth_anything3/parity_test.py
+++ b/paz/models/foundation/depth_anything3/parity_test.py
@@ -14,14 +14,14 @@ import pytest
 REFERENCE = os.environ.get("DA3_REFERENCE")
 
 
-def load_reference_backbone():
+def load_reference_backbone(model_name="DA3-SMALL"):
     from depth_anything_3.cfg import import_item
     from safetensors.torch import load_file
     pattern = os.path.expanduser("~/.cache/huggingface/hub/"
-                                 "models--depth-anything--DA3-SMALL/snapshots/*")
+                                 f"models--depth-anything--{model_name}/snapshots/*")
     snapshots = glob.glob(pattern)
     if not snapshots:
-        pytest.skip("DA3-SMALL checkpoint not cached")
+        pytest.skip(f"{model_name} checkpoint not cached")
     config = json.load(open(os.path.join(snapshots[0], "config.json")))["config"]
     net = build_object(config, import_item).eval()
     state = load_file(os.path.join(snapshots[0], "model.safetensors"))
@@ -64,25 +64,34 @@ def test_backbone_matches_reference():
 
 @pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
 def test_da3_small_matches_reference():
+    from paz.models.foundation.depth_anything3.models import build_da3_small
+    check_da3_reference("DA3-SMALL", build_da3_small, 384)
+
+
+@pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
+def test_da3_base_matches_reference():
+    from paz.models.foundation.depth_anything3.models import build_da3_base
+    check_da3_reference("DA3-BASE", build_da3_base, 768)
+
+
+def check_da3_reference(model_name, builder, hidden_size):
     import torch
     from depth_anything_3.model.utils.transform import pose_encoding_to_extri_intri
     from depth_anything_3.utils.geometry import affine_inverse
-    from paz.models.foundation.depth_anything3.models import build_da3_small
     from paz.models.foundation.depth_anything3 import port_weights
-    net, state = load_reference_backbone()
+    net, state = load_reference_backbone(model_name)
     views, height, width = 2, 154, 154
     image = np.random.RandomState(5).randn(1, views, 3, height, width).astype("float32")
-    tensor = torch.from_numpy(image)
     with torch.no_grad():
-        feats, _ = net.backbone(tensor)
+        feats, _ = net.backbone(torch.from_numpy(image))
         head = net.head(feats, height, width, patch_start_idx=0)
         camera_to_world, intrinsics = pose_encoding_to_extri_intri(
             net.cam_dec(feats[-1][1]), (height, width))
         extrinsics = affine_inverse(camera_to_world)
 
-    model = build_da3_small(views, (height, width, 3))
+    model = builder(views, (height, width, 3))
     positions = (height // 14) * (width // 14) + 1
-    port_weights.port_backbone_weights(model, state, 12, positions, 384)
+    port_weights.port_backbone_weights(model, state, 12, positions, hidden_size)
     port_weights.port_head_weights(model, state)
     port_weights.port_camera_decoder_weights(model, state)
     outputs = model(np.transpose(image, (0, 1, 3, 4, 2)))

--- a/paz/models/foundation/depth_anything3/parity_test.py
+++ b/paz/models/foundation/depth_anything3/parity_test.py
@@ -26,7 +26,7 @@ def load_reference_backbone():
     net = build_object(config, import_item).eval()
     state = load_file(os.path.join(snapshots[0], "model.safetensors"))
     net.load_state_dict({k[6:]: v for k, v in state.items()}, strict=False)
-    return net.backbone, {k: v.numpy() for k, v in state.items()}
+    return net, {k: v.numpy() for k, v in state.items()}
 
 
 def build_object(node, import_item):
@@ -44,11 +44,11 @@ def test_backbone_matches_reference():
     import torch
     from paz.models.foundation.depth_anything3.models import build_da3_small_backbone
     from paz.models.foundation.depth_anything3.port_weights import port_backbone_weights
-    backbone, state = load_reference_backbone()
+    net, state = load_reference_backbone()
     views, size = 2, 518
     image = np.random.RandomState(0).randn(1, views, 3, size, size).astype("float32")
     with torch.no_grad():
-        features = backbone(torch.from_numpy(image))[0]
+        features = net.backbone(torch.from_numpy(image))[0]
     reference_features = [tensor[0].numpy() for tensor in features]
     reference_cameras = [tensor[1].numpy() for tensor in features]
 
@@ -60,3 +60,33 @@ def test_backbone_matches_reference():
                            reference_features[index], atol=2e-3)
         assert np.allclose(np.array(outputs[4 + index]),
                            reference_cameras[index], atol=1e-3)
+
+
+@pytest.mark.skipif(not REFERENCE, reason="set DA3_REFERENCE to run")
+def test_da3_small_matches_reference():
+    import torch
+    from depth_anything_3.model.utils.transform import pose_encoding_to_extri_intri
+    from depth_anything_3.utils.geometry import affine_inverse
+    from paz.models.foundation.depth_anything3.models import build_da3_small
+    from paz.models.foundation.depth_anything3 import port_weights
+    net, state = load_reference_backbone()
+    views, height, width = 2, 154, 154
+    image = np.random.RandomState(5).randn(1, views, 3, height, width).astype("float32")
+    tensor = torch.from_numpy(image)
+    with torch.no_grad():
+        feats, _ = net.backbone(tensor)
+        head = net.head(feats, height, width, patch_start_idx=0)
+        camera_to_world, intrinsics = pose_encoding_to_extri_intri(
+            net.cam_dec(feats[-1][1]), (height, width))
+        extrinsics = affine_inverse(camera_to_world)
+
+    model = build_da3_small(views, (height, width, 3))
+    positions = (height // 14) * (width // 14) + 1
+    port_weights.port_backbone_weights(model, state, 12, positions, 384)
+    port_weights.port_head_weights(model, state)
+    port_weights.port_camera_decoder_weights(model, state)
+    outputs = model(np.transpose(image, (0, 1, 3, 4, 2)))
+    assert np.allclose(np.array(outputs[0]), head["depth"].numpy(), atol=1e-3)
+    assert np.allclose(np.array(outputs[2]), extrinsics.numpy(), atol=1e-3)
+    assert np.allclose(np.array(outputs[3]), intrinsics.numpy(), atol=1e-1)
+    assert np.allclose(np.array(outputs[4]), head["ray"].numpy(), atol=1e-3)

--- a/paz/models/foundation/depth_anything3/port_weights.py
+++ b/paz/models/foundation/depth_anything3/port_weights.py
@@ -22,6 +22,81 @@ def port_backbone_weights(model, state_dict, depth, num_positions,
     return model
 
 
+def port_head_weights(model, state_dict):
+    state_dict = strip_model_prefix(state_dict)
+    assign(model, "head_norm", named_norm(state_dict, "head.norm"))
+    for stage in range(4):
+        assign(model, f"head_project_{stage}",
+               conv_bias(state_dict, f"head.projects.{stage}"))
+    for stage in (0, 1, 3):
+        assign(model, f"head_resize_{stage}",
+               conv_bias(state_dict, f"head.resize_layers.{stage}"))
+    for stage in range(1, 5):
+        assign(model, f"head_layer{stage}_rn",
+               [conv_kernel(state_dict, f"head.scratch.layer{stage}_rn")])
+    for suffix in ("", "_aux"):
+        port_refinenets(model, state_dict, suffix)
+    assign(model, "head_out1", conv_bias(state_dict, "head.scratch.output_conv1"))
+    assign(model, "head_out2_conv0", conv_bias(state_dict, "head.scratch.output_conv2.0"))
+    assign(model, "head_out2_conv1", conv_bias(state_dict, "head.scratch.output_conv2.2"))
+    for index in range(5):
+        assign(model, f"head_out1_aux_{index}",
+               conv_bias(state_dict, f"head.scratch.output_conv1_aux.3.{index}"))
+    assign(model, "head_out2_aux_conv0",
+           conv_bias(state_dict, "head.scratch.output_conv2_aux.3.0"))
+    assign(model, "head_out2_aux_ln",
+           named_norm(state_dict, "head.scratch.output_conv2_aux.0.2"))
+    assign(model, "head_out2_aux_conv1",
+           conv_bias(state_dict, "head.scratch.output_conv2_aux.3.5"))
+    return model
+
+
+def port_refinenets(model, state_dict, suffix):
+    for index in (1, 2, 3):
+        source = f"head.scratch.refinenet{index}{suffix}.resConfUnit1"
+        assign(model, f"head_refine{index}{suffix}_unit1_conv1",
+               conv_bias(state_dict, source + ".conv1"))
+        assign(model, f"head_refine{index}{suffix}_unit1_conv2",
+               conv_bias(state_dict, source + ".conv2"))
+    for index in (1, 2, 3, 4):
+        block = f"head.scratch.refinenet{index}{suffix}"
+        assign(model, f"head_refine{index}{suffix}_unit2_conv1",
+               conv_bias(state_dict, block + ".resConfUnit2.conv1"))
+        assign(model, f"head_refine{index}{suffix}_unit2_conv2",
+               conv_bias(state_dict, block + ".resConfUnit2.conv2"))
+        assign(model, f"head_refine{index}{suffix}_out",
+               conv_bias(state_dict, block + ".out_conv"))
+
+
+def port_camera_decoder_weights(model, state_dict):
+    state_dict = strip_model_prefix(state_dict)
+    assign(model, "cam_dec_fc1", named_dense(state_dict, "cam_dec.backbone.0"))
+    assign(model, "cam_dec_fc2", named_dense(state_dict, "cam_dec.backbone.2"))
+    assign(model, "cam_dec_t", named_dense(state_dict, "cam_dec.fc_t"))
+    assign(model, "cam_dec_qvec", named_dense(state_dict, "cam_dec.fc_qvec"))
+    assign(model, "cam_dec_fov", named_dense(state_dict, "cam_dec.fc_fov.0"))
+    return model
+
+
+def conv_bias(state_dict, source):
+    return [conv_kernel(state_dict, source),
+            np.asarray(state_dict[source + ".bias"])]
+
+
+def conv_kernel(state_dict, source):
+    return np.transpose(np.asarray(state_dict[source + ".weight"]), (2, 3, 1, 0))
+
+
+def named_dense(state_dict, source):
+    return [np.asarray(state_dict[source + ".weight"]).T,
+            np.asarray(state_dict[source + ".bias"])]
+
+
+def named_norm(state_dict, source):
+    return [np.asarray(state_dict[source + ".weight"]),
+            np.asarray(state_dict[source + ".bias"])]
+
+
 def assign_block(model, state_dict, index):
     source = f"blocks.{index}."
     name = f"block_{index}"

--- a/paz/models/foundation/depth_anything3/port_weights.py
+++ b/paz/models/foundation/depth_anything3/port_weights.py
@@ -1,8 +1,8 @@
 """Development-only converter from the official DA3 checkpoint to Keras.
 
 Torch, numpy, and safetensors are imported lazily; nothing here runs at
-model call time. Covers the backbone; head and camera converters are added
-with their modules.
+model call time. Covers the backbone, the DualDPT head, the standard DPT
+head, and the camera decoder.
 """
 import numpy as np
 
@@ -14,10 +14,11 @@ def port_backbone_weights(model, state_dict, depth, num_positions,
     state_dict = strip_model_prefix(state_dict)
     assign(model, "patch_embed_proj", patch_embedding(state_dict))
     assign(model, "cls_token", [reshape(state_dict, "cls_token", hidden_size)])
-    assign(model, "pos_embed", [positions(state_dict, num_positions, hidden_size)])
+    pos = positions(state_dict, num_positions, hidden_size)
+    assign(model, "pos_embed", [pos])
     if use_camera:
-        assign(model, "camera_token",
-               [take(state_dict, "camera_token").reshape(2, hidden_size)])
+        camera = take(state_dict, "camera_token").reshape(2, hidden_size)
+        assign(model, "camera_token", [camera])
     assign(model, "norm", norm(state_dict, "norm"))
     for index in range(depth):
         assign_block(model, state_dict, index, use_qk_norm)
@@ -26,51 +27,50 @@ def port_backbone_weights(model, state_dict, depth, num_positions,
 
 def port_dpt_head_weights(model, state_dict):
     state_dict = strip_model_prefix(state_dict)
-    for stage in range(4):
-        assign(model, f"head_project_{stage}",
-               conv_bias(state_dict, f"head.projects.{stage}"))
-    for stage in (0, 1, 3):
-        assign(model, f"head_resize_{stage}",
-               conv_bias(state_dict, f"head.resize_layers.{stage}"))
-    for stage in range(1, 5):
-        assign(model, f"head_layer{stage}_rn",
-               [conv_kernel(state_dict, f"head.scratch.layer{stage}_rn")])
+    port_projections(model, state_dict)
     port_refinenets(model, state_dict, "")
-    assign(model, "head_out1", conv_bias(state_dict, "head.scratch.output_conv1"))
-    assign(model, "head_out2_conv0", conv_bias(state_dict, "head.scratch.output_conv2.0"))
-    assign(model, "head_out2_conv1", conv_bias(state_dict, "head.scratch.output_conv2.2"))
-    assign(model, "head_sky_conv0", conv_bias(state_dict, "head.scratch.sky_output_conv2.0"))
-    assign(model, "head_sky_conv1", conv_bias(state_dict, "head.scratch.sky_output_conv2.2"))
+    head_conv(model, state_dict, "head_out1", "output_conv1")
+    head_conv(model, state_dict, "head_out2_conv0", "output_conv2.0")
+    head_conv(model, state_dict, "head_out2_conv1", "output_conv2.2")
+    head_conv(model, state_dict, "head_sky_conv0", "sky_output_conv2.0")
+    head_conv(model, state_dict, "head_sky_conv1", "sky_output_conv2.2")
     return model
 
 
 def port_head_weights(model, state_dict):
     state_dict = strip_model_prefix(state_dict)
     assign(model, "head_norm", named_norm(state_dict, "head.norm"))
-    for stage in range(4):
-        assign(model, f"head_project_{stage}",
-               conv_bias(state_dict, f"head.projects.{stage}"))
-    for stage in (0, 1, 3):
-        assign(model, f"head_resize_{stage}",
-               conv_bias(state_dict, f"head.resize_layers.{stage}"))
-    for stage in range(1, 5):
-        assign(model, f"head_layer{stage}_rn",
-               [conv_kernel(state_dict, f"head.scratch.layer{stage}_rn")])
+    port_projections(model, state_dict)
     for suffix in ("", "_aux"):
         port_refinenets(model, state_dict, suffix)
-    assign(model, "head_out1", conv_bias(state_dict, "head.scratch.output_conv1"))
-    assign(model, "head_out2_conv0", conv_bias(state_dict, "head.scratch.output_conv2.0"))
-    assign(model, "head_out2_conv1", conv_bias(state_dict, "head.scratch.output_conv2.2"))
-    for index in range(5):
-        assign(model, f"head_out1_aux_{index}",
-               conv_bias(state_dict, f"head.scratch.output_conv1_aux.3.{index}"))
-    assign(model, "head_out2_aux_conv0",
-           conv_bias(state_dict, "head.scratch.output_conv2_aux.3.0"))
-    assign(model, "head_out2_aux_ln",
-           named_norm(state_dict, "head.scratch.output_conv2_aux.0.2"))
-    assign(model, "head_out2_aux_conv1",
-           conv_bias(state_dict, "head.scratch.output_conv2_aux.3.5"))
+    head_conv(model, state_dict, "head_out1", "output_conv1")
+    head_conv(model, state_dict, "head_out2_conv0", "output_conv2.0")
+    head_conv(model, state_dict, "head_out2_conv1", "output_conv2.2")
+    port_aux_outputs(model, state_dict)
     return model
+
+
+def port_projections(model, state_dict):
+    for stage in range(4):
+        source = f"head.projects.{stage}"
+        assign(model, f"head_project_{stage}", conv_bias(state_dict, source))
+    for stage in (0, 1, 3):
+        source = f"head.resize_layers.{stage}"
+        assign(model, f"head_resize_{stage}", conv_bias(state_dict, source))
+    for stage in range(1, 5):
+        source = f"head.scratch.layer{stage}_rn"
+        kernel = [conv_kernel(state_dict, source)]
+        assign(model, f"head_layer{stage}_rn", kernel)
+
+
+def port_aux_outputs(model, state_dict):
+    for index in range(5):
+        source = f"head.scratch.output_conv1_aux.3.{index}"
+        assign(model, f"head_out1_aux_{index}", conv_bias(state_dict, source))
+    head_conv(model, state_dict, "head_out2_aux_conv0", "output_conv2_aux.3.0")
+    ln = named_norm(state_dict, "head.scratch.output_conv2_aux.0.2")
+    assign(model, "head_out2_aux_ln", ln)
+    head_conv(model, state_dict, "head_out2_aux_conv1", "output_conv2_aux.3.5")
 
 
 def port_refinenets(model, state_dict, suffix):
@@ -100,25 +100,6 @@ def port_camera_decoder_weights(model, state_dict):
     return model
 
 
-def conv_bias(state_dict, source):
-    return [conv_kernel(state_dict, source),
-            np.asarray(state_dict[source + ".bias"])]
-
-
-def conv_kernel(state_dict, source):
-    return np.transpose(np.asarray(state_dict[source + ".weight"]), (2, 3, 1, 0))
-
-
-def named_dense(state_dict, source):
-    return [np.asarray(state_dict[source + ".weight"]).T,
-            np.asarray(state_dict[source + ".bias"])]
-
-
-def named_norm(state_dict, source):
-    return [np.asarray(state_dict[source + ".weight"]),
-            np.asarray(state_dict[source + ".bias"])]
-
-
 def assign_block(model, state_dict, index, use_qk_norm=True):
     source = f"blocks.{index}."
     name = f"block_{index}"
@@ -131,8 +112,36 @@ def assign_block(model, state_dict, index, use_qk_norm=True):
     assign(model, f"{name}_ls1", [take(state_dict, source + "ls1.gamma")])
     assign(model, f"{name}_ls2", [take(state_dict, source + "ls2.gamma")])
     if use_qk_norm and index >= 4:
-        assign(model, f"{name}_q_norm", norm(state_dict, source + "attn.q_norm"))
-        assign(model, f"{name}_k_norm", norm(state_dict, source + "attn.k_norm"))
+        assign_qk_norm(model, state_dict, source, name)
+
+
+def assign_qk_norm(model, state_dict, source, name):
+    assign(model, f"{name}_q_norm", norm(state_dict, source + "attn.q_norm"))
+    assign(model, f"{name}_k_norm", norm(state_dict, source + "attn.k_norm"))
+
+
+def head_conv(model, state_dict, target, source):
+    assign(model, target, conv_bias(state_dict, "head.scratch." + source))
+
+
+def conv_bias(state_dict, source):
+    return [conv_kernel(state_dict, source),
+            np.asarray(state_dict[source + ".bias"])]
+
+
+def conv_kernel(state_dict, source):
+    kernel = np.asarray(state_dict[source + ".weight"])
+    return np.transpose(kernel, (2, 3, 1, 0))
+
+
+def named_dense(state_dict, source):
+    return [np.asarray(state_dict[source + ".weight"]).T,
+            np.asarray(state_dict[source + ".bias"])]
+
+
+def named_norm(state_dict, source):
+    return [np.asarray(state_dict[source + ".weight"]),
+            np.asarray(state_dict[source + ".bias"])]
 
 
 def patch_embedding(state_dict):

--- a/paz/models/foundation/depth_anything3/port_weights.py
+++ b/paz/models/foundation/depth_anything3/port_weights.py
@@ -1,0 +1,99 @@
+"""Development-only converter from the official DA3 checkpoint to Keras.
+
+Torch, numpy, and safetensors are imported lazily; nothing here runs at
+model call time. Covers the backbone; head and camera converters are added
+with their modules.
+"""
+import numpy as np
+
+BACKBONE = "backbone.pretrained."
+
+
+def port_backbone_weights(model, state_dict, depth, num_positions,
+                          hidden_size):
+    state_dict = strip_model_prefix(state_dict)
+    assign(model, "patch_embed_proj", patch_embedding(state_dict))
+    assign(model, "cls_token", [reshape(state_dict, "cls_token", hidden_size)])
+    assign(model, "pos_embed", [positions(state_dict, num_positions, hidden_size)])
+    assign(model, "camera_token", [take(state_dict, "camera_token").reshape(2, hidden_size)])
+    assign(model, "norm", norm(state_dict, "norm"))
+    for index in range(depth):
+        assign_block(model, state_dict, index)
+    return model
+
+
+def assign_block(model, state_dict, index):
+    source = f"blocks.{index}."
+    name = f"block_{index}"
+    assign(model, f"{name}_norm1", norm(state_dict, source + "norm1"))
+    assign(model, f"{name}_norm2", norm(state_dict, source + "norm2"))
+    assign(model, f"{name}_qkv", dense(state_dict, source + "attn.qkv"))
+    assign(model, f"{name}_proj", dense(state_dict, source + "attn.proj"))
+    assign(model, f"{name}_mlp_fc1", dense(state_dict, source + "mlp.fc1"))
+    assign(model, f"{name}_mlp_fc2", dense(state_dict, source + "mlp.fc2"))
+    assign(model, f"{name}_ls1", [take(state_dict, source + "ls1.gamma")])
+    assign(model, f"{name}_ls2", [take(state_dict, source + "ls2.gamma")])
+    if index >= 4:
+        assign(model, f"{name}_q_norm", norm(state_dict, source + "attn.q_norm"))
+        assign(model, f"{name}_k_norm", norm(state_dict, source + "attn.k_norm"))
+
+
+def patch_embedding(state_dict):
+    kernel = take(state_dict, "patch_embed.proj.weight")
+    bias = take(state_dict, "patch_embed.proj.bias")
+    return [np.transpose(kernel, (2, 3, 1, 0)), bias]
+
+
+def positions(state_dict, num_positions, hidden_size):
+    source = take(state_dict, "pos_embed").reshape(-1, hidden_size)
+    if source.shape[0] == num_positions:
+        return source
+    return interpolate_positions(source, num_positions, hidden_size)
+
+
+def dense(state_dict, source):
+    return [take(state_dict, source + ".weight").T,
+            take(state_dict, source + ".bias")]
+
+
+def norm(state_dict, source):
+    return [take(state_dict, source + ".weight"),
+            take(state_dict, source + ".bias")]
+
+
+def reshape(state_dict, key, hidden_size):
+    return take(state_dict, key).reshape(1, hidden_size)
+
+
+def take(state_dict, key):
+    return np.asarray(state_dict[BACKBONE + key])
+
+
+def assign(model, name, arrays):
+    layer = model.get_layer(name)
+    current = [weight.shape for weight in layer.get_weights()]
+    target = [tuple(array.shape) for array in arrays]
+    if current != target:
+        raise ValueError(f"{name} shape {target} does not fit {current}")
+    layer.set_weights(arrays)
+
+
+def strip_model_prefix(state_dict):
+    if any(key.startswith("model.") for key in state_dict):
+        return {key[len("model."):]: value for key, value in state_dict.items()}
+    return state_dict
+
+
+def interpolate_positions(source, num_positions, hidden_size):
+    import torch
+    import torch.nn.functional as functional
+    class_position, patch_positions = source[:1], source[1:]
+    source_grid = int(round(np.sqrt(patch_positions.shape[0])))
+    target_grid = int(round(np.sqrt(num_positions - 1)))
+    grid = patch_positions.reshape(1, source_grid, source_grid, hidden_size)
+    grid = torch.from_numpy(grid).permute(0, 3, 1, 2)
+    scale = (target_grid + 0.1) / source_grid
+    grid = functional.interpolate(grid, scale_factor=(scale, scale),
+                                  mode="bicubic", antialias=False)
+    grid = grid.permute(0, 2, 3, 1).reshape(-1, hidden_size).numpy()
+    return np.concatenate([class_position, grid], axis=0)

--- a/paz/models/foundation/depth_anything3/port_weights.py
+++ b/paz/models/foundation/depth_anything3/port_weights.py
@@ -10,15 +10,37 @@ BACKBONE = "backbone.pretrained."
 
 
 def port_backbone_weights(model, state_dict, depth, num_positions,
-                          hidden_size):
+                          hidden_size, use_camera=True, use_qk_norm=True):
     state_dict = strip_model_prefix(state_dict)
     assign(model, "patch_embed_proj", patch_embedding(state_dict))
     assign(model, "cls_token", [reshape(state_dict, "cls_token", hidden_size)])
     assign(model, "pos_embed", [positions(state_dict, num_positions, hidden_size)])
-    assign(model, "camera_token", [take(state_dict, "camera_token").reshape(2, hidden_size)])
+    if use_camera:
+        assign(model, "camera_token",
+               [take(state_dict, "camera_token").reshape(2, hidden_size)])
     assign(model, "norm", norm(state_dict, "norm"))
     for index in range(depth):
-        assign_block(model, state_dict, index)
+        assign_block(model, state_dict, index, use_qk_norm)
+    return model
+
+
+def port_dpt_head_weights(model, state_dict):
+    state_dict = strip_model_prefix(state_dict)
+    for stage in range(4):
+        assign(model, f"head_project_{stage}",
+               conv_bias(state_dict, f"head.projects.{stage}"))
+    for stage in (0, 1, 3):
+        assign(model, f"head_resize_{stage}",
+               conv_bias(state_dict, f"head.resize_layers.{stage}"))
+    for stage in range(1, 5):
+        assign(model, f"head_layer{stage}_rn",
+               [conv_kernel(state_dict, f"head.scratch.layer{stage}_rn")])
+    port_refinenets(model, state_dict, "")
+    assign(model, "head_out1", conv_bias(state_dict, "head.scratch.output_conv1"))
+    assign(model, "head_out2_conv0", conv_bias(state_dict, "head.scratch.output_conv2.0"))
+    assign(model, "head_out2_conv1", conv_bias(state_dict, "head.scratch.output_conv2.2"))
+    assign(model, "head_sky_conv0", conv_bias(state_dict, "head.scratch.sky_output_conv2.0"))
+    assign(model, "head_sky_conv1", conv_bias(state_dict, "head.scratch.sky_output_conv2.2"))
     return model
 
 
@@ -97,7 +119,7 @@ def named_norm(state_dict, source):
             np.asarray(state_dict[source + ".bias"])]
 
 
-def assign_block(model, state_dict, index):
+def assign_block(model, state_dict, index, use_qk_norm=True):
     source = f"blocks.{index}."
     name = f"block_{index}"
     assign(model, f"{name}_norm1", norm(state_dict, source + "norm1"))
@@ -108,7 +130,7 @@ def assign_block(model, state_dict, index):
     assign(model, f"{name}_mlp_fc2", dense(state_dict, source + "mlp.fc2"))
     assign(model, f"{name}_ls1", [take(state_dict, source + "ls1.gamma")])
     assign(model, f"{name}_ls2", [take(state_dict, source + "ls2.gamma")])
-    if index >= 4:
+    if use_qk_norm and index >= 4:
         assign(model, f"{name}_q_norm", norm(state_dict, source + "attn.q_norm"))
         assign(model, f"{name}_k_norm", norm(state_dict, source + "attn.k_norm"))
 

--- a/paz/models/foundation/depth_anything3/routing.py
+++ b/paz/models/foundation/depth_anything3/routing.py
@@ -4,57 +4,53 @@ Tokens carry an explicit view axis as ``(batch, views, tokens, channels)``.
 Local blocks fold views into the batch so each view attends to itself; global
 blocks merge views into one sequence so all views attend jointly.
 """
-import numpy as np
+import jax.numpy as jp
 from keras import ops
 
 
 def fold_view_images(images):
-    height, width, channels = images.shape[-3:]
+    batch, views, height, width, channels = images.shape
     return ops.reshape(images, (-1, height, width, channels))
 
 
 def fold_views_into_batch(tokens):
-    channels = tokens.shape[-1]
-    num_tokens = tokens.shape[-2]
+    batch, views, num_tokens, channels = tokens.shape
     return ops.reshape(tokens, (-1, num_tokens, channels))
 
 
 def restore_view_dimension(tokens, num_views):
-    channels = tokens.shape[-1]
-    num_tokens = tokens.shape[-2]
+    batch, num_tokens, channels = tokens.shape
     return ops.reshape(tokens, (-1, num_views, num_tokens, channels))
 
 
 def merge_views_into_sequence(tokens):
-    channels = tokens.shape[-1]
-    num_views = tokens.shape[-3]
-    num_tokens = tokens.shape[-2]
+    batch, num_views, num_tokens, channels = tokens.shape
     return ops.reshape(tokens, (-1, num_views * num_tokens, channels))
 
 
 def split_sequence_into_views(tokens, num_views):
-    channels = tokens.shape[-1]
-    num_tokens = tokens.shape[-2] // num_views
+    batch, sequence, channels = tokens.shape
+    num_tokens = sequence // num_views
     return ops.reshape(tokens, (-1, num_views, num_tokens, channels))
 
 
 def build_local_positions(grid_height, grid_width):
     grid = build_grid_positions(grid_height, grid_width) + 1
-    special = np.zeros((1, 2), "int32")
-    positions = np.concatenate([special, grid], axis=0)
-    return ops.array(positions[None])
+    special = jp.zeros((1, 2), "int32")
+    positions = jp.concatenate([special, grid], axis=0)
+    return positions[None]
 
 
 def build_global_positions(num_views, grid_height, grid_width):
     num_patches = grid_height * grid_width
-    special = np.zeros((1, 2), "int32")
-    patches = np.ones((num_patches, 2), "int32")
-    per_view = np.concatenate([special, patches], axis=0)
-    positions = np.tile(per_view, (num_views, 1))
-    return ops.array(positions[None])
+    special = jp.zeros((1, 2), "int32")
+    patches = jp.ones((num_patches, 2), "int32")
+    per_view = jp.concatenate([special, patches], axis=0)
+    positions = jp.tile(per_view, (num_views, 1))
+    return positions[None]
 
 
 def build_grid_positions(grid_height, grid_width):
-    rows = np.repeat(np.arange(grid_height), grid_width)
-    columns = np.tile(np.arange(grid_width), grid_height)
-    return np.stack([rows, columns], axis=-1).astype("int32")
+    rows = jp.repeat(jp.arange(grid_height), grid_width)
+    columns = jp.tile(jp.arange(grid_width), grid_height)
+    return jp.stack([rows, columns], axis=-1).astype("int32")

--- a/paz/models/foundation/depth_anything3/routing.py
+++ b/paz/models/foundation/depth_anything3/routing.py
@@ -1,0 +1,60 @@
+"""View routing between per-view (local) and cross-view (global) layouts.
+
+Tokens carry an explicit view axis as ``(batch, views, tokens, channels)``.
+Local blocks fold views into the batch so each view attends to itself; global
+blocks merge views into one sequence so all views attend jointly.
+"""
+import numpy as np
+from keras import ops
+
+
+def fold_view_images(images):
+    height, width, channels = images.shape[-3:]
+    return ops.reshape(images, (-1, height, width, channels))
+
+
+def fold_views_into_batch(tokens):
+    channels = tokens.shape[-1]
+    num_tokens = tokens.shape[-2]
+    return ops.reshape(tokens, (-1, num_tokens, channels))
+
+
+def restore_view_dimension(tokens, num_views):
+    channels = tokens.shape[-1]
+    num_tokens = tokens.shape[-2]
+    return ops.reshape(tokens, (-1, num_views, num_tokens, channels))
+
+
+def merge_views_into_sequence(tokens):
+    channels = tokens.shape[-1]
+    num_views = tokens.shape[-3]
+    num_tokens = tokens.shape[-2]
+    return ops.reshape(tokens, (-1, num_views * num_tokens, channels))
+
+
+def split_sequence_into_views(tokens, num_views):
+    channels = tokens.shape[-1]
+    num_tokens = tokens.shape[-2] // num_views
+    return ops.reshape(tokens, (-1, num_views, num_tokens, channels))
+
+
+def build_local_positions(grid_height, grid_width):
+    grid = build_grid_positions(grid_height, grid_width) + 1
+    special = np.zeros((1, 2), "int32")
+    positions = np.concatenate([special, grid], axis=0)
+    return ops.array(positions[None])
+
+
+def build_global_positions(num_views, grid_height, grid_width):
+    num_patches = grid_height * grid_width
+    special = np.zeros((1, 2), "int32")
+    patches = np.ones((num_patches, 2), "int32")
+    per_view = np.concatenate([special, patches], axis=0)
+    positions = np.tile(per_view, (num_views, 1))
+    return ops.array(positions[None])
+
+
+def build_grid_positions(grid_height, grid_width):
+    rows = np.repeat(np.arange(grid_height), grid_width)
+    columns = np.tile(np.arange(grid_width), grid_height)
+    return np.stack([rows, columns], axis=-1).astype("int32")

--- a/paz/models/foundation/dinov2/__init__.py
+++ b/paz/models/foundation/dinov2/__init__.py
@@ -1,6 +1,11 @@
-"""Canonical function-only DINOv2 implementation.
+"""Canonical function-only DINOv2 built from reusable transformer primitives.
 
-Reserved for the new implementation built from reusable PAZ transformer
-primitives. The previous work lives in
-``paz.models.foundation.dinov2_legacy`` until the detector migrates.
+Standard models return ``(class_token, patch_tokens)``. Feature models return
+a plain tuple of channels-last feature maps in the requested layer order.
 """
+from paz.models.foundation.dinov2.models import DINOv2Small
+from paz.models.foundation.dinov2.models import DINOv2Base
+from paz.models.foundation.dinov2.models import DINOv2Large
+from paz.models.foundation.dinov2.models import DINOv2SmallFeatures
+from paz.models.foundation.dinov2.models import DINOv2BaseFeatures
+from paz.models.foundation.dinov2.models import DINOv2LargeFeatures

--- a/paz/models/foundation/dinov2/blocks.py
+++ b/paz/models/foundation/dinov2/blocks.py
@@ -1,0 +1,54 @@
+import keras
+from keras.layers import Add, Dense, EinsumDense, LayerNormalization
+
+from paz.models.transformers import attention, feedforward
+
+LAYER_NORM_EPSILON = 1e-6
+
+
+def build_dinov2_block(tokens, hidden_size, num_heads, mlp_ratio,
+                       layer_scale_init, name):
+    attended = apply_attention(tokens, hidden_size, num_heads, name)
+    scaled = apply_layer_scale(attended, hidden_size, layer_scale_init,
+                               f"{name}_ls1")
+    tokens = Add(name=f"{name}_add1")([tokens, scaled])
+    forwarded = apply_feedforward(tokens, hidden_size, mlp_ratio, name)
+    scaled = apply_layer_scale(forwarded, hidden_size, layer_scale_init,
+                               f"{name}_ls2")
+    return Add(name=f"{name}_add2")([tokens, scaled])
+
+
+def apply_attention(tokens, hidden_size, num_heads, name):
+    normed = normalize(tokens, f"{name}_norm1")
+    fused = attention.project_query_key_value(normed, hidden_size, True, name)
+    head_dim = hidden_size // num_heads
+    query, key, value = attention.split_query_key_value(fused, num_heads,
+                                                         head_dim)
+    context = attention.compute_attention(query, key, value)
+    merged = attention.merge_attention_heads(context)
+    return project_output(merged, hidden_size, f"{name}_proj")
+
+
+def apply_feedforward(tokens, hidden_size, mlp_ratio, name):
+    normed = normalize(tokens, f"{name}_norm2")
+    inner_size = int(hidden_size * mlp_ratio)
+    return feedforward.gelu(normed, inner_size, hidden_size,
+                            f"{name}_mlp_fc1", f"{name}_mlp_fc2")
+
+
+def project_output(tokens, hidden_size, name):
+    layer = Dense(hidden_size, use_bias=True,
+                  kernel_initializer=attention.kernel(), name=name)
+    return layer(tokens)
+
+
+def apply_layer_scale(tokens, hidden_size, init, name):
+    initializer = keras.initializers.Constant(init)
+    layer = EinsumDense("...d,d->...d", output_shape=(hidden_size,),
+                        bias_axes=None, kernel_initializer=initializer,
+                        name=name)
+    return layer(tokens)
+
+
+def normalize(tokens, name):
+    return LayerNormalization(epsilon=LAYER_NORM_EPSILON, name=name)(tokens)

--- a/paz/models/foundation/dinov2/blocks.py
+++ b/paz/models/foundation/dinov2/blocks.py
@@ -1,54 +1,55 @@
 import keras
 from keras.layers import Add, Dense, EinsumDense, LayerNormalization
 
-from paz.models.transformers import attention, feedforward
+from paz.models.transformers import feedforward
+from paz.models.transformers.attention import kernel
+from paz.models.transformers.attention import project_query_key_value
+from paz.models.transformers.attention import split_query_key_value
+from paz.models.transformers.attention import compute_attention
+from paz.models.transformers.attention import merge_attention_heads
 
-LAYER_NORM_EPSILON = 1e-6
 
-
-def build_dinov2_block(tokens, hidden_size, num_heads, mlp_ratio,
-                       layer_scale_init, name):
+def build(tokens, hidden_size, num_heads, MLP_ratio, scale_init, name):
     attended = apply_attention(tokens, hidden_size, num_heads, name)
-    scaled = apply_layer_scale(attended, hidden_size, layer_scale_init,
-                               f"{name}_ls1")
-    tokens = Add(name=f"{name}_add1")([tokens, scaled])
-    forwarded = apply_feedforward(tokens, hidden_size, mlp_ratio, name)
-    scaled = apply_layer_scale(forwarded, hidden_size, layer_scale_init,
-                               f"{name}_ls2")
-    return Add(name=f"{name}_add2")([tokens, scaled])
+    tokens = add_residual(tokens, attended, hidden_size, scale_init, name, 1)
+    forwarded = apply_feedforward(tokens, hidden_size, MLP_ratio, name)
+    return add_residual(tokens, forwarded, hidden_size, scale_init, name, 2)
+
+
+def add_residual(tokens, branch, hidden_size, scale_init, name, index):
+    scale_name = f"{name}_ls{index}"
+    scaled = apply_layer_scale(branch, hidden_size, scale_init, scale_name)
+    return Add(name=f"{name}_add{index}")([tokens, scaled])
 
 
 def apply_attention(tokens, hidden_size, num_heads, name):
     normed = normalize(tokens, f"{name}_norm1")
-    fused = attention.project_query_key_value(normed, hidden_size, True, name)
+    fused = project_query_key_value(normed, hidden_size, True, name)
     head_dim = hidden_size // num_heads
-    query, key, value = attention.split_query_key_value(fused, num_heads,
-                                                         head_dim)
-    context = attention.compute_attention(query, key, value)
-    merged = attention.merge_attention_heads(context)
+    query, key, value = split_query_key_value(fused, num_heads, head_dim)
+    context = compute_attention(query, key, value)
+    merged = merge_attention_heads(context)
     return project_output(merged, hidden_size, f"{name}_proj")
 
 
-def apply_feedforward(tokens, hidden_size, mlp_ratio, name):
+def apply_feedforward(tokens, hidden_size, MLP_ratio, name):
     normed = normalize(tokens, f"{name}_norm2")
-    inner_size = int(hidden_size * mlp_ratio)
-    return feedforward.gelu(normed, inner_size, hidden_size,
-                            f"{name}_mlp_fc1", f"{name}_mlp_fc2")
+    inner_size = int(hidden_size * MLP_ratio)
+    names = f"{name}_mlp_fc1", f"{name}_mlp_fc2"
+    return feedforward.gelu(normed, inner_size, hidden_size, *names)
 
 
 def project_output(tokens, hidden_size, name):
-    layer = Dense(hidden_size, use_bias=True,
-                  kernel_initializer=attention.kernel(), name=name)
-    return layer(tokens)
+    kwargs = dict(use_bias=True, kernel_initializer=kernel(), name=name)
+    return Dense(hidden_size, **kwargs)(tokens)
 
 
-def apply_layer_scale(tokens, hidden_size, init, name):
-    initializer = keras.initializers.Constant(init)
-    layer = EinsumDense("...d,d->...d", output_shape=(hidden_size,),
-                        bias_axes=None, kernel_initializer=initializer,
-                        name=name)
-    return layer(tokens)
+def apply_layer_scale(tokens, hidden_size, scale_init, name):
+    initializer = keras.initializers.Constant(scale_init)
+    kwargs = dict(output_shape=(hidden_size,), bias_axes=None, name=name)
+    kwargs["kernel_initializer"] = initializer
+    return EinsumDense("...d,d->...d", **kwargs)(tokens)
 
 
 def normalize(tokens, name):
-    return LayerNormalization(epsilon=LAYER_NORM_EPSILON, name=name)(tokens)
+    return LayerNormalization(epsilon=1e-6, name=name)(tokens)

--- a/paz/models/foundation/dinov2/blocks_test.py
+++ b/paz/models/foundation/dinov2/blocks_test.py
@@ -2,12 +2,12 @@ import numpy as np
 import jax
 from keras import Input, Model
 
-from paz.models.foundation.dinov2.blocks import build_dinov2_block
+from paz.models.foundation.dinov2 import blocks
 
 
 def build_block_model():
     tokens = Input((26, 384), name="tokens")
-    output = build_dinov2_block(tokens, 384, 6, 4.0, 1e-5, "block_0")
+    output = blocks.build(tokens, 384, 6, 4.0, 1e-5, "block_0")
     return Model(tokens, output)
 
 

--- a/paz/models/foundation/dinov2/blocks_test.py
+++ b/paz/models/foundation/dinov2/blocks_test.py
@@ -1,0 +1,25 @@
+import numpy as np
+import jax
+from keras import Input, Model
+
+from paz.models.foundation.dinov2.blocks import build_dinov2_block
+
+
+def build_block_model():
+    tokens = Input((26, 384), name="tokens")
+    output = build_dinov2_block(tokens, 384, 6, 4.0, 1e-5, "block_0")
+    return Model(tokens, output)
+
+
+def test_block_preserves_shape():
+    model = build_block_model()
+    output = model(np.zeros((2, 26, 384), "float32"))
+    assert tuple(output.shape) == (2, 26, 384)
+
+
+def test_block_jit_matches_eager():
+    model = build_block_model()
+    data = np.random.RandomState(0).randn(2, 26, 384).astype("float32")
+    eager = np.array(model(data))
+    jitted = np.array(jax.jit(lambda x: model(x))(data))
+    assert np.allclose(eager, jitted, atol=1e-5)

--- a/paz/models/foundation/dinov2/embeddings.py
+++ b/paz/models/foundation/dinov2/embeddings.py
@@ -1,50 +1,36 @@
 from keras import ops
-from keras.layers import Conv2D, Embedding, Lambda, Reshape
+from keras.layers import Conv2D, Reshape
 
-from paz.models.transformers.attention import kernel
-from paz.models.transformers.embeddings import absolute
+from paz.models.transformers.embeddings.token import LearnableTokens
 
 
-def build_dinov2_embeddings(images, patch_size, hidden_size, num_positions,
-                            num_register_tokens):
+def build(images, patch_size, hidden_size, num_positions, num_registers):
     patches = build_patch_tokens(images, patch_size, hidden_size)
     tokens = prepend_class_token(patches, hidden_size)
-    tokens = add_position_embedding(tokens, num_positions)
-    if num_register_tokens:
-        tokens = insert_register_tokens(tokens, num_register_tokens,
-                                        hidden_size)
+    tokens = add_position_embedding(tokens, num_positions, hidden_size)
+    if num_registers:
+        tokens = insert_register_tokens(tokens, num_registers, hidden_size)
     return tokens
 
 
 def build_patch_tokens(images, patch_size, hidden_size):
-    projection = Conv2D(hidden_size, patch_size, strides=patch_size,
-                        padding="valid", name="patch_embed_proj")
+    kwargs = dict(strides=patch_size, padding="valid", name="patch_embed_proj")
+    projection = Conv2D(hidden_size, patch_size, **kwargs)
     return Reshape((-1, hidden_size))(projection(images))
 
 
 def prepend_class_token(patches, hidden_size):
-    class_token = build_learnable_tokens(patches, 1, hidden_size, "cls_token")
+    class_token = LearnableTokens(1, hidden_size, name="cls_token")(patches)
     return ops.concatenate([class_token, patches], axis=1)
 
 
-def insert_register_tokens(tokens, num_register_tokens, hidden_size):
-    registers = build_learnable_tokens(tokens, num_register_tokens,
-                                        hidden_size, "register_tokens")
-    return ops.concatenate([tokens[:, :1], registers, tokens[:, 1:]], axis=1)
+def add_position_embedding(tokens, num_positions, hidden_size):
+    table = LearnableTokens(num_positions, hidden_size, name="pos_embed")
+    return tokens + table(tokens)
 
 
-def add_position_embedding(tokens, num_positions):
-    position = absolute.embed_position(tokens, num_positions, True, None,
-                                       "pos_embed")
-    return tokens + position
-
-
-def build_learnable_tokens(reference, count, hidden_size, name):
-    indices = build_token_indices(count, f"{name}_indices")(reference)
-    table = Embedding(count, hidden_size, kernel(), name=name)(indices)
-    return ops.zeros_like(reference[:, :count, :]) + table
-
-
-def build_token_indices(count, name):
-    select = lambda reference: ops.arange(count, dtype="int32")
-    return Lambda(select, output_shape=(count,), name=name)
+def insert_register_tokens(tokens, num_registers, hidden_size):
+    name = "register_tokens"
+    registers = LearnableTokens(num_registers, hidden_size, name=name)(tokens)
+    head, tail = tokens[:, :1], tokens[:, 1:]
+    return ops.concatenate([head, registers, tail], axis=1)

--- a/paz/models/foundation/dinov2/embeddings.py
+++ b/paz/models/foundation/dinov2/embeddings.py
@@ -1,0 +1,50 @@
+from keras import ops
+from keras.layers import Conv2D, Embedding, Lambda, Reshape
+
+from paz.models.transformers.attention import kernel
+from paz.models.transformers.embeddings import absolute
+
+
+def build_dinov2_embeddings(images, patch_size, hidden_size, num_positions,
+                            num_register_tokens):
+    patches = build_patch_tokens(images, patch_size, hidden_size)
+    tokens = prepend_class_token(patches, hidden_size)
+    tokens = add_position_embedding(tokens, num_positions)
+    if num_register_tokens:
+        tokens = insert_register_tokens(tokens, num_register_tokens,
+                                        hidden_size)
+    return tokens
+
+
+def build_patch_tokens(images, patch_size, hidden_size):
+    projection = Conv2D(hidden_size, patch_size, strides=patch_size,
+                        padding="valid", name="patch_embed_proj")
+    return Reshape((-1, hidden_size))(projection(images))
+
+
+def prepend_class_token(patches, hidden_size):
+    class_token = build_learnable_tokens(patches, 1, hidden_size, "cls_token")
+    return ops.concatenate([class_token, patches], axis=1)
+
+
+def insert_register_tokens(tokens, num_register_tokens, hidden_size):
+    registers = build_learnable_tokens(tokens, num_register_tokens,
+                                        hidden_size, "register_tokens")
+    return ops.concatenate([tokens[:, :1], registers, tokens[:, 1:]], axis=1)
+
+
+def add_position_embedding(tokens, num_positions):
+    position = absolute.embed_position(tokens, num_positions, True, None,
+                                       "pos_embed")
+    return tokens + position
+
+
+def build_learnable_tokens(reference, count, hidden_size, name):
+    indices = build_token_indices(count, f"{name}_indices")(reference)
+    table = Embedding(count, hidden_size, kernel(), name=name)(indices)
+    return ops.zeros_like(reference[:, :count, :]) + table
+
+
+def build_token_indices(count, name):
+    select = lambda reference: ops.arange(count, dtype="int32")
+    return Lambda(select, output_shape=(count,), name=name)

--- a/paz/models/foundation/dinov2/embeddings_test.py
+++ b/paz/models/foundation/dinov2/embeddings_test.py
@@ -1,19 +1,18 @@
 import numpy as np
 from keras import Input, Model
 
-from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
-from paz.models.foundation.dinov2.embeddings import build_patch_tokens
+from paz.models.foundation.dinov2 import embeddings
 
 
-def build_embedding_model(num_register_tokens):
+def build_embedding_model(num_registers):
     images = Input((70, 70, 3), name="pixels")
-    tokens = build_dinov2_embeddings(images, 14, 384, 26, num_register_tokens)
+    tokens = embeddings.build(images, 14, 384, 26, num_registers)
     return Model(images, tokens)
 
 
 def test_patch_tokens_shape():
     images = Input((70, 70, 3))
-    patches = build_patch_tokens(images, 14, 384)
+    patches = embeddings.build_patch_tokens(images, 14, 384)
     assert tuple(patches.shape) == (None, 25, 384)
 
 
@@ -29,7 +28,8 @@ def test_embeddings_insert_register_tokens():
     assert tuple(output.shape) == (2, 30, 384)
 
 
-def test_position_embedding_changes_tokens():
+def test_position_embedding_is_added():
     model = build_embedding_model(0)
+    model.get_layer("pos_embed").set_weights([np.ones((26, 384), "float32")])
     output = np.array(model(np.zeros((2, 70, 70, 3), "float32")))
-    assert np.any(output != 0.0)
+    assert np.allclose(output, 1.0)

--- a/paz/models/foundation/dinov2/embeddings_test.py
+++ b/paz/models/foundation/dinov2/embeddings_test.py
@@ -1,0 +1,35 @@
+import numpy as np
+from keras import Input, Model
+
+from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
+from paz.models.foundation.dinov2.embeddings import build_patch_tokens
+
+
+def build_embedding_model(num_register_tokens):
+    images = Input((70, 70, 3), name="pixels")
+    tokens = build_dinov2_embeddings(images, 14, 384, 26, num_register_tokens)
+    return Model(images, tokens)
+
+
+def test_patch_tokens_shape():
+    images = Input((70, 70, 3))
+    patches = build_patch_tokens(images, 14, 384)
+    assert tuple(patches.shape) == (None, 25, 384)
+
+
+def test_embeddings_add_class_token():
+    model = build_embedding_model(0)
+    output = model(np.zeros((2, 70, 70, 3), "float32"))
+    assert tuple(output.shape) == (2, 26, 384)
+
+
+def test_embeddings_insert_register_tokens():
+    model = build_embedding_model(4)
+    output = model(np.zeros((2, 70, 70, 3), "float32"))
+    assert tuple(output.shape) == (2, 30, 384)
+
+
+def test_position_embedding_changes_tokens():
+    model = build_embedding_model(0)
+    output = np.array(model(np.zeros((2, 70, 70, 3), "float32")))
+    assert np.any(output != 0.0)

--- a/paz/models/foundation/dinov2/encoder.py
+++ b/paz/models/foundation/dinov2/encoder.py
@@ -1,11 +1,10 @@
-from paz.models.foundation.dinov2.blocks import build_dinov2_block
+from paz.models.foundation.dinov2 import blocks
 
 
-def build_dinov2_encoder(tokens, hidden_size, depth, num_heads, mlp_ratio,
-                         layer_scale_init):
+def build(tokens, hidden_size, depth, num_heads, MLP_ratio, scale_init):
     hidden_states = []
-    for index in range(depth):
-        args = (hidden_size, num_heads, mlp_ratio, layer_scale_init)
-        tokens = build_dinov2_block(tokens, *args, f"block_{index}")
+    for arg in range(depth):
+        args = (hidden_size, num_heads, MLP_ratio, scale_init)
+        tokens = blocks.build(tokens, *args, f"block_{arg}")
         hidden_states.append(tokens)
     return tokens, tuple(hidden_states)

--- a/paz/models/foundation/dinov2/encoder.py
+++ b/paz/models/foundation/dinov2/encoder.py
@@ -1,0 +1,11 @@
+from paz.models.foundation.dinov2.blocks import build_dinov2_block
+
+
+def build_dinov2_encoder(tokens, hidden_size, depth, num_heads, mlp_ratio,
+                         layer_scale_init):
+    hidden_states = []
+    for index in range(depth):
+        args = (hidden_size, num_heads, mlp_ratio, layer_scale_init)
+        tokens = build_dinov2_block(tokens, *args, f"block_{index}")
+        hidden_states.append(tokens)
+    return tokens, tuple(hidden_states)

--- a/paz/models/foundation/dinov2/models.py
+++ b/paz/models/foundation/dinov2/models.py
@@ -1,0 +1,102 @@
+from keras import Input, Model
+from keras.layers import LayerNormalization, Reshape
+
+from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
+from paz.models.foundation.dinov2.encoder import build_dinov2_encoder
+
+PATCH_SIZE = 14
+MLP_RATIO = 4.0
+LAYER_SCALE_INIT = 1e-5
+LAYER_NORM_EPSILON = 1e-6
+DEFAULT_IMAGE_SHAPE = (518, 518, 3)
+DEFAULT_OUT_LAYERS = (5, 7, 9, 11)
+
+
+def build_dinov2(image_shape, patch_size, hidden_size, depth, num_heads,
+                 mlp_ratio, num_register_tokens, name):
+    images = Input(image_shape, name="pixels")
+    positions = count_positions(image_shape, patch_size)
+    tokens = build_dinov2_embeddings(images, patch_size, hidden_size,
+                                     positions, num_register_tokens)
+    args = (hidden_size, depth, num_heads, mlp_ratio, LAYER_SCALE_INIT)
+    tokens, _ = build_dinov2_encoder(tokens, *args)
+    normalized = normalize_tokens(tokens)
+    class_token = normalized[:, 0]
+    patch_tokens = normalized[:, 1 + num_register_tokens:]
+    return Model(images, (class_token, patch_tokens), name=name)
+
+
+def build_dinov2_features(image_shape, patch_size, hidden_size, depth,
+                          num_heads, mlp_ratio, num_register_tokens,
+                          out_layers, name):
+    images = Input(image_shape, name="pixels")
+    positions = count_positions(image_shape, patch_size)
+    tokens = build_dinov2_embeddings(images, patch_size, hidden_size,
+                                     positions, num_register_tokens)
+    args = (hidden_size, depth, num_heads, mlp_ratio, LAYER_SCALE_INIT)
+    _, hidden_states = build_dinov2_encoder(tokens, *args)
+    grid = grid_shape(image_shape, patch_size)
+    maps = select_feature_maps(hidden_states, out_layers,
+                               num_register_tokens, grid, hidden_size)
+    return Model(images, maps, name=name)
+
+
+def select_feature_maps(hidden_states, out_layers, skip, grid, hidden_size):
+    height, width = grid
+    maps = []
+    for index in out_layers:
+        patch_tokens = hidden_states[index][:, 1 + skip:]
+        maps.append(Reshape((height, width, hidden_size))(patch_tokens))
+    return maps
+
+
+def normalize_tokens(tokens):
+    return LayerNormalization(epsilon=LAYER_NORM_EPSILON, name="norm")(tokens)
+
+
+def count_positions(image_shape, patch_size):
+    height, width = grid_shape(image_shape, patch_size)
+    return height * width + 1
+
+
+def grid_shape(image_shape, patch_size):
+    return image_shape[0] // patch_size, image_shape[1] // patch_size
+
+
+def DINOv2Small(image_shape=DEFAULT_IMAGE_SHAPE, num_register_tokens=0,
+                name="dinov2_small"):
+    args = (image_shape, PATCH_SIZE, 384, 12, 6, MLP_RATIO)
+    return build_dinov2(*args, num_register_tokens, name)
+
+
+def DINOv2Base(image_shape=DEFAULT_IMAGE_SHAPE, num_register_tokens=0,
+               name="dinov2_base"):
+    args = (image_shape, PATCH_SIZE, 768, 12, 12, MLP_RATIO)
+    return build_dinov2(*args, num_register_tokens, name)
+
+
+def DINOv2Large(image_shape=DEFAULT_IMAGE_SHAPE, num_register_tokens=0,
+                name="dinov2_large"):
+    args = (image_shape, PATCH_SIZE, 1024, 24, 16, MLP_RATIO)
+    return build_dinov2(*args, num_register_tokens, name)
+
+
+def DINOv2SmallFeatures(image_shape=DEFAULT_IMAGE_SHAPE,
+                        out_layers=DEFAULT_OUT_LAYERS, num_register_tokens=0,
+                        name="dinov2_small_features"):
+    args = (image_shape, PATCH_SIZE, 384, 12, 6, MLP_RATIO)
+    return build_dinov2_features(*args, num_register_tokens, out_layers, name)
+
+
+def DINOv2BaseFeatures(image_shape=DEFAULT_IMAGE_SHAPE,
+                       out_layers=DEFAULT_OUT_LAYERS, num_register_tokens=0,
+                       name="dinov2_base_features"):
+    args = (image_shape, PATCH_SIZE, 768, 12, 12, MLP_RATIO)
+    return build_dinov2_features(*args, num_register_tokens, out_layers, name)
+
+
+def DINOv2LargeFeatures(image_shape=DEFAULT_IMAGE_SHAPE,
+                        out_layers=DEFAULT_OUT_LAYERS, num_register_tokens=0,
+                        name="dinov2_large_features"):
+    args = (image_shape, PATCH_SIZE, 1024, 24, 16, MLP_RATIO)
+    return build_dinov2_features(*args, num_register_tokens, out_layers, name)

--- a/paz/models/foundation/dinov2/models.py
+++ b/paz/models/foundation/dinov2/models.py
@@ -1,57 +1,49 @@
 from keras import Input, Model
 from keras.layers import LayerNormalization, Reshape
 
-from paz.models.foundation.dinov2.embeddings import build_dinov2_embeddings
-from paz.models.foundation.dinov2.encoder import build_dinov2_encoder
-
-PATCH_SIZE = 14
-MLP_RATIO = 4.0
-LAYER_SCALE_INIT = 1e-5
-LAYER_NORM_EPSILON = 1e-6
-DEFAULT_IMAGE_SHAPE = (518, 518, 3)
-DEFAULT_OUT_LAYERS = (5, 7, 9, 11)
+from paz.models.foundation.dinov2 import embeddings, encoder
 
 
 def build_dinov2(image_shape, patch_size, hidden_size, depth, num_heads,
-                 mlp_ratio, num_register_tokens, name):
+                 MLP_ratio, num_registers, name):
     images = Input(image_shape, name="pixels")
     positions = count_positions(image_shape, patch_size)
-    tokens = build_dinov2_embeddings(images, patch_size, hidden_size,
-                                     positions, num_register_tokens)
-    args = (hidden_size, depth, num_heads, mlp_ratio, LAYER_SCALE_INIT)
-    tokens, _ = build_dinov2_encoder(tokens, *args)
+    args = images, patch_size, hidden_size, positions, num_registers
+    tokens = embeddings.build(*args)
+    args = hidden_size, depth, num_heads, MLP_ratio, 1e-5
+    tokens, _ = encoder.build(tokens, *args)
     normalized = normalize_tokens(tokens)
     class_token = normalized[:, 0]
-    patch_tokens = normalized[:, 1 + num_register_tokens:]
+    patch_tokens = normalized[:, 1 + num_registers:]
     return Model(images, (class_token, patch_tokens), name=name)
 
 
 def build_dinov2_features(image_shape, patch_size, hidden_size, depth,
-                          num_heads, mlp_ratio, num_register_tokens,
-                          out_layers, name):
+                          num_heads, MLP_ratio, num_registers, out_layers,
+                          name):
     images = Input(image_shape, name="pixels")
     positions = count_positions(image_shape, patch_size)
-    tokens = build_dinov2_embeddings(images, patch_size, hidden_size,
-                                     positions, num_register_tokens)
-    args = (hidden_size, depth, num_heads, mlp_ratio, LAYER_SCALE_INIT)
-    _, hidden_states = build_dinov2_encoder(tokens, *args)
+    args = images, patch_size, hidden_size, positions, num_registers
+    tokens = embeddings.build(*args)
+    args = hidden_size, depth, num_heads, MLP_ratio, 1e-5
+    _, hidden_states = encoder.build(tokens, *args)
     grid = grid_shape(image_shape, patch_size)
-    maps = select_feature_maps(hidden_states, out_layers,
-                               num_register_tokens, grid, hidden_size)
+    maps = select_feature_maps(hidden_states, out_layers, num_registers,
+                               grid, hidden_size)
     return Model(images, maps, name=name)
 
 
 def select_feature_maps(hidden_states, out_layers, skip, grid, hidden_size):
     height, width = grid
     maps = []
-    for index in out_layers:
-        patch_tokens = hidden_states[index][:, 1 + skip:]
+    for arg in out_layers:
+        patch_tokens = hidden_states[arg][:, 1 + skip:]
         maps.append(Reshape((height, width, hidden_size))(patch_tokens))
     return maps
 
 
 def normalize_tokens(tokens):
-    return LayerNormalization(epsilon=LAYER_NORM_EPSILON, name="norm")(tokens)
+    return LayerNormalization(epsilon=1e-6, name="norm")(tokens)
 
 
 def count_positions(image_shape, patch_size):
@@ -63,40 +55,37 @@ def grid_shape(image_shape, patch_size):
     return image_shape[0] // patch_size, image_shape[1] // patch_size
 
 
-def DINOv2Small(image_shape=DEFAULT_IMAGE_SHAPE, num_register_tokens=0,
+def DINOv2Small(image_shape=(518, 518, 3), num_registers=0,
                 name="dinov2_small"):
-    args = (image_shape, PATCH_SIZE, 384, 12, 6, MLP_RATIO)
-    return build_dinov2(*args, num_register_tokens, name)
+    args = image_shape, 14, 384, 12, 6, 4.0
+    return build_dinov2(*args, num_registers, name)
 
 
-def DINOv2Base(image_shape=DEFAULT_IMAGE_SHAPE, num_register_tokens=0,
+def DINOv2Base(image_shape=(518, 518, 3), num_registers=0,
                name="dinov2_base"):
-    args = (image_shape, PATCH_SIZE, 768, 12, 12, MLP_RATIO)
-    return build_dinov2(*args, num_register_tokens, name)
+    args = image_shape, 14, 768, 12, 12, 4.0
+    return build_dinov2(*args, num_registers, name)
 
 
-def DINOv2Large(image_shape=DEFAULT_IMAGE_SHAPE, num_register_tokens=0,
+def DINOv2Large(image_shape=(518, 518, 3), num_registers=0,
                 name="dinov2_large"):
-    args = (image_shape, PATCH_SIZE, 1024, 24, 16, MLP_RATIO)
-    return build_dinov2(*args, num_register_tokens, name)
+    args = image_shape, 14, 1024, 24, 16, 4.0
+    return build_dinov2(*args, num_registers, name)
 
 
-def DINOv2SmallFeatures(image_shape=DEFAULT_IMAGE_SHAPE,
-                        out_layers=DEFAULT_OUT_LAYERS, num_register_tokens=0,
-                        name="dinov2_small_features"):
-    args = (image_shape, PATCH_SIZE, 384, 12, 6, MLP_RATIO)
-    return build_dinov2_features(*args, num_register_tokens, out_layers, name)
+def DINOv2SmallFeatures(image_shape=(518, 518, 3), out_layers=(5, 7, 9, 11),
+                        num_registers=0, name="dinov2_small_features"):
+    args = image_shape, 14, 384, 12, 6, 4.0
+    return build_dinov2_features(*args, num_registers, out_layers, name)
 
 
-def DINOv2BaseFeatures(image_shape=DEFAULT_IMAGE_SHAPE,
-                       out_layers=DEFAULT_OUT_LAYERS, num_register_tokens=0,
-                       name="dinov2_base_features"):
-    args = (image_shape, PATCH_SIZE, 768, 12, 12, MLP_RATIO)
-    return build_dinov2_features(*args, num_register_tokens, out_layers, name)
+def DINOv2BaseFeatures(image_shape=(518, 518, 3), out_layers=(5, 7, 9, 11),
+                       num_registers=0, name="dinov2_base_features"):
+    args = image_shape, 14, 768, 12, 12, 4.0
+    return build_dinov2_features(*args, num_registers, out_layers, name)
 
 
-def DINOv2LargeFeatures(image_shape=DEFAULT_IMAGE_SHAPE,
-                        out_layers=DEFAULT_OUT_LAYERS, num_register_tokens=0,
-                        name="dinov2_large_features"):
-    args = (image_shape, PATCH_SIZE, 1024, 24, 16, MLP_RATIO)
-    return build_dinov2_features(*args, num_register_tokens, out_layers, name)
+def DINOv2LargeFeatures(image_shape=(518, 518, 3), out_layers=(5, 7, 9, 11),
+                        num_registers=0, name="dinov2_large_features"):
+    args = image_shape, 14, 1024, 24, 16, 4.0
+    return build_dinov2_features(*args, num_registers, out_layers, name)

--- a/paz/models/foundation/dinov2/models_test.py
+++ b/paz/models/foundation/dinov2/models_test.py
@@ -42,7 +42,8 @@ def test_large_builds():
 
 
 def test_feature_model_returns_ordered_maps():
-    model = DINOv2SmallFeatures(image_shape=IMAGE_SHAPE, out_layers=(5, 7, 9, 11))
+    layers = (5, 7, 9, 11)
+    model = DINOv2SmallFeatures(image_shape=IMAGE_SHAPE, out_layers=layers)
     maps = model(make_input())
     assert not isinstance(maps, dict)
     assert not hasattr(maps, "_fields")

--- a/paz/models/foundation/dinov2/models_test.py
+++ b/paz/models/foundation/dinov2/models_test.py
@@ -1,0 +1,72 @@
+import os
+
+import numpy as np
+import jax
+
+from paz.models import DINOv2Small, DINOv2Base, DINOv2Large
+from paz.models import DINOv2SmallFeatures
+
+IMAGE_SHAPE = (70, 70, 3)
+GRID = (5, 5)
+
+
+def make_input(batch=2):
+    return np.random.RandomState(0).randn(batch, *IMAGE_SHAPE).astype("float32")
+
+
+def test_small_returns_class_and_patch_tokens():
+    model = DINOv2Small(image_shape=IMAGE_SHAPE)
+    class_token, patch_tokens = model(make_input())
+    assert tuple(class_token.shape) == (2, 384)
+    assert tuple(patch_tokens.shape) == (2, 25, 384)
+
+
+def test_standard_output_is_two_plain_tensors():
+    model = DINOv2Small(image_shape=IMAGE_SHAPE)
+    output = model(make_input())
+    assert not isinstance(output, dict)
+    assert not hasattr(output, "_fields")
+    assert len(output) == 2
+
+
+def test_base_returns_class_and_patch_tokens():
+    model = DINOv2Base(image_shape=IMAGE_SHAPE)
+    class_token, patch_tokens = model(make_input())
+    assert tuple(class_token.shape) == (2, 768)
+    assert tuple(patch_tokens.shape) == (2, 25, 768)
+
+
+def test_large_builds():
+    model = DINOv2Large(image_shape=IMAGE_SHAPE)
+    assert model.output_shape == [(None, 1024), (None, 25, 1024)]
+
+
+def test_feature_model_returns_ordered_maps():
+    model = DINOv2SmallFeatures(image_shape=IMAGE_SHAPE, out_layers=(5, 7, 9, 11))
+    maps = model(make_input())
+    assert not isinstance(maps, dict)
+    assert not hasattr(maps, "_fields")
+    assert len(maps) == 4
+    for feature_map in maps:
+        assert tuple(feature_map.shape) == (2, GRID[0], GRID[1], 384)
+
+
+def test_small_save_and_reload_weights(tmp_path):
+    model = DINOv2Small(image_shape=IMAGE_SHAPE)
+    data = make_input()
+    before = [np.array(tensor) for tensor in model(data)]
+    path = os.path.join(tmp_path, "dinov2_small.weights.h5")
+    model.save_weights(path)
+    reloaded = DINOv2Small(image_shape=IMAGE_SHAPE)
+    reloaded.load_weights(path)
+    after = [np.array(tensor) for tensor in reloaded(data)]
+    for expected, actual in zip(before, after):
+        assert np.allclose(expected, actual, atol=1e-6)
+
+
+def test_small_jit_matches_eager():
+    model = DINOv2Small(image_shape=IMAGE_SHAPE)
+    data = make_input()
+    eager = np.array(model(data)[0])
+    jitted = np.array(jax.jit(lambda x: model(x))(data)[0])
+    assert np.allclose(eager, jitted, atol=1e-5)

--- a/paz/models/foundation/dinov2/parity_test.py
+++ b/paz/models/foundation/dinov2/parity_test.py
@@ -1,0 +1,129 @@
+import os
+
+import numpy as np
+import pytest
+from keras import Model
+
+from paz.models import DINOv2Small
+from paz.models.foundation.dinov2.models import count_positions
+from paz.models.foundation.dinov2.port_weights import port_weights
+from paz.models.foundation.dinov2_legacy.models.vision_transformer import (
+    DINOV2Small as LegacyDINOv2Small,
+)
+
+IMAGE_SHAPE = (98, 98, 3)
+HIDDEN_SIZE = 384
+DEPTH = 12
+
+
+def copy_weights_by_name(source, target):
+    for layer in target.layers:
+        weights = layer.get_weights()
+        if weights:
+            layer.set_weights(source.get_layer(layer.name).get_weights())
+
+
+def test_matches_legacy_dinov2():
+    canonical = DINOv2Small(image_shape=IMAGE_SHAPE)
+    legacy = LegacyDINOv2Small(img_size=IMAGE_SHAPE[0])
+    copy_weights_by_name(legacy, canonical)
+    legacy_norm = Model(legacy.input, legacy.get_layer("norm").output)
+    data = np.random.RandomState(0).randn(2, *IMAGE_SHAPE).astype("float32")
+    class_token, patch_tokens = canonical(data)
+    normalized = np.array(legacy_norm(data))
+    assert np.allclose(np.array(class_token), normalized[:, 0], atol=1e-5)
+    assert np.allclose(np.array(patch_tokens), normalized[:, 1:], atol=1e-5)
+
+
+def build_torch_state_dict(model):
+    state_dict = {}
+    for layer in model.layers:
+        add_torch_parameters(state_dict, layer)
+    return state_dict
+
+
+def add_torch_parameters(state_dict, layer):
+    name = layer.name
+    weights = layer.get_weights()
+    if name == "patch_embed_proj":
+        state_dict["patch_embed.proj.weight"] = np.transpose(weights[0], (3, 2, 0, 1))  # noqa: E501
+        state_dict["patch_embed.proj.bias"] = weights[1]
+    elif name == "cls_token":
+        state_dict["cls_token"] = weights[0].reshape(1, 1, -1)
+    elif name == "pos_embed":
+        state_dict["pos_embed"] = weights[0].reshape(1, -1, HIDDEN_SIZE)
+    elif name == "norm":
+        state_dict["norm.weight"], state_dict["norm.bias"] = weights
+    elif name.startswith("block_"):
+        add_block_parameters(state_dict, name, weights)
+
+
+def add_block_parameters(state_dict, name, weights):
+    index = name.split("_")[1]
+    kinds = {"norm1": "norm1", "norm2": "norm2", "qkv": "attn.qkv",
+             "proj": "attn.proj", "mlp_fc1": "mlp.fc1", "mlp_fc2": "mlp.fc2"}
+    suffix = name[len(f"block_{index}_"):]
+    if suffix in ("norm1", "norm2"):
+        gamma, beta = weights
+        state_dict[f"blocks.{index}.{kinds[suffix]}.weight"] = gamma
+        state_dict[f"blocks.{index}.{kinds[suffix]}.bias"] = beta
+    elif suffix in ("qkv", "proj", "mlp_fc1", "mlp_fc2"):
+        kernel, bias = weights
+        state_dict[f"blocks.{index}.{kinds[suffix]}.weight"] = kernel.T
+        state_dict[f"blocks.{index}.{kinds[suffix]}.bias"] = bias
+    elif suffix in ("ls1", "ls2"):
+        state_dict[f"blocks.{index}.{suffix}.gamma"] = weights[0]
+
+
+def test_converter_reproduces_source_model(tmp_path):
+    source = DINOv2Small(image_shape=IMAGE_SHAPE)
+    state_dict = build_torch_state_dict(source)
+    positions = count_positions(IMAGE_SHAPE, 14)
+    target = DINOv2Small(image_shape=IMAGE_SHAPE)
+    port_weights(target, state_dict, positions, HIDDEN_SIZE, DEPTH)
+    path = os.path.join(tmp_path, "ported.weights.h5")
+    target.save_weights(path)
+    reloaded = DINOv2Small(image_shape=IMAGE_SHAPE)
+    reloaded.load_weights(path)
+    data = np.random.RandomState(1).randn(1, *IMAGE_SHAPE).astype("float32")
+    expected = np.array(source(data)[0])
+    assert np.allclose(np.array(reloaded(data)[0]), expected, atol=1e-5)
+
+
+def test_converter_rejects_missing_key():
+    source = DINOv2Small(image_shape=IMAGE_SHAPE)
+    state_dict = build_torch_state_dict(source)
+    del state_dict["norm.weight"]
+    positions = count_positions(IMAGE_SHAPE, 14)
+    target = DINOv2Small(image_shape=IMAGE_SHAPE)
+    with pytest.raises(KeyError):
+        port_weights(target, state_dict, positions, HIDDEN_SIZE, DEPTH)
+
+
+def test_converter_rejects_unexpected_key():
+    source = DINOv2Small(image_shape=IMAGE_SHAPE)
+    state_dict = build_torch_state_dict(source)
+    state_dict["blocks.0.attn.extra"] = np.zeros((3,), "float32")
+    positions = count_positions(IMAGE_SHAPE, 14)
+    target = DINOv2Small(image_shape=IMAGE_SHAPE)
+    with pytest.raises(KeyError):
+        port_weights(target, state_dict, positions, HIDDEN_SIZE, DEPTH)
+
+
+@pytest.mark.skipif(not os.environ.get("DINOV2_REFERENCE"),
+                    reason="set DINOV2_REFERENCE to run torch-hub parity")
+def test_reference_torch_parity():
+    import torch
+    reference = torch.hub.load("facebookresearch/dinov2", "dinov2_vits14",
+                               verbose=False).eval()
+    state_dict = {key: value.detach().cpu().numpy()
+                  for key, value in reference.state_dict().items()}
+    model = DINOv2Small(image_shape=(518, 518, 3))
+    positions = count_positions((518, 518, 3), 14)
+    port_weights(model, state_dict, positions, HIDDEN_SIZE, DEPTH)
+    data = np.random.RandomState(0).randn(1, 518, 518, 3).astype("float32")
+    tensor = torch.from_numpy(data).permute(0, 3, 1, 2)
+    with torch.no_grad():
+        expected = reference.forward_features(tensor)["x_norm_clstoken"].numpy()
+    class_token = np.array(model(data)[0])
+    assert np.allclose(class_token, expected, atol=1e-3)

--- a/paz/models/foundation/dinov2/parity_test.py
+++ b/paz/models/foundation/dinov2/parity_test.py
@@ -46,7 +46,8 @@ def add_torch_parameters(state_dict, layer):
     name = layer.name
     weights = layer.get_weights()
     if name == "patch_embed_proj":
-        state_dict["patch_embed.proj.weight"] = np.transpose(weights[0], (3, 2, 0, 1))  # noqa: E501
+        kernel = np.transpose(weights[0], (3, 2, 0, 1))
+        state_dict["patch_embed.proj.weight"] = kernel
         state_dict["patch_embed.proj.bias"] = weights[1]
     elif name == "cls_token":
         state_dict["cls_token"] = weights[0].reshape(1, 1, -1)

--- a/paz/models/foundation/dinov2/port_weights.py
+++ b/paz/models/foundation/dinov2/port_weights.py
@@ -1,0 +1,115 @@
+"""Development-only converter from official torch DINOv2 to canonical Keras.
+
+Maps every source parameter explicitly, transposes Dense and Conv2D kernels,
+preserves fused QKV order, and interpolates positional embeddings to the
+constructed grid. Not imported at runtime; torch/numpy are imported lazily.
+"""
+import numpy as np
+
+
+def port_weights(model, state_dict, num_positions, hidden_size, depth):
+    expected = set()
+    assign_patch_embedding(model, state_dict, expected)
+    assign_class_token(model, state_dict, hidden_size, expected)
+    assign_position_embedding(model, state_dict, num_positions, hidden_size,
+                              expected)
+    for index in range(depth):
+        assign_block(model, state_dict, index, expected)
+    assign_final_norm(model, state_dict, expected)
+    reject_unmapped_keys(state_dict, expected)
+    return model
+
+
+def assign_patch_embedding(model, state_dict, expected):
+    kernel = take(state_dict, "patch_embed.proj.weight", expected)
+    bias = take(state_dict, "patch_embed.proj.bias", expected)
+    kernel = np.transpose(kernel, (2, 3, 1, 0))
+    set_layer(model, "patch_embed_proj", [kernel, bias])
+
+
+def assign_class_token(model, state_dict, hidden_size, expected):
+    token = take(state_dict, "cls_token", expected).reshape(1, hidden_size)
+    set_layer(model, "cls_token", [token])
+
+
+def assign_position_embedding(model, state_dict, num_positions, hidden_size,
+                              expected):
+    source = take(state_dict, "pos_embed", expected).reshape(-1, hidden_size)
+    resized = interpolate_positions(source, num_positions, hidden_size)
+    set_layer(model, "pos_embed", [resized])
+
+
+def assign_block(model, state_dict, index, expected):
+    prefix = f"blocks.{index}"
+    name = f"block_{index}"
+    set_norm(model, state_dict, f"{prefix}.norm1", f"{name}_norm1", expected)
+    set_norm(model, state_dict, f"{prefix}.norm2", f"{name}_norm2", expected)
+    set_dense(model, state_dict, f"{prefix}.attn.qkv", f"{name}_qkv", expected)
+    set_dense(model, state_dict, f"{prefix}.attn.proj", f"{name}_proj", expected)
+    set_dense(model, state_dict, f"{prefix}.mlp.fc1", f"{name}_mlp_fc1", expected)
+    set_dense(model, state_dict, f"{prefix}.mlp.fc2", f"{name}_mlp_fc2", expected)
+    scale1 = take(state_dict, f"{prefix}.ls1.gamma", expected)
+    scale2 = take(state_dict, f"{prefix}.ls2.gamma", expected)
+    set_layer(model, f"{name}_ls1", [scale1])
+    set_layer(model, f"{name}_ls2", [scale2])
+
+
+def assign_final_norm(model, state_dict, expected):
+    set_norm(model, state_dict, "norm", "norm", expected)
+
+
+def set_dense(model, state_dict, source, target, expected):
+    kernel = take(state_dict, f"{source}.weight", expected).T
+    bias = take(state_dict, f"{source}.bias", expected)
+    set_layer(model, target, [kernel, bias])
+
+
+def set_norm(model, state_dict, source, target, expected):
+    gamma = take(state_dict, f"{source}.weight", expected)
+    beta = take(state_dict, f"{source}.bias", expected)
+    set_layer(model, target, [gamma, beta])
+
+
+def set_layer(model, name, arrays):
+    layer = model.get_layer(name)
+    current = [weight.shape for weight in layer.get_weights()]
+    target = [tuple(array.shape) for array in arrays]
+    if current != target:
+        raise ValueError(f"{name} shape {target} does not fit {current}")
+    layer.set_weights(arrays)
+
+
+def take(state_dict, key, expected):
+    if key not in state_dict:
+        raise KeyError(f"missing source key: {key}")
+    expected.add(key)
+    return np.asarray(state_dict[key])
+
+
+def reject_unmapped_keys(state_dict, expected):
+    unused = set(state_dict) - expected
+    if unused:
+        raise KeyError(f"unexpected source keys: {sorted(unused)}")
+
+
+def interpolate_positions(source, num_positions, hidden_size):
+    if source.shape[0] == num_positions:
+        return source
+    class_position, patch_positions = source[:1], source[1:]
+    source_grid = int(round(np.sqrt(patch_positions.shape[0])))
+    target_grid = int(round(np.sqrt(num_positions - 1)))
+    resized = resize_grid(patch_positions, source_grid, target_grid)
+    return np.concatenate([class_position, resized], axis=0)
+
+
+def resize_grid(positions, source_grid, target_grid):
+    import torch
+    import torch.nn.functional as functional
+    hidden_size = positions.shape[-1]
+    grid = positions.reshape(1, source_grid, source_grid, hidden_size)
+    grid = torch.from_numpy(grid).permute(0, 3, 1, 2)
+    size = (target_grid, target_grid)
+    grid = functional.interpolate(grid, size=size, mode="bicubic",
+                                  align_corners=False)
+    grid = grid.permute(0, 2, 3, 1).reshape(-1, hidden_size)
+    return grid.numpy()

--- a/paz/models/foundation/dinov2/port_weights.py
+++ b/paz/models/foundation/dinov2/port_weights.py
@@ -42,12 +42,18 @@ def assign_position_embedding(model, state_dict, num_positions, hidden_size,
 def assign_block(model, state_dict, index, expected):
     prefix = f"blocks.{index}"
     name = f"block_{index}"
-    set_norm(model, state_dict, f"{prefix}.norm1", f"{name}_norm1", expected)
-    set_norm(model, state_dict, f"{prefix}.norm2", f"{name}_norm2", expected)
-    set_dense(model, state_dict, f"{prefix}.attn.qkv", f"{name}_qkv", expected)
-    set_dense(model, state_dict, f"{prefix}.attn.proj", f"{name}_proj", expected)
-    set_dense(model, state_dict, f"{prefix}.mlp.fc1", f"{name}_mlp_fc1", expected)
-    set_dense(model, state_dict, f"{prefix}.mlp.fc2", f"{name}_mlp_fc2", expected)
+
+    def port(setter, source, target):
+        full_source = f"{prefix}.{source}"
+        full_target = f"{name}_{target}"
+        setter(model, state_dict, full_source, full_target, expected)
+
+    port(set_norm, "norm1", "norm1")
+    port(set_norm, "norm2", "norm2")
+    port(set_dense, "attn.qkv", "qkv")
+    port(set_dense, "attn.proj", "proj")
+    port(set_dense, "mlp.fc1", "mlp_fc1")
+    port(set_dense, "mlp.fc2", "mlp_fc2")
     scale1 = take(state_dict, f"{prefix}.ls1.gamma", expected)
     scale2 = take(state_dict, f"{prefix}.ls2.gamma", expected)
     set_layer(model, f"{name}_ls1", [scale1])

--- a/paz/models/transformers/attention.py
+++ b/paz/models/transformers/attention.py
@@ -2,7 +2,8 @@ import string
 
 import keras
 from keras import ops
-from keras.layers import Dense, Dropout, EinsumDense, LayerNormalization, Reshape
+from keras.layers import Dense, Dropout, EinsumDense, Reshape
+from keras.layers import LayerNormalization
 
 from paz.models.transformers import cache as kv_cache
 
@@ -176,9 +177,9 @@ def kernel(stddev=0.02):
 
 def project_query_key_value(tokens, hidden_size, use_bias, name):
     units = hidden_size * 3
-    layer = Dense(units, use_bias=use_bias, kernel_initializer=kernel(),
-                  name=f"{name}_qkv")
-    return layer(tokens)
+    name_qkv = f"{name}_qkv"
+    kwargs = dict(use_bias=use_bias, kernel_initializer=kernel(), name=name_qkv)
+    return Dense(units, **kwargs)(tokens)
 
 
 def split_query_key_value(fused, num_heads, head_dim):
@@ -203,6 +204,10 @@ def merge_attention_heads(context):
 
 
 def normalize_query_key(query, key, epsilon, name):
-    query_norm = LayerNormalization(axis=-1, epsilon=epsilon, name=f"{name}_q_norm")
-    key_norm = LayerNormalization(axis=-1, epsilon=epsilon, name=f"{name}_k_norm")
-    return query_norm(query), key_norm(key)
+    query = head_norm(query, epsilon, f"{name}_q_norm")
+    key = head_norm(key, epsilon, f"{name}_k_norm")
+    return query, key
+
+
+def head_norm(values, epsilon, name):
+    return LayerNormalization(axis=-1, epsilon=epsilon, name=name)(values)

--- a/paz/models/transformers/attention.py
+++ b/paz/models/transformers/attention.py
@@ -2,7 +2,7 @@ import string
 
 import keras
 from keras import ops
-from keras.layers import Dense, Dropout, EinsumDense, Reshape
+from keras.layers import Dense, Dropout, EinsumDense, LayerNormalization, Reshape
 
 from paz.models.transformers import cache as kv_cache
 
@@ -200,3 +200,9 @@ def merge_attention_heads(context):
     num_heads = transposed.shape[2]
     head_dim = transposed.shape[3]
     return Reshape((-1, num_heads * head_dim))(transposed)
+
+
+def normalize_query_key(query, key, epsilon, name):
+    query_norm = LayerNormalization(axis=-1, epsilon=epsilon, name=f"{name}_q_norm")
+    key_norm = LayerNormalization(axis=-1, epsilon=epsilon, name=f"{name}_k_norm")
+    return query_norm(query), key_norm(key)

--- a/paz/models/transformers/attention.py
+++ b/paz/models/transformers/attention.py
@@ -2,7 +2,7 @@ import string
 
 import keras
 from keras import ops
-from keras.layers import Dropout, EinsumDense
+from keras.layers import Dense, Dropout, EinsumDense, Reshape
 
 from paz.models.transformers import cache as kv_cache
 
@@ -172,3 +172,31 @@ def merge_heads(tensor):
 
 def kernel(stddev=0.02):
     return keras.initializers.TruncatedNormal(stddev=stddev)
+
+
+def project_query_key_value(tokens, hidden_size, use_bias, name):
+    units = hidden_size * 3
+    layer = Dense(units, use_bias=use_bias, kernel_initializer=kernel(),
+                  name=f"{name}_qkv")
+    return layer(tokens)
+
+
+def split_query_key_value(fused, num_heads, head_dim):
+    heads = Reshape((-1, 3, num_heads, head_dim))(fused)
+    heads = ops.transpose(heads, (2, 0, 3, 1, 4))
+    return heads[0], heads[1], heads[2]
+
+
+def compute_attention(query, key, value):
+    head_dim = query.shape[-1]
+    scale = head_dim ** -0.5
+    scores = ops.matmul(query, ops.transpose(key, (0, 1, 3, 2))) * scale
+    probabilities = ops.softmax(scores, axis=-1)
+    return ops.matmul(probabilities, value)
+
+
+def merge_attention_heads(context):
+    transposed = ops.transpose(context, (0, 2, 1, 3))
+    num_heads = transposed.shape[2]
+    head_dim = transposed.shape[3]
+    return Reshape((-1, num_heads * head_dim))(transposed)

--- a/paz/models/transformers/attention_test.py
+++ b/paz/models/transformers/attention_test.py
@@ -48,7 +48,8 @@ def test_split_recovers_fused_qkv_layout():
     num_heads, head_dim = 2, 4
     hidden = num_heads * head_dim
     ramp = np.arange(3 * hidden, dtype="float32").reshape(1, 1, 3 * hidden)
-    query, key, value = split_query_key_value(ops.array(ramp), num_heads, head_dim)
+    fused = ops.array(ramp)
+    query, key, value = split_query_key_value(fused, num_heads, head_dim)
     expected = ramp.reshape(3, num_heads, head_dim)
     assert np.allclose(np.array(query)[0, :, 0, :], expected[0])
     assert np.allclose(np.array(key)[0, :, 0, :], expected[1])

--- a/paz/models/transformers/attention_test.py
+++ b/paz/models/transformers/attention_test.py
@@ -6,6 +6,7 @@ from paz.models.transformers.attention import project_query_key_value
 from paz.models.transformers.attention import split_query_key_value
 from paz.models.transformers.attention import compute_attention
 from paz.models.transformers.attention import merge_attention_heads
+from paz.models.transformers.attention import normalize_query_key
 
 
 def test_attend_preserves_query_shape():
@@ -74,3 +75,13 @@ def test_merge_attention_heads_inverts_split_layout():
     context = ops.zeros((1, num_heads, 4, head_dim))
     merged = merge_attention_heads(context)
     assert tuple(merged.shape) == (1, 4, num_heads * head_dim)
+
+
+def test_normalize_query_key_normalizes_over_head_dim():
+    values = np.random.RandomState(2).randn(2, 3, 5, 16).astype("float32")
+    query, key = normalize_query_key(ops.array(values), ops.array(values),
+                                     1e-5, "blk")
+    query = np.array(query)
+    assert np.allclose(query.mean(axis=-1), 0.0, atol=1e-5)
+    assert np.allclose(query.std(axis=-1), 1.0, atol=1e-2)
+    assert np.allclose(query, np.array(key))

--- a/paz/models/transformers/attention_test.py
+++ b/paz/models/transformers/attention_test.py
@@ -1,6 +1,11 @@
+import numpy as np
 from keras import ops
 
 from paz.models.transformers.attention import attend, kv_attend, build_cache
+from paz.models.transformers.attention import project_query_key_value
+from paz.models.transformers.attention import split_query_key_value
+from paz.models.transformers.attention import compute_attention
+from paz.models.transformers.attention import merge_attention_heads
 
 
 def test_attend_preserves_query_shape():
@@ -22,3 +27,50 @@ def test_kv_attend_cross_attention_shape():
     args = (query, cache, None, None, None, 2, 16, 0.0, "cross_test")
     output, updated = kv_attend(*args)
     assert tuple(output.shape) == (1, 1, 16)
+
+
+def test_project_query_key_value_triples_last_axis():
+    tokens = ops.zeros((1, 4, 16))
+    fused = project_query_key_value(tokens, 16, True, "qkv_test")
+    assert tuple(fused.shape) == (1, 4, 48)
+
+
+def test_split_query_key_value_shapes():
+    fused = ops.zeros((1, 4, 48))
+    query, key, value = split_query_key_value(fused, 2, 8)
+    assert tuple(query.shape) == (1, 2, 4, 8)
+    assert tuple(key.shape) == (1, 2, 4, 8)
+    assert tuple(value.shape) == (1, 2, 4, 8)
+
+
+def test_split_recovers_fused_qkv_layout():
+    num_heads, head_dim = 2, 4
+    hidden = num_heads * head_dim
+    ramp = np.arange(3 * hidden, dtype="float32").reshape(1, 1, 3 * hidden)
+    query, key, value = split_query_key_value(ops.array(ramp), num_heads, head_dim)
+    expected = ramp.reshape(3, num_heads, head_dim)
+    assert np.allclose(np.array(query)[0, :, 0, :], expected[0])
+    assert np.allclose(np.array(key)[0, :, 0, :], expected[1])
+    assert np.allclose(np.array(value)[0, :, 0, :], expected[2])
+
+
+def test_compute_attention_matches_numpy():
+    rng = np.random.default_rng(0)
+    shape = (1, 2, 4, 8)
+    query = rng.standard_normal(shape).astype("float32")
+    key = rng.standard_normal(shape).astype("float32")
+    value = rng.standard_normal(shape).astype("float32")
+    output = np.array(compute_attention(*map(ops.array, (query, key, value))))
+    scale = shape[-1] ** -0.5
+    scores = query @ np.swapaxes(key, -1, -2) * scale
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    probabilities = np.exp(scores)
+    probabilities /= probabilities.sum(axis=-1, keepdims=True)
+    assert np.allclose(output, probabilities @ value, atol=1e-5)
+
+
+def test_merge_attention_heads_inverts_split_layout():
+    num_heads, head_dim = 2, 8
+    context = ops.zeros((1, num_heads, 4, head_dim))
+    merged = merge_attention_heads(context)
+    assert tuple(merged.shape) == (1, 4, num_heads * head_dim)

--- a/paz/models/transformers/embeddings/__init__.py
+++ b/paz/models/transformers/embeddings/__init__.py
@@ -1,3 +1,4 @@
 from paz.models.transformers.embeddings import rotary
 from paz.models.transformers.embeddings import absolute
 from paz.models.transformers.embeddings import reversible
+from paz.models.transformers.embeddings import patch

--- a/paz/models/transformers/embeddings/__init__.py
+++ b/paz/models/transformers/embeddings/__init__.py
@@ -2,3 +2,4 @@ from paz.models.transformers.embeddings import rotary
 from paz.models.transformers.embeddings import absolute
 from paz.models.transformers.embeddings import reversible
 from paz.models.transformers.embeddings import patch
+from paz.models.transformers.embeddings import token

--- a/paz/models/transformers/embeddings/patch.py
+++ b/paz/models/transformers/embeddings/patch.py
@@ -1,0 +1,10 @@
+"""Patch-grid spatial positions for two-dimensional rotary embeddings."""
+from keras import ops
+
+
+def build_patch_positions(height, width):
+    rows = ops.arange(height, dtype="int32")
+    columns = ops.arange(width, dtype="int32")
+    grid_rows = ops.repeat(rows, width)
+    grid_columns = ops.tile(columns, (height,))
+    return ops.stack([grid_rows, grid_columns], axis=-1)

--- a/paz/models/transformers/embeddings/patch_test.py
+++ b/paz/models/transformers/embeddings/patch_test.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+from paz.models.transformers.embeddings.patch import build_patch_positions
+
+
+def test_build_patch_positions_is_row_major_cartesian():
+    positions = np.array(build_patch_positions(2, 3))
+    expected = [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2]]
+    assert positions.tolist() == expected

--- a/paz/models/transformers/embeddings/rotary.py
+++ b/paz/models/transformers/embeddings/rotary.py
@@ -13,7 +13,7 @@ def apply(inputs, wavelength, scaling_factor, denominator, positions=None):
     return (inputs * cosine) + (rotated * sine)
 
 
-def apply_2d(tokens, positions, base_frequency=100.0):
+def apply_2D(tokens, positions, base_frequency=100.0):
     vertical, horizontal = ops.split(tokens, 2, axis=-1)
     vertical = apply_axis(vertical, positions[..., 0], base_frequency)
     horizontal = apply_axis(horizontal, positions[..., 1], base_frequency)
@@ -26,8 +26,8 @@ def apply_axis(tokens, positions, base_frequency):
     inverse = 1.0 / (base_frequency ** exponents)
     angles = ops.cast(positions, "float32")[..., None] * inverse
     angles = ops.concatenate([angles, angles], axis=-1)
-    cosine = ops.cos(angles)[:, None, :, :]
-    sine = ops.sin(angles)[:, None, :, :]
+    cosine = ops.expand_dims(ops.cos(angles), axis=1)
+    sine = ops.expand_dims(ops.sin(angles), axis=1)
     return tokens * cosine + rotate_half(tokens) * sine
 
 

--- a/paz/models/transformers/embeddings/rotary.py
+++ b/paz/models/transformers/embeddings/rotary.py
@@ -13,6 +13,29 @@ def apply(inputs, wavelength, scaling_factor, denominator, positions=None):
     return (inputs * cosine) + (rotated * sine)
 
 
+def apply_2d(tokens, positions, base_frequency=100.0):
+    vertical, horizontal = ops.split(tokens, 2, axis=-1)
+    vertical = apply_axis(vertical, positions[..., 0], base_frequency)
+    horizontal = apply_axis(horizontal, positions[..., 1], base_frequency)
+    return ops.concatenate([vertical, horizontal], axis=-1)
+
+
+def apply_axis(tokens, positions, base_frequency):
+    half = tokens.shape[-1]
+    exponents = ops.arange(0, half, 2, dtype="float32") / half
+    inverse = 1.0 / (base_frequency ** exponents)
+    angles = ops.cast(positions, "float32")[..., None] * inverse
+    angles = ops.concatenate([angles, angles], axis=-1)
+    cosine = ops.cos(angles)[:, None, :, :]
+    sine = ops.sin(angles)[:, None, :, :]
+    return tokens * cosine + rotate_half(tokens) * sine
+
+
+def rotate_half(tokens):
+    first_half, second_half = ops.split(tokens, 2, axis=-1)
+    return ops.concatenate([-second_half, first_half], axis=-1)
+
+
 def apply_partial(inputs, wavelength, scaling_factor, partial_rotary_factor,
                   positions=None):
     head_dim = inputs.shape[-1]

--- a/paz/models/transformers/embeddings/rotary_test.py
+++ b/paz/models/transformers/embeddings/rotary_test.py
@@ -24,3 +24,22 @@ def test_apply_partial_preserves_shape():
     x = np.random.RandomState(2).rand(1, 3, 8).astype("float32")
     output = np.asarray(rotary.apply_partial(x, 10000.0, 1.0, 0.5))
     assert output.shape == (1, 3, 8)
+
+
+def test_apply_2d_at_position_zero_is_identity():
+    tokens = np.random.RandomState(0).randn(1, 2, 1, 8).astype("float32")
+    positions = np.zeros((1, 1, 2), "int32")
+    output = np.asarray(rotary.apply_2d(tokens, positions, 100.0))
+    np.testing.assert_allclose(output, tokens, atol=1e-6)
+
+
+def test_apply_2d_preserves_norm_of_each_axis_half():
+    from paz.models.transformers.embeddings.patch import build_patch_positions
+    tokens = np.random.RandomState(1).randn(2, 3, 5, 8).astype("float32")
+    positions = np.broadcast_to(np.array(build_patch_positions(1, 5)), (2, 5, 2))
+    output = np.asarray(rotary.apply_2d(tokens, positions, 100.0))
+    for start in (0, 4):
+        half = slice(start, start + 4)
+        source = np.linalg.norm(tokens[..., half], axis=-1)
+        rotated = np.linalg.norm(output[..., half], axis=-1)
+        np.testing.assert_allclose(source, rotated, atol=1e-5)

--- a/paz/models/transformers/embeddings/rotary_test.py
+++ b/paz/models/transformers/embeddings/rotary_test.py
@@ -29,15 +29,16 @@ def test_apply_partial_preserves_shape():
 def test_apply_2d_at_position_zero_is_identity():
     tokens = np.random.RandomState(0).randn(1, 2, 1, 8).astype("float32")
     positions = np.zeros((1, 1, 2), "int32")
-    output = np.asarray(rotary.apply_2d(tokens, positions, 100.0))
+    output = np.asarray(rotary.apply_2D(tokens, positions, 100.0))
     np.testing.assert_allclose(output, tokens, atol=1e-6)
 
 
 def test_apply_2d_preserves_norm_of_each_axis_half():
     from paz.models.transformers.embeddings.patch import build_patch_positions
     tokens = np.random.RandomState(1).randn(2, 3, 5, 8).astype("float32")
-    positions = np.broadcast_to(np.array(build_patch_positions(1, 5)), (2, 5, 2))
-    output = np.asarray(rotary.apply_2d(tokens, positions, 100.0))
+    grid = np.array(build_patch_positions(1, 5))
+    positions = np.broadcast_to(grid, (2, 5, 2))
+    output = np.asarray(rotary.apply_2D(tokens, positions, 100.0))
     for start in (0, 4):
         half = slice(start, start + 4)
         source = np.linalg.norm(tokens[..., half], axis=-1)

--- a/paz/models/transformers/embeddings/token.py
+++ b/paz/models/transformers/embeddings/token.py
@@ -1,0 +1,30 @@
+"""Learnable tokens as a serializable weight, without Lambda layers.
+
+Holds a ``(count, hidden_size)`` weight and broadcasts it to the batch of a
+reference tensor. Used for class, register, position, and camera tokens so the
+functional models stay serializable.
+"""
+import keras
+from keras import ops
+from keras.layers import Layer
+
+
+@keras.saving.register_keras_serializable(package="paz")
+class LearnableTokens(Layer):
+    def __init__(self, count, hidden_size, **kwargs):
+        super().__init__(**kwargs)
+        self.count = count
+        self.hidden_size = hidden_size
+
+    def build(self, input_shape):
+        shape = (self.count, self.hidden_size)
+        arguments = dict(name="tokens", shape=shape, initializer="zeros")
+        self.tokens = self.add_weight(**arguments)
+
+    def call(self, reference):
+        return ops.zeros_like(reference[:, :self.count, :]) + self.tokens
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(count=self.count, hidden_size=self.hidden_size)
+        return config

--- a/paz/models/transformers/embeddings/token_test.py
+++ b/paz/models/transformers/embeddings/token_test.py
@@ -1,0 +1,17 @@
+import numpy as np
+from keras import Input, Model
+
+from paz.models.transformers.embeddings.token import LearnableTokens
+
+
+def test_learnable_tokens_broadcasts_to_batch():
+    tokens = Input((5, 8))
+    output = LearnableTokens(1, 8, name="cls_token")(tokens)
+    model = Model(tokens, output)
+    assert tuple(model(np.zeros((3, 5, 8), "float32")).shape) == (3, 1, 8)
+
+
+def test_learnable_tokens_config_round_trips():
+    layer = LearnableTokens(2, 16, name="camera_token")
+    restored = LearnableTokens.from_config(layer.get_config())
+    assert restored.count == 2 and restored.hidden_size == 16


### PR DESCRIPTION
Consolidated PR for the canonical DINOv2 / Depth Anything 3 port (milestone 1
merged separately as #399). Every model component is verified bit-for-bit
against the pinned references in the same process (opt-in via DA3_REFERENCE).

## M2 — transformer primitives (`paz/models/transformers`)
Fused-QKV self-attention + DA3 primitives (2D RoPE, per-head QK-norm, patch
positions), verified ~5e-7. Existing attention untouched.

## M3 — canonical function-only DINOv2 (`foundation/dinov2`)
`(class_token, patch_tokens)` / feature-map tuples; canonical == legacy
bit-for-bit; strict converter, save/reload, JIT. Exported from `paz.models`.

## M4/M6 — DA3 any-view SMALL and BASE (`foundation/depth_anything3`)
Backbone (view routing, camera tokens, alternating local/global attention, 2D
RoPE, QK-norm), DualDPT head (depth+rays), camera decoder. `build_da3_small` /
`build_da3_base` return `depth, depth_confidence, extrinsics, intrinsics, rays,
ray_confidence`. BASE reuses the same functions. End-to-end parity vs real
Apache-2.0 checkpoints ~1e-6.

## M7 — permissive monocular/metric large
`build_da3_mono_large` / `build_da3_metric_large`: plain DINOv2-Large backbone +
standard DPT head with sky → `(depth, sky)`. Verified vs DA3MONO-LARGE.

## M5 — weights
`convert.py` (small/base/mono/metric): download → port → save `.weights.h5` →
reload/verify → license+checksum metadata. Weights not committed.

## Applications and examples
`paz.applications.depth_estimators`: `EstimateDepthAnything3Small/Base/MonoLarge/
MetricLarge` (function factories returning closures). Preprocessing runs outside
the compiled model; models build per view count and load a converted weights
file. Examples under `examples/depth_anything3/`.

## Verification (`KERAS_BACKEND=jax`)
- `pytest paz/models/transformers paz/models/foundation/{dinov2,depth_anything3}
  paz/applications/depth_estimators_test.py` — all pass (5 skipped opt-in ref).
- Opt-in reference (`DA3_REFERENCE=1`): DINOv2, DA3 backbone, SMALL e2e, BASE
  e2e, MONO-LARGE all pass. Real-weights app smoke: finite depth, sane cameras.
- No named tuples, tensor dicts, or custom classes. No runtime torch/xformers.

## Remaining
Weight hosting only (maintainer infra); the converter produces files + metadata.