### PR TITLE
Refactor Gemma4 into a single-weight-set backbone

### DIFF
--- a/examples/gemma4/demo_image.py
+++ b/examples/gemma4/demo_image.py
@@ -19,7 +19,7 @@ import jax
 import paz
 from paz.applications import DescribeImageGemma4
 from paz.models import Gemma4
-from paz.models.foundation.gemma4.model import (
+from paz.models.foundation.gemma4.pretrained import (
     resolve_dir, load_vision_encoder)
 
 SAMPLE_IMAGE_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.9.1/image_with_everyday_classes.jpg"  # fmt: skip

--- a/paz/applications/generators.py
+++ b/paz/applications/generators.py
@@ -6,7 +6,7 @@ from keras import ops
 
 from paz import place_on_model_device
 from paz.models import Gemma4
-from paz.models.foundation.gemma4.model import resolve_dir
+from paz.models.foundation.gemma4.pretrained import resolve_dir
 from paz.models.foundation.gemma4.tokenizer import Gemma4Tokenizer
 from paz.models.foundation.gemma4.image_converter import preprocess_images
 from paz.models.foundation.gemma4.multimodal_decoding import (
@@ -23,8 +23,7 @@ def GenerateGemma4(model_name="gemma4_2b", max_tokens=64, max_seq=512,
     tokenizer = build_gemma4_tokenizer(model_dir)
     stop_id = tokenizer.get_stop_token_ids()[-1]
     stream = build_token_printer(tokenizer, stop_id)
-    args = (models.decoder_step, models.per_layer_step, models.config,
-            stop_id, max_tokens, max_seq, max_prompt)
+    args = (models.model, stop_id, max_tokens, max_seq, max_prompt)
     decode = build_text_generator(*args, emit=stream)
 
     def generate(prompt):
@@ -53,8 +52,7 @@ def DescribeImageGemma4(model_name="gemma4_2b", max_tokens=64, max_seq=512,
     vision = VisionEncoderArgs(**read_vision_config(model_dir))
     stop_id = tokenizer.get_stop_token_ids()[-1]
     stream = build_token_printer(tokenizer, stop_id)
-    args = (models.decoder_step, models.per_layer_step, models.config,
-            stop_id, max_tokens, max_seq, max_prompt)
+    args = (models.model, stop_id, max_tokens, max_seq, max_prompt)
     generate = build_generator(*args, emit=stream)
 
     def encode(image):

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -34,7 +34,9 @@ from .foundation.dinov3.models.vision_transformer import DINOV3VITS
 from .foundation.dinov3.models.vision_transformer import DINOV3VITB
 from .foundation.dinov3.models.vision_transformer import DINOV3VITL
 from .foundation.whisper.model import Whisper
-from .foundation.gemma4.model import Gemma4
+from .foundation.gemma4.pretrained import Gemma4
+from .foundation.gemma4.model import Gemma4Backbone
+from .foundation.gemma4.causal_lm import Gemma4CausalLM
 from .feature.xfeat.model import XFeatModel
 from .feature.xfeat.model import XFeat
 from .feature.lightglue.model import LighterGlue

--- a/paz/models/foundation/gemma4/causal_lm.py
+++ b/paz/models/foundation/gemma4/causal_lm.py
@@ -1,20 +1,46 @@
-from pathlib import Path
-
-from keras import Model
+import keras
 
 from paz.models.transformers.logits import soft_cap as apply_soft_cap
+from paz.models.foundation.gemma4.configuration import TextBackboneArgs
+from paz.models.foundation.gemma4.model import Gemma4Backbone
 
-from paz.models.foundation.gemma4.model import build_text_backbone
 
+@keras.saving.register_keras_serializable(package="gemma4")
+class Gemma4CausalLM(keras.Model):
+    """Wraps Gemma4Backbone with reverse-embedding logits and final soft-cap.
 
-def Gemma4CausalLM(config, weights_path=None, name="gemma4_causal_lm"):
-    backbone = build_text_backbone(config)
-    inputs = backbone.input
-    hidden = backbone(inputs)
-    embedding = backbone.get_layer("token_embedding")
-    logits = embedding(hidden, reverse=True)
-    logits = apply_soft_cap(logits, config.final_logit_soft_cap)
-    model = Model(inputs, logits, name=name)
-    if weights_path is not None:
-        model.load_weights(str(Path(weights_path)))
-    return model
+    `call` scores a full sequence; `call_with_cache` runs one cached step for
+    generation. Both share the backbone's single weight set.
+    """
+
+    def __init__(self, config, name="gemma4_causal_lm", **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.config = config
+        self.backbone = Gemma4Backbone(config)
+
+    def call(self, inputs):
+        return self.logits(self.backbone(inputs))
+
+    def call_with_cache(self, input_embedding, cache, index, positions=None,
+                        per_layer_full=None):
+        hidden, cache = self.backbone.call_with_cache(
+            input_embedding, cache, index, positions, per_layer_full)
+        return self.logits(hidden), cache
+
+    def logits(self, hidden):
+        logits = self.backbone.token_embedding(hidden, reverse=True)
+        return apply_soft_cap(logits, self.config.final_logit_soft_cap)
+
+    def build_cache(self, max_length, batch_size=1):
+        return self.backbone.build_cache(max_length, batch_size)
+
+    def get_config(self):
+        config = super().get_config()
+        config["config"] = self.config._asdict()
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        config = dict(config)
+        config["config"] = TextBackboneArgs(**config["config"])
+        return cls(**config)

--- a/paz/models/foundation/gemma4/causal_lm_test.py
+++ b/paz/models/foundation/gemma4/causal_lm_test.py
@@ -44,5 +44,7 @@ def test_causal_lm_save_and_load(tmp_path):
     output = model(inputs)
     path = tmp_path / "causal_lm.weights.h5"
     model.save_weights(str(path))
-    loaded = Gemma4CausalLM(config, weights_path=path)
+    loaded = Gemma4CausalLM(config)
+    loaded(inputs)
+    loaded.load_weights(str(path))
     assert_close(output, loaded(inputs))

--- a/paz/models/foundation/gemma4/conversion.py
+++ b/paz/models/foundation/gemma4/conversion.py
@@ -6,12 +6,12 @@ It writes the split inference artifacts that demo_e2b.py loads: config.json,
 decoder_step.weights.h5 and embedding_step.weights.h5.
 """
 import argparse
-import gc
 import re
 import sys
 from pathlib import Path
 
 import numpy as np
+import jax.numpy as jp
 from keras import ops
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -19,8 +19,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from paz.models.foundation.gemma4.configuration import save_config
-from paz.models.foundation.gemma4.model import (
-    Gemma4DecoderStep, Gemma4PerLayerEmbeddingStep)
+from paz.models.foundation.gemma4.model import Gemma4Backbone
 from paz.models.foundation.gemma4.configuration import TextBackboneArgs
 
 ROLE_SYNONYMS = {
@@ -28,6 +27,7 @@ ROLE_SYNONYMS = {
     "per_layer_input_gate": "per_layer_gate",
     "per_layer_up_proj": "per_layer_projection",
     "post_per_layer_input_norm": "post_per_layer_norm",
+    "attention_attention_output": "attention_output",
 }
 
 
@@ -40,20 +40,22 @@ def convert(preset, output_dir):
     return save_paz_models(backbone, output_dir)
 
 
-def save_paz_models(backbone, output_dir):
+def save_paz_models(source, output_dir):
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    config = build_paz_config(backbone)
+    config = build_paz_config(source)
     save_config(config, output_dir / "config.json")
-    decoder_step = Gemma4DecoderStep(config)
-    transfer(backbone, decoder_step)
-    decoder_step.save_weights(str(output_dir / "decoder_step.weights.h5"))
-    del decoder_step
-    gc.collect()
-    embedding_step = Gemma4PerLayerEmbeddingStep(config)
-    transfer(backbone, embedding_step)
-    embedding_step.save_weights(str(output_dir / "embedding_step.weights.h5"))
+    backbone = build_target_backbone(config)
+    transfer(source, backbone)
+    backbone.save_weights(str(output_dir / "backbone.weights.h5"))
     return config
+
+
+def build_target_backbone(config):
+    backbone = Gemma4Backbone(config)
+    backbone({"token_ids": jp.zeros((1, 1), "int32"),
+              "padding_mask": jp.ones((1, 1), "int32")})
+    return backbone
 
 
 def transfer(source, target):
@@ -74,7 +76,10 @@ def role(path):
         if "layer_scalar" in rest:
             rest = "layer_scalar"
         return "b{}:{}".format(int(match.group(1)), canonical(rest))
-    return "g:" + canonical(path.replace("/", "_"))
+    # Globals: key on the owning layer + variable only, so a subclassed
+    # model-name prefix (e.g. "gemma4_backbone/") does not shift the role.
+    leaf = "_".join(path.split("/")[-2:])
+    return "g:" + canonical(leaf)
 
 
 def canonical(name):

--- a/paz/models/foundation/gemma4/conversion_test.py
+++ b/paz/models/foundation/gemma4/conversion_test.py
@@ -3,22 +3,21 @@ import os
 os.environ.setdefault("KERAS_BACKEND", "jax")
 
 import numpy as np
+import jax.numpy as jp
 import pytest
 
 from paz.models.foundation.gemma4.configuration import load_config
 from paz.models.foundation.gemma4.conversion import (
-    build_paz_config, save_paz_models, transfer)
-from paz.models.foundation.gemma4.model import (
-    Gemma4DecoderStep, Gemma4PerLayerEmbeddingStep)
-from paz.models.foundation.gemma4.model import build_text_backbone
+    build_paz_config, build_target_backbone, save_paz_models, transfer)
+from paz.models.foundation.gemma4.model import Gemma4Backbone
 
 gemma4 = pytest.importorskip(
     "keras_hub.src.models.gemma4.gemma4_backbone")
-Gemma4Backbone = gemma4.Gemma4Backbone
+KerasHubGemma4Backbone = gemma4.Gemma4Backbone
 
 
 def build_reference():
-    return Gemma4Backbone(
+    return KerasHubGemma4Backbone(
         vocabulary_size=64, image_size=16, num_layers=6, num_query_heads=2,
         num_key_value_heads=1, hidden_dim=16, intermediate_dim=32,
         head_dim=16, use_sliding_window_attention=True, sliding_window_size=4,
@@ -38,24 +37,24 @@ def build_inputs():
 
 
 def test_transfer_matches_keras_hub():
-    backbone = build_reference()
-    config = build_paz_config(backbone)
-    model = build_text_backbone(config)
-    transfer(backbone, model)
+    reference = build_reference()
+    config = build_paz_config(reference)
+    model = build_target_backbone(config)
+    transfer(reference, model)
     tokens, padding, positions = build_inputs()
-    reference = backbone(
+    expected = reference(
         {"token_ids": tokens, "padding_mask": padding,
          "position_ids": positions})
     output = model({"token_ids": tokens, "padding_mask": padding})
-    diff = float(np.max(np.abs(np.array(reference) - np.array(output))))
+    diff = float(np.max(np.abs(np.array(expected) - np.array(output))))
     assert diff < 1e-4
 
 
 def test_converter_writes_loadable_artifacts(tmp_path):
-    backbone = build_reference()
-    save_paz_models(backbone, tmp_path)
+    reference = build_reference()
+    save_paz_models(reference, tmp_path)
     config = load_config(tmp_path / "config.json")
-    Gemma4DecoderStep(config).load_weights(
-        str(tmp_path / "decoder_step.weights.h5"))
-    Gemma4PerLayerEmbeddingStep(config).load_weights(
-        str(tmp_path / "embedding_step.weights.h5"))
+    model = Gemma4Backbone(config)
+    model({"token_ids": jp.zeros((1, 1), "int32"),
+           "padding_mask": jp.ones((1, 1), "int32")})
+    model.load_weights(str(tmp_path / "backbone.weights.h5"))

--- a/paz/models/foundation/gemma4/decoding.py
+++ b/paz/models/foundation/gemma4/decoding.py
@@ -1,40 +1,41 @@
+"""Single-sequence jitted greedy/sampling text decoding over a Gemma4CausalLM.
+
+Jits over the bound `call_with_cache` (weights become constants), so this path
+suits small models and tests; the memory-lean stateless path for the large
+pretrained weights lives in `multimodal_decoding`.
+"""
 import jax
 import jax.numpy as jp
 from keras import ops
 
 from paz.models.transformers import search
 
-from paz.models.foundation.gemma4.model import build_empty_cache
 
-
-def kv_decode(step_model, config, prompt_ids, stop_id, max_tokens,
-              max_seq=4096):
-    """Single-sequence jitted greedy decoding (text, no per-layer input)."""
-    args = (step_model, config, prompt_ids, stop_id, max_tokens,
-            jax.random.PRNGKey(0), search.greedy, max_seq)
+def kv_decode(model, prompt_ids, stop_id, max_tokens, max_seq=4096):
+    """Single-sequence jitted greedy decoding."""
+    args = (model, prompt_ids, stop_id, max_tokens, jax.random.PRNGKey(0),
+            search.greedy, max_seq)
     return run_kv_decode(*args)
 
 
-def kv_sample(step_model, config, prompt_ids, stop_id, max_tokens, key,
-              sampling, max_seq=4096):
+def kv_sample(model, prompt_ids, stop_id, max_tokens, key, sampling,
+              max_seq=4096):
     """Single-sequence jitted sampling decoding seeded by `key`."""
     select = search.build_sampler(
         sampling.temperature, sampling.top_k, sampling.top_p)
-    args = (step_model, config, prompt_ids, stop_id, max_tokens, key, select,
-            max_seq)
+    args = (model, prompt_ids, stop_id, max_tokens, key, select, max_seq)
     return run_kv_decode(*args)
 
 
-def run_kv_decode(step_model, config, prompt_ids, stop_id, max_tokens, key,
-                  select, max_seq):
-    decoder = KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq)
-    cache = jp.asarray(build_empty_cache(config, decoder.max_decode_length))
+def run_kv_decode(model, prompt_ids, stop_id, max_tokens, key, select, max_seq):
+    decoder = KVDecoder(model, prompt_ids, max_tokens, select, max_seq)
+    cache = jp.asarray(model.build_cache(decoder.max_decode_length))
     stop = jp.array(stop_id, dtype=jp.int32)
     buffer, length = decoder(cache, stop, key)
     return ops.convert_to_numpy(buffer[0, :length]).tolist()
 
 
-def KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq=4096,
+def KVDecoder(model, prompt_ids, max_tokens, select, max_seq=4096,
               emit=search.discard):
     max_len = min(max_seq, len(prompt_ids) + max_tokens)
     prompt = jp.array(prompt_ids, dtype=jp.int32)
@@ -46,9 +47,9 @@ def KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq=4096,
         buffer = buffer.at[0, :prompt_len].set(prompt)
         cache = self_cache
         if prompt_len > 1:
-            warmup = warmup_step(prompt, step_model)
+            warmup = warmup_step(prompt, model)
             cache = jax.lax.fori_loop(0, prompt_len - 1, warmup, cache)
-        step = build_step(step_model)
+        step = build_step(model)
         run = search.build_streaming(step, select, max_tokens, max_len, emit)
         token = jp.reshape(prompt[prompt_len - 1], (1, 1))
         index = jp.array(prompt_len - 1, dtype=jp.int32)
@@ -58,26 +59,26 @@ def KVDecoder(step_model, prompt_ids, max_tokens, select, max_seq=4096,
     return decode
 
 
-def build_step(step_model):
+def build_step(model):
     def step(cache, token, index, key):
-        return step_model(build_step_inputs(token, cache, index))
+        return cached_forward(model, token, cache, index)
 
     return step
 
 
-def warmup_step(prompt, step_model):
+def warmup_step(prompt, model):
     def step(index, cache):
         token = jp.reshape(prompt[index], (1, 1))
-        inputs = build_step_inputs(token, cache, index)
-        _, cache = step_model(inputs)
+        _, cache = cached_forward(model, token, cache, index)
         return cache
 
     return step
 
 
-def build_step_inputs(token, cache, index):
-    index_array = jp.array([index], dtype=jp.int32)
-    return [token, cache, index_array]
+def cached_forward(model, token, cache, index):
+    embeds = model.backbone.token_embedding(token)
+    per_layer = model.backbone.per_layer_lookup(token)
+    return model.call_with_cache(embeds, cache, index, None, per_layer)
 
 
 def extract_generated_ids(ids, prompt_length, stop_id):

--- a/paz/models/foundation/gemma4/decoding_test.py
+++ b/paz/models/foundation/gemma4/decoding_test.py
@@ -5,22 +5,24 @@ from paz.models.transformers import search
 
 from paz.models.foundation.gemma4.decoding import (
     KVDecoder, extract_generated_ids, kv_decode, kv_sample)
-from paz.models.foundation.gemma4.model import (
-    Gemma4DecoderStep, build_empty_cache)
+from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
 from paz.models.foundation.gemma4.model import build_text_backbone_args
 from paz.models.foundation.gemma4.sampling import SamplingArgs
 
 
-def build_test_config():
-    return build_text_backbone_args(use_sliding_window_attention=False)
+def build_model():
+    config = build_text_backbone_args(use_sliding_window_attention=False)
+    model = Gemma4CausalLM(config)
+    model({"token_ids": jp.zeros((1, 1), "int32"),
+           "padding_mask": jp.ones((1, 1), "int32")})
+    return model, config
 
 
 def test_kv_decoder_generates_tokens():
-    config = build_test_config()
-    step_model = Gemma4DecoderStep(config)
+    model, config = build_model()
     prompt = [1, 2, 3]
-    decoder = KVDecoder(step_model, prompt, 5, search.greedy, 16)
-    cache = jp.asarray(build_empty_cache(config, decoder.max_decode_length))
+    decoder = KVDecoder(model, prompt, 5, search.greedy, 16)
+    cache = jp.asarray(model.build_cache(decoder.max_decode_length))
     stop_id = jp.array(config.vocabulary_size - 1, dtype=jp.int32)
     buffer, length = decoder(cache, stop_id, jax.random.PRNGKey(0))
     ids = buffer[0, :length].tolist()
@@ -29,32 +31,30 @@ def test_kv_decoder_generates_tokens():
 
 
 def test_kv_decoder_streams_generated_tokens_in_order():
-    config = build_test_config()
-    step_model = Gemma4DecoderStep(config)
+    model, config = build_model()
     prompt = [1, 2, 3]
     seen = []
-    decoder = KVDecoder(step_model, prompt, 5, search.greedy, 16,
+    decoder = KVDecoder(model, prompt, 5, search.greedy, 16,
                         emit=lambda token_id: seen.append(int(token_id)))
-    cache = jp.asarray(build_empty_cache(config, decoder.max_decode_length))
+    cache = jp.asarray(model.build_cache(decoder.max_decode_length))
     stop_id = jp.array(config.vocabulary_size - 1, dtype=jp.int32)
     buffer, length = decoder(cache, stop_id, jax.random.PRNGKey(0))
     assert seen == buffer[0, len(prompt):int(length)].tolist()
 
 
 def test_kv_sample_seeded_and_greedy_matches_kv_decode():
-    config = build_test_config()
-    step_model = Gemma4DecoderStep(config)
+    model, config = build_model()
     prompt = [1, 2, 3]
     stop = config.vocabulary_size - 1
-    greedy = kv_decode(step_model, config, prompt, stop, 6)
+    greedy = kv_decode(model, prompt, stop, 6)
     # top_k=1 sampling reduces to argmax here (no exact ties in float32 logits).
-    peaked = kv_sample(step_model, config, prompt, stop, 6,
+    peaked = kv_sample(model, prompt, stop, 6,
                        jax.random.PRNGKey(0), SamplingArgs(1.0, 1, 1.0))
     assert peaked == greedy
     args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
     key = jax.random.PRNGKey(2)
-    a = kv_sample(step_model, config, prompt, stop, 6, key, args)
-    b = kv_sample(step_model, config, prompt, stop, 6, key, args)
+    a = kv_sample(model, prompt, stop, 6, key, args)
+    b = kv_sample(model, prompt, stop, 6, key, args)
     assert a == b and a[:len(prompt)] == prompt
 
 

--- a/paz/models/foundation/gemma4/gemma4_test.py
+++ b/paz/models/foundation/gemma4/gemma4_test.py
@@ -6,12 +6,13 @@ import numpy as np
 import pytest
 
 from paz.models import Gemma4
-from paz.models.foundation.gemma4 import model
+from paz.models.foundation.gemma4 import pretrained
 from paz.models.foundation.gemma4.tokenizer import Gemma4Tokenizer
 from paz.models.foundation.gemma4.multimodal_decoding import generate_eager
 
-ROOT = Path(__file__).resolve().parents[4]
-WEIGHTS_DIR = ROOT / "examples" / "gemma4" / "weights"
+DEFAULT_WEIGHTS_DIR = (
+    Path.home() / ".keras" / "paz" / "models" / "gemma4" / "gemma4_2b")
+WEIGHTS_DIR = Path(os.environ.get("GEMMA4_WEIGHTS_DIR", DEFAULT_WEIGHTS_DIR))
 
 
 def run_weights_test():
@@ -19,51 +20,52 @@ def run_weights_test():
     # end-to-end check is opt-in via GEMMA4_WEIGHTS_TEST=1 with local weights.
     if os.environ.get("GEMMA4_WEIGHTS_TEST") != "1":
         return False
-    return (WEIGHTS_DIR / "decoder_step.weights.h5").exists()
+    return (WEIGHTS_DIR / "backbone.weights.h5").exists()
 
 
 def test_shard_and_reassemble_round_trips(tmp_path):
     blob = os.urandom(5_000_001)
-    source = tmp_path / "decoder_step.weights.h5"
+    source = tmp_path / "backbone.weights.h5"
     source.write_bytes(blob)
-    parts = model.split_file(source, tmp_path, "gemma4_2b_decoder",
+    parts = pretrained.split_file(source, tmp_path, "gemma4_2b_backbone",
                                   part_bytes=2_000_000)
-    assert parts == ["gemma4_2b_decoder.part0", "gemma4_2b_decoder.part1",
-                     "gemma4_2b_decoder.part2"]
+    assert parts == ["gemma4_2b_backbone.part0", "gemma4_2b_backbone.part1",
+                     "gemma4_2b_backbone.part2"]
     part_paths = [tmp_path / name for name in parts]
     output = tmp_path / "reassembled.h5"
-    model.concatenate_parts(part_paths, output)
+    pretrained.concatenate_parts(part_paths, output)
     assert output.read_bytes() == blob
-    assert model.compute_sha256(output) == model.compute_sha256(source)
+    assert pretrained.compute_sha256(output) == pretrained.compute_sha256(
+        source)
 
 
 def test_shard_weights_writes_manifest(tmp_path):
     source_dir = tmp_path / "weights"
     source_dir.mkdir()
     (source_dir / "config.json").write_text("{}")
-    (source_dir / "decoder_step.weights.h5").write_bytes(os.urandom(3_000_000))
+    (source_dir / "backbone.weights.h5").write_bytes(os.urandom(3_000_000))
     output_dir = tmp_path / "release"
-    manifest_path = model.shard_weights(
+    manifest_path = pretrained.shard_weights(
         source_dir, "gemma4_2b", output_dir, part_bytes=2_000_000)
     manifest = json.loads(manifest_path.read_text())
     assert manifest["config.json"]["parts"] == ["gemma4_2b_config.json.part0"]
-    assert len(manifest["decoder_step.weights.h5"]["parts"]) == 2
-    assert "sha256" in manifest["decoder_step.weights.h5"]
-    decoder = manifest["decoder_step.weights.h5"]
-    paths = [output_dir / asset for asset in decoder["parts"]]
+    assert len(manifest["backbone.weights.h5"]["parts"]) == 2
+    assert "sha256" in manifest["backbone.weights.h5"]
+    backbone = manifest["backbone.weights.h5"]
+    paths = [output_dir / asset for asset in backbone["parts"]]
     merged = output_dir / "merged.h5"
-    model.concatenate_parts(paths, merged)
-    assert model.compute_sha256(merged) == decoder["sha256"]
+    pretrained.concatenate_parts(paths, merged)
+    assert pretrained.compute_sha256(merged) == backbone["sha256"]
 
 
 def test_assemble_detects_corruption(tmp_path, monkeypatch):
     (tmp_path / "part0").write_bytes(os.urandom(2048))
     monkeypatch.setattr(
-        model, "get_file",
+        pretrained, "get_file",
         lambda asset, url, cache_subdir: str(tmp_path / "part0"))
     entry = {"parts": ["part0"], "sha256": "0" * 64}
     with pytest.raises(ValueError):
-        model.assemble_weights_file(tmp_path / "out.h5", entry, "sub")
+        pretrained.assemble_weights_file(tmp_path / "out.h5", entry, "sub")
 
 
 @pytest.mark.skipif(not run_weights_test(), reason="set GEMMA4_WEIGHTS_TEST=1")
@@ -73,7 +75,5 @@ def test_gemma4_generates_capital_of_germany():
     prompt = tokenizer.tokenize_generation_prompt("The capital of Germany is")
     stop = tokenizer.get_stop_token_ids()[-1]
     no_vision = np.zeros((0, models.config.hidden_dim), "float32")
-    args = (models.decoder_step, models.per_layer_step, no_vision,
-            models.config, prompt, [], stop, 16)
-    generated = generate_eager(*args)
+    generated = generate_eager(models.model, no_vision, prompt, [], stop, 16)
     assert "Berlin" in tokenizer.detokenize(generated)

--- a/paz/models/foundation/gemma4/layers/__init__.py
+++ b/paz/models/foundation/gemma4/layers/__init__.py
@@ -1,5 +1,4 @@
-from paz.models.foundation.gemma4.layers.attention import attend
-from paz.models.foundation.gemma4.layers.decoder import decoder_block
+from paz.models.foundation.gemma4.layers.decoder import Gemma4DecoderLayer
 from paz.models.foundation.gemma4.layers.normalization import Gemma4VNorm
 from paz.models.foundation.gemma4.layers.normalization import ScalarMultiply
 from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
@@ -8,8 +7,7 @@ from paz.models.foundation.gemma4.layers.normalization import (
     build_scalar_multiply)
 
 __all__ = [
-    "attend",
-    "decoder_block",
+    "Gemma4DecoderLayer",
     "Gemma4VNorm",
     "ScalarMultiply",
     "build_rms_norm",

--- a/paz/models/foundation/gemma4/layers/attention.py
+++ b/paz/models/foundation/gemma4/layers/attention.py
@@ -1,5 +1,12 @@
+"""Pure attention computation for Gemma4 decoder layers.
+
+These helpers receive already-built sublayers (the projection EinsumDenses and
+their norms) and run the math only: RoPE, GQA reshape, softmax, KV-cache update,
+masking and soft-cap. The layer that owns the sublayers (Gemma4DecoderLayer)
+threads them in; nothing here creates weight-bearing layers.
+"""
 from keras import ops
-from keras.layers import Dropout, EinsumDense, Softmax
+from keras.layers import Dropout, Softmax
 
 from paz.layers import MergeDims, SplitDim
 from paz.models.transformers import cache as kv_cache
@@ -7,69 +14,68 @@ from paz.models.transformers import mask as attention_mask
 from paz.models.transformers.embeddings import rotary
 from paz.models.transformers.logits import soft_cap as apply_soft_cap
 
-from paz.models.foundation.gemma4.layers.normalization import (
-    build_rms_norm, build_v_norm)
+
+def project(x, projection, norm):
+    return norm(projection(x))
 
 
-def attend(x, mask, head_dim, num_query_heads, num_kv_heads, epsilon,
-           wavelength, scaling_factor, partial_rotary, soft_cap, dropout,
-           dtype, name, shared_kv=None):
-    query = project_query(x, num_query_heads, head_dim, epsilon, dtype, name)
-    rope_args = (wavelength, scaling_factor, partial_rotary)
-    query = rotary.apply_partial(query, *rope_args)
-    if shared_kv is not None:
-        key, value = shared_kv[:, 0, ...], shared_kv[:, 1, ...]
-    else:
-        key = project_key(x, num_kv_heads, head_dim, epsilon, dtype, name)
-        value = project_value(x, num_kv_heads, head_dim, epsilon, dtype, name)
-        key = rotary.apply_partial(key, *rope_args)
-    kv = ops.stack((key, value), axis=1)
-    args = (query, key, value, mask, num_query_heads, num_kv_heads, head_dim,
-            soft_cap, dropout, dtype, name)
-    output = compute_attention(*args)
-    output = zero_masked_positions(output, mask)
-    return project_output(output, x.shape[-1], dtype, name), kv
+def apply_rope(x, wavelength, scaling_factor, partial_rotary, positions=None):
+    return rotary.apply_partial(
+        x, wavelength, scaling_factor, partial_rotary, positions)
 
 
-def cached_attend(x, cache, index, head_dim, num_query_heads, num_kv_heads,
-                  epsilon, wavelength, scaling_factor, partial_rotary, soft_cap,
-                  dtype, name, cache_head_dim, window, positions,
-                  shared_kv_cache=None):
-    """Single-step cached attention.
+def compute_attention(query, key, value, mask, num_query_heads, num_kv_heads,
+                      head_dim, soft_cap, dropout, dtype, name):
+    query = reshape_query(query, num_query_heads, num_kv_heads, head_dim)
+    logits = ops.einsum("btkgh,bskh->bkgts", query, key)
+    logits = apply_soft_cap(logits, soft_cap)
+    if mask is not None:
+        mask = mask[:, None, None, :, :]
+    softmax = Softmax(dtype="float32", name="{}_softmax".format(name))
+    weights = ops.cast(softmax(logits, mask=mask), logits.dtype)
+    drop = build_dropout(dropout, dtype, name)
+    if drop is not None:
+        weights = drop(weights)
+    output = ops.einsum("bkgts,bskh->btkgh", weights, value)
+    return MergeDims(axis=-3)(output)
 
-    When shared_kv_cache is provided (kv_shared layers), K/V are read from
-    that cache instead of being projected from x.
-    """
-    cache_head_dim = cache_head_dim or head_dim
-    query = project_query(x, num_query_heads, head_dim, epsilon, dtype, name)
-    cache_positions = build_cache_positions(index, positions)
-    rope_args = (wavelength, scaling_factor, partial_rotary, cache_positions)
-    query = rotary.apply_partial(query, *rope_args)
-    if shared_kv_cache is not None:
-        kv_src = shared_kv_cache
-        updated_cache = cache
-    else:
-        key = project_key(x, num_kv_heads, head_dim, epsilon, dtype, name)
-        value = project_value(x, num_kv_heads, head_dim, epsilon, dtype, name)
-        key = rotary.apply_partial(key, *rope_args)
-        key = ops.cast(key, dtype)
-        value = ops.cast(value, dtype)
-        if head_dim < cache_head_dim:
-            key = pad_to_cache_dim(key, cache_head_dim - head_dim)
-            value = pad_to_cache_dim(value, cache_head_dim - head_dim)
-        updated_cache = kv_cache.update(cache, index, key, value)
-        kv_src = updated_cache
-    full_key, full_value = ops.split(kv_src, 2, axis=1)
-    full_key = ops.squeeze(full_key, axis=1)
-    full_value = ops.squeeze(full_value, axis=1)
+
+def build_dropout(rate, dtype, name):
+    if not rate:
+        return None
+    return Dropout(rate, dtype=dtype, name="{}_dropout".format(name))
+
+
+def reshape_query(query, num_query_heads, num_kv_heads, head_dim):
+    group_size = num_query_heads // num_kv_heads
+    return SplitDim(axis=-2, sizes=(num_kv_heads, group_size))(query)
+
+
+def zero_masked_positions(output, mask):
+    if mask is None:
+        return output
+    no_tokens = ops.all(ops.equal(mask, 0), axis=-1, keepdims=True)
+    zeros = ops.zeros_like(output)
+    return ops.where(no_tokens[..., None], zeros, output)
+
+
+def update_kv_cache(cache, index, key, value, head_dim, cache_head_dim):
+    key = ops.cast(key, cache.dtype)
+    value = ops.cast(value, cache.dtype)
     if head_dim < cache_head_dim:
-        full_key = full_key[..., :head_dim]
-        full_value = full_value[..., :head_dim]
-    mask = build_cache_mask(full_key, index, positions, window)
-    args = (query, full_key, full_value, mask, num_query_heads, num_kv_heads,
-            head_dim, soft_cap, 0.0, dtype, name)
-    output = compute_attention(*args)
-    return project_output(output, x.shape[-1], dtype, name), updated_cache
+        key = pad_to_cache_dim(key, cache_head_dim - head_dim)
+        value = pad_to_cache_dim(value, cache_head_dim - head_dim)
+    return kv_cache.update(cache, index, key, value)
+
+
+def read_kv_cache(kv_source, head_dim, cache_head_dim):
+    key, value = ops.split(kv_source, 2, axis=1)
+    key = ops.squeeze(key, axis=1)
+    value = ops.squeeze(value, axis=1)
+    if head_dim < cache_head_dim:
+        key = key[..., :head_dim]
+        value = value[..., :head_dim]
+    return key, value
 
 
 def pad_to_cache_dim(tensor, pad_size):
@@ -101,73 +107,3 @@ def query_positions(index, positions):
 def build_cache_positions(index, positions):
     transposed = ops.transpose(query_positions(index, positions))
     return ops.cast(transposed, "float32")
-
-
-def project_query(x, num_heads, head_dim, epsilon, dtype, name):
-    shape = (None, num_heads, head_dim)
-    equation = "btd,ndh->btnh"
-    proj_name = "{}_query".format(name)
-    proj = EinsumDense(equation, shape, dtype=dtype, name=proj_name)
-    norm = build_rms_norm(epsilon, dtype, "{}_query_norm".format(name))
-    return norm(proj(x))
-
-
-def project_key(x, num_kv_heads, head_dim, epsilon, dtype, name):
-    shape = (None, num_kv_heads, head_dim)
-    equation = "btd,kdh->btkh"
-    proj_name = "{}_key".format(name)
-    proj = EinsumDense(equation, shape, dtype=dtype, name=proj_name)
-    norm = build_rms_norm(epsilon, dtype, "{}_key_norm".format(name))
-    return norm(proj(x))
-
-
-def project_value(x, num_kv_heads, head_dim, epsilon, dtype, name):
-    shape = (None, num_kv_heads, head_dim)
-    equation = "btd,kdh->btkh"
-    proj_name = "{}_value".format(name)
-    proj = EinsumDense(equation, shape, dtype=dtype, name=proj_name)
-    norm = build_v_norm(epsilon, dtype, "{}_value_norm".format(name))
-    return norm(proj(x))
-
-
-def compute_attention(query, key, value, mask, num_query_heads, num_kv_heads,
-                      head_dim, soft_cap, dropout, dtype, name):
-    query = reshape_query(query, num_query_heads, num_kv_heads, head_dim)
-    logits = ops.einsum("btkgh,bskh->bkgts", query, key)
-    logits = apply_soft_cap(logits, soft_cap)
-    if mask is not None:
-        mask = mask[:, None, None, :, :]
-    softmax = Softmax(dtype="float32", name="{}_softmax".format(name))
-    weights = ops.cast(softmax(logits, mask=mask), logits.dtype)
-    drop = build_dropout(dropout, dtype, name)
-    if drop is not None:
-        weights = drop(weights)
-    output = ops.einsum("bkgts,bskh->btkgh", weights, value)
-    return MergeDims(axis=-3)(output)
-
-
-def project_output(output, output_dim, dtype, name):
-    shape = (None, output_dim)
-    proj_name = "{}_attention_output".format(name)
-    proj = EinsumDense("btnh,nhd->btd", shape, dtype=dtype, name=proj_name)
-    return proj(output)
-
-
-def zero_masked_positions(output, mask):
-    if mask is None:
-        return output
-    no_tokens = ops.all(ops.equal(mask, 0), axis=-1, keepdims=True)
-    zeros = ops.zeros_like(output)
-    return ops.where(no_tokens[..., None], zeros, output)
-
-
-def reshape_query(query, num_query_heads, num_kv_heads, head_dim):
-    group_size = num_query_heads // num_kv_heads
-    sizes = (num_kv_heads, group_size)
-    return SplitDim(axis=-2, sizes=sizes)(query)
-
-
-def build_dropout(rate, dtype, name):
-    if not rate:
-        return None
-    return Dropout(rate, dtype=dtype, name="{}_dropout".format(name))

--- a/paz/models/foundation/gemma4/layers/decoder.py
+++ b/paz/models/foundation/gemma4/layers/decoder.py
@@ -1,183 +1,222 @@
 import keras
-from keras.layers import Dropout, EinsumDense
+from keras import ops
+from keras.layers import EinsumDense, Layer
 
 from paz.models.foundation.gemma4.configuration import (
     build_cache_head_dim, build_feedforward_dim, build_head_dim,
     build_partial_rotary_factor, build_rope_scaling_factor,
     build_rope_wavelength, is_global_attention_layer, use_sliding_window)
 from paz.models.transformers.numerics import add_residual, clip_float16
-from paz.models.foundation.gemma4.layers.attention import attend, cached_attend
+from paz.models.foundation.gemma4.configuration import TextBackboneArgs
+from paz.models.foundation.gemma4.layers import attention as attend_ops
 from paz.models.foundation.gemma4.layers.core import build_attention_mask
 from paz.models.foundation.gemma4.layers.normalization import (
-    build_rms_norm, build_scalar_multiply)
+    build_rms_norm, build_scalar_multiply, build_v_norm)
 
 
-def decoder_block(x, padding_mask, config, layer_index, name,
-                  per_layer_embedding=None, shared_kv=None):
-    dtype = keras.backend.standardize_dtype(x.dtype)
-    if dtype == "float16":
-        x = clip_float16(x)
-    hidden, kv = attention_path(
-        x, padding_mask, config, layer_index, name, shared_kv=shared_kv)
-    hidden = feedforward_path(hidden, config, name, layer_index=layer_index)
-    # Per-layer input applied AFTER FFW, BEFORE layer scalar.
-    if per_layer_embedding is not None:
-        hidden = per_layer_input_path(
-            hidden, per_layer_embedding, config, name)
-    scaled = build_scalar_multiply("{}_layer_scalar".format(name))(hidden)
-    return scaled, kv
+@keras.saving.register_keras_serializable(package="gemma4")
+class Gemma4DecoderLayer(Layer):
+    """One Gemma4 transformer block owning its sublayers.
+
+    `call` runs the full-sequence forward; `call_with_cache` runs the cached
+    single/multi-step forward. Both thread the owned sublayers into the pure
+    helpers in `attention.py`; the transformer math is shared, not duplicated.
+    """
+
+    def __init__(self, config, layer_index, **kwargs):
+        super().__init__(**kwargs)
+        self.config = config
+        self.layer_index = layer_index
+        self.is_global = is_global_attention_layer(config, layer_index)
+        self.head_dim = build_head_dim(config, self.is_global)
+        self.cache_head_dim = build_cache_head_dim(config)
+        self.wavelength = build_rope_wavelength(config, self.is_global)
+        self.scaling_factor = build_rope_scaling_factor(config, self.is_global)
+        self.partial_rotary = build_partial_rotary_factor(
+            config, self.is_global)
+        self.window = window_size(config, self.is_global)
+        self.feedforward_dim = build_feedforward_dim(config, layer_index)
+        self.has_per_layer = bool(config.hidden_size_per_layer_input)
+        self.build_attention_layers()
+        self.build_feedforward_layers()
+        if self.has_per_layer:
+            self.build_per_layer_layers()
+        self.layer_scalar = build_scalar_multiply("layer_scalar")
+
+    def build_attention_layers(self):
+        config, head_dim = self.config, self.head_dim
+        epsilon, dtype = config.layer_norm_epsilon, config.dtype
+        self.pre_attention_norm = build_rms_norm(
+            epsilon, dtype, "pre_attention_norm")
+        self.query_proj = head_projection(
+            "btd,ndh->btnh", config.num_query_heads, head_dim, dtype,
+            "attention_query")
+        self.query_norm = build_rms_norm(epsilon, dtype, "attention_query_norm")
+        self.key_proj = head_projection(
+            "btd,kdh->btkh", config.num_key_value_heads, head_dim, dtype,
+            "attention_key")
+        self.key_norm = build_rms_norm(epsilon, dtype, "attention_key_norm")
+        self.value_proj = head_projection(
+            "btd,kdh->btkh", config.num_key_value_heads, head_dim, dtype,
+            "attention_value")
+        self.value_norm = build_v_norm(epsilon, dtype, "attention_value_norm")
+        self.output_proj = dense(
+            "btnh,nhd->btd", config.hidden_dim, dtype, "attention_output")
+        self.post_attention_norm = build_rms_norm(
+            epsilon, dtype, "post_attention_norm")
+
+    def build_feedforward_layers(self):
+        config = self.config
+        epsilon, dtype = config.layer_norm_epsilon, config.dtype
+        self.pre_ffw_norm = build_rms_norm(epsilon, dtype, "pre_ffw_norm")
+        self.ffw_gating = dense(
+            "btd,df->btf", self.feedforward_dim, dtype, "ffw_gating")
+        self.ffw_gating_2 = dense(
+            "btd,df->btf", self.feedforward_dim, dtype, "ffw_gating_2")
+        self.ffw_linear = dense(
+            "btf,fd->btd", config.hidden_dim, dtype, "ffw_linear")
+        self.post_ffw_norm = build_rms_norm(epsilon, dtype, "post_ffw_norm")
+
+    def build_per_layer_layers(self):
+        config = self.config
+        epsilon, dtype = config.layer_norm_epsilon, config.dtype
+        per_layer_dim = config.hidden_size_per_layer_input
+        self.per_layer_gate = dense(
+            "btd,dp->btp", per_layer_dim, dtype, "per_layer_gate")
+        self.per_layer_projection = dense(
+            "btp,pd->btd", config.hidden_dim, dtype, "per_layer_projection")
+        self.post_per_layer_norm = build_rms_norm(
+            epsilon, dtype, "post_per_layer_norm")
+
+    def call(self, x, padding_mask=None, per_layer_embedding=None,
+             shared_kv=None):
+        x = clip_bfloat_guard(x)
+        hidden, kv = self.attention(x, padding_mask, shared_kv)
+        hidden = self.feedforward(hidden)
+        if per_layer_embedding is not None:
+            hidden = self.per_layer_input(hidden, per_layer_embedding)
+        return self.layer_scalar(hidden), kv
+
+    def call_with_cache(self, x, cache, index, positions=None,
+                        per_layer_embedding=None, shared_kv_cache=None):
+        x = clip_bfloat_guard(x)
+        hidden, cache = self.cached_attention(
+            x, cache, index, positions, shared_kv_cache)
+        hidden = self.feedforward(hidden)
+        if per_layer_embedding is not None:
+            hidden = self.per_layer_input(hidden, per_layer_embedding)
+        return self.layer_scalar(hidden), cache
+
+    def attention(self, x, padding_mask, shared_kv):
+        normed = self.pre_attention_norm(x)
+        mask = self.attention_mask(padding_mask)
+        hidden, kv = self.attend(normed, mask, shared_kv)
+        hidden = self.post_attention_norm(hidden)
+        return add_residual(x, hidden), kv
+
+    def attend(self, x, mask, shared_kv):
+        query = self.query_with_rope(x)
+        if shared_kv is not None:
+            key, value = shared_kv[:, 0, ...], shared_kv[:, 1, ...]
+        else:
+            key = self.key_with_rope(x)
+            value = attend_ops.project(x, self.value_proj, self.value_norm)
+        kv = ops.stack((key, value), axis=1)
+        output = self.mix(query, key, value, mask)
+        output = attend_ops.zero_masked_positions(output, mask)
+        return self.output_proj(output), kv
+
+    def cached_attention(self, x, cache, index, positions, shared_kv_cache):
+        normed = self.pre_attention_norm(x)
+        hidden, cache = self.cached_attend(
+            normed, cache, index, positions, shared_kv_cache)
+        hidden = self.post_attention_norm(hidden)
+        return add_residual(x, hidden), cache
+
+    def cached_attend(self, x, cache, index, positions, shared_kv_cache):
+        cache_positions = attend_ops.build_cache_positions(index, positions)
+        query = self.query_with_rope(x, cache_positions)
+        if shared_kv_cache is not None:
+            kv_source, updated_cache = shared_kv_cache, cache
+        else:
+            key = self.key_with_rope(x, cache_positions)
+            value = attend_ops.project(x, self.value_proj, self.value_norm)
+            updated_cache = attend_ops.update_kv_cache(
+                cache, index, key, value, self.head_dim, self.cache_head_dim)
+            kv_source = updated_cache
+        key, value = attend_ops.read_kv_cache(
+            kv_source, self.head_dim, self.cache_head_dim)
+        mask = attend_ops.build_cache_mask(key, index, positions, self.window)
+        output = self.mix(query, key, value, mask)
+        return self.output_proj(output), updated_cache
+
+    def query_with_rope(self, x, positions=None):
+        query = attend_ops.project(x, self.query_proj, self.query_norm)
+        return self.rope(query, positions)
+
+    def key_with_rope(self, x, positions=None):
+        key = attend_ops.project(x, self.key_proj, self.key_norm)
+        return self.rope(key, positions)
+
+    def rope(self, x, positions=None):
+        return attend_ops.apply_rope(
+            x, self.wavelength, self.scaling_factor, self.partial_rotary,
+            positions)
+
+    def mix(self, query, key, value, mask):
+        args = (query, key, value, mask, self.config.num_query_heads,
+                self.config.num_key_value_heads, self.head_dim,
+                self.config.attention_logit_soft_cap, self.config.dropout,
+                self.config.dtype, self.name + "_attention")
+        return attend_ops.compute_attention(*args)
+
+    def attention_mask(self, padding_mask):
+        return build_attention_mask(
+            padding_mask, self.config.use_bidirectional_attention, self.window)
+
+    def feedforward(self, x):
+        hidden = self.pre_ffw_norm(x)
+        gate = keras.activations.gelu(self.ffw_gating(hidden), approximate=True)
+        hidden = self.ffw_linear(gate * self.ffw_gating_2(hidden))
+        hidden = self.post_ffw_norm(hidden)
+        return add_residual(x, hidden)
+
+    def per_layer_input(self, x, per_layer_embedding):
+        gate = keras.activations.gelu(
+            self.per_layer_gate(x), approximate=True)
+        hidden = self.per_layer_projection(gate * per_layer_embedding)
+        hidden = self.post_per_layer_norm(hidden)
+        return add_residual(x, hidden)
+
+    def get_config(self):
+        config = super().get_config()
+        config["config"] = self.config._asdict()
+        config["layer_index"] = self.layer_index
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        config = dict(config)
+        config["config"] = TextBackboneArgs(**config["config"])
+        return cls(**config)
 
 
-def per_layer_input_path(x, per_layer_embed, config, name):
-    epsilon, dtype = config.layer_norm_epsilon, config.dtype
-    per_layer_dim = config.hidden_size_per_layer_input
-    gate_name = "{}_per_layer_gate".format(name)
-    gate = keras.activations.gelu(
-        build_einsum_dense("btd,dp->btp", per_layer_dim, dtype, gate_name)(x),
-        approximate=True)
-    hidden = gate * per_layer_embed
-    proj_name = "{}_per_layer_projection".format(name)
-    hidden = build_einsum_dense(
-        "btp,pd->btd", config.hidden_dim, dtype, proj_name)(hidden)
-    norm_name = "{}_post_per_layer_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, norm_name)(hidden)
-    return add_residual(x, hidden)
-
-
-def attention_path(x, padding_mask, config, layer_index, name,
-                   shared_kv=None):
-    epsilon, dtype = config.layer_norm_epsilon, config.dtype
-    norm_name = "{}_pre_attention_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
-    mask = build_block_attention_mask(padding_mask, config, layer_index)
-    attention_args = build_attend_args(hidden, mask, config, layer_index, name)
-    hidden, kv = attend(*attention_args, shared_kv=shared_kv)
-    post_name = "{}_post_attention_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
-    if config.dropout:
-        drop_name = "{}_attention_dropout".format(name)
-        hidden = Dropout(config.dropout, dtype=dtype, name=drop_name)(hidden)
-    return add_residual(x, hidden), kv
-
-
-def feedforward_path(x, config, name, layer_index=None):
-    epsilon, dtype = config.layer_norm_epsilon, config.dtype
-    feedforward_dim = (build_feedforward_dim(config, layer_index)
-                       if layer_index is not None else config.intermediate_dim)
-    pre_name = "{}_pre_ffw_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, pre_name)(x)
-    up_equation = "btd,df->btf"
-    gate_name = "{}_ffw_gating".format(name)
-    gate = build_einsum_dense(
-        up_equation, feedforward_dim, dtype, gate_name)(hidden)
-    gate_2_name = "{}_ffw_gating_2".format(name)
-    value = build_einsum_dense(
-        up_equation, feedforward_dim, dtype, gate_2_name)(hidden)
-    hidden = keras.activations.gelu(gate, approximate=True) * value
-    down_equation = "btf,fd->btd"
-    linear_name = "{}_ffw_linear".format(name)
-    layer = build_einsum_dense(
-        down_equation, config.hidden_dim, dtype, linear_name)
-    hidden = layer(hidden)
-    post_name = "{}_post_ffw_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
-    if config.dropout:
-        drop_name = "{}_ffw_dropout".format(name)
-        hidden = Dropout(config.dropout, dtype=dtype, name=drop_name)(hidden)
-    return add_residual(x, hidden)
-
-
-def build_block_attention_mask(padding_mask, config, layer_index):
-    is_global = is_global_attention_layer(config, layer_index)
-    window = None
+def window_size(config, is_global):
     if use_sliding_window(config, is_global):
-        window = config.sliding_window_size
-    return build_attention_mask(
-        padding_mask, config.use_bidirectional_attention, window)
+        return config.sliding_window_size
+    return None
 
 
-def build_attend_args(hidden, mask, config, layer_index, name):
-    is_global = is_global_attention_layer(config, layer_index)
-    attention_name = "{}_attention".format(name)
-    return (
-        hidden,
-        mask,
-        build_head_dim(config, is_global),
-        config.num_query_heads,
-        config.num_key_value_heads,
-        config.layer_norm_epsilon,
-        build_rope_wavelength(config, is_global),
-        build_rope_scaling_factor(config, is_global),
-        build_partial_rotary_factor(config, is_global),
-        config.attention_logit_soft_cap,
-        config.dropout,
-        config.dtype,
-        attention_name,
-    )
+def clip_bfloat_guard(x):
+    if keras.backend.standardize_dtype(x.dtype) == "float16":
+        return clip_float16(x)
+    return x
 
 
-def cached_decoder_block(x, cache, cache_index, config,
-                          layer_index, name,
-                          per_layer_embedding=None,
-                          shared_kv_cache=None, positions=None):
-    dtype = keras.backend.standardize_dtype(x.dtype)
-    if dtype == "float16":
-        x = clip_float16(x)
-    hidden, cache = cached_attention_path(
-        x, cache, cache_index, config, layer_index, name,
-        shared_kv_cache=shared_kv_cache, positions=positions)
-    hidden = feedforward_path(
-        hidden, config, name, layer_index=layer_index)
-    # Per-layer input applied AFTER FFW, BEFORE layer scalar.
-    if per_layer_embedding is not None:
-        hidden = per_layer_input_path(
-            hidden, per_layer_embedding, config, name)
-    scaled = build_scalar_multiply(
-        "{}_layer_scalar".format(name))(hidden)
-    return scaled, cache
-
-
-def cached_attention_path(x, cache, cache_index, config, layer_index, name,
-                           shared_kv_cache=None, positions=None):
-    epsilon, dtype = config.layer_norm_epsilon, config.dtype
-    norm_name = "{}_pre_attention_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, norm_name)(x)
-    attention_args = build_cached_attend_args(
-        hidden, cache, cache_index, config, layer_index, name, positions)
-    hidden, cache = cached_attend(
-        *attention_args, shared_kv_cache=shared_kv_cache)
-    post_name = "{}_post_attention_norm".format(name)
-    hidden = build_rms_norm(epsilon, dtype, post_name)(hidden)
-    return add_residual(x, hidden), cache
-
-
-def build_cached_attend_args(hidden, cache, index, config, layer_index, name,
-                             positions=None):
-    is_global = is_global_attention_layer(config, layer_index)
-    window = None
-    if use_sliding_window(config, is_global):
-        window = config.sliding_window_size
-    attention_name = "{}_attention".format(name)
-    return (
-        hidden,
-        cache,
-        index,
-        build_head_dim(config, is_global),
-        config.num_query_heads,
-        config.num_key_value_heads,
-        config.layer_norm_epsilon,
-        build_rope_wavelength(config, is_global),
-        build_rope_scaling_factor(config, is_global),
-        build_partial_rotary_factor(config, is_global),
-        config.attention_logit_soft_cap,
-        config.dtype,
-        attention_name,
-        build_cache_head_dim(config),
-        window,
-        positions,
-    )
-
-
-def build_einsum_dense(equation, output_dim, dtype, name):
-    shape = (None, output_dim)
+def head_projection(equation, num_heads, head_dim, dtype, name):
+    shape = (None, num_heads, head_dim)
     return EinsumDense(equation, shape, dtype=dtype, name=name)
+
+
+def dense(equation, output_dim, dtype, name):
+    return EinsumDense(equation, (None, output_dim), dtype=dtype, name=name)

--- a/paz/models/foundation/gemma4/model.py
+++ b/paz/models/foundation/gemma4/model.py
@@ -1,142 +1,150 @@
-import hashlib
-import json
-import shutil
-from collections import namedtuple
-from pathlib import Path
-
-from keras import Model, ops
+import keras
+from keras import ops
 from keras.initializers import VarianceScaling
-from keras.layers import Embedding, EinsumDense, Input
-from keras.utils import get_file
-from paz.models.transformers.embeddings.reversible import ReversibleEmbedding
+from keras.layers import Embedding, EinsumDense
 
+from paz.models.transformers.embeddings.reversible import ReversibleEmbedding
 from paz.models.transformers import cache as kv_cache
-from paz.models.transformers.logits import soft_cap as apply_soft_cap
 from paz.models.foundation.gemma4.configuration import TextBackboneArgs
 from paz.models.foundation.gemma4.configuration import build_cache_head_dim
 from paz.models.foundation.gemma4.configuration import build_kv_source_map
-from paz.models.foundation.gemma4.configuration import load_config
-from paz.models.foundation.gemma4.layers.decoder import decoder_block
-from paz.models.foundation.gemma4.layers.decoder import cached_decoder_block
+from paz.models.foundation.gemma4.layers.decoder import Gemma4DecoderLayer
 from paz.models.foundation.gemma4.layers.normalization import build_rms_norm
-from paz.models.foundation.gemma4.vision import VisionEncoderArgs
-from paz.models.foundation.gemma4.vision import build_vision_encoder
 
-BACKBONE_NAME = "gemma4_text_backbone"
-TextIntermediates = namedtuple(
-    "TextIntermediates", "embedding_output block_outputs final_output")
+BACKBONE_NAME = "gemma4_backbone"
 
 
-def build_text_backbone_args(**overrides):
-    values = {
-        "vocabulary_size": 256,
-        "image_size": 8,
-        "num_layers": 2,
-        "num_query_heads": 2,
-        "num_key_value_heads": 1,
-        "hidden_dim": 8,
-        "intermediate_dim": 16,
-        "head_dim": 4,
-        "attention_logit_soft_cap": None,
-        "final_logit_soft_cap": None,
-        "use_sliding_window_attention": True,
-        "sliding_window_size": 16,
-        "sliding_window_pattern": 6,
-        "global_head_dim": None,
-        "local_rope_wavelength": 10_000.0,
-        "global_rope_wavelength": 1_000_000.0,
-        "local_rope_scaling_factor": 1.0,
-        "global_rope_scaling_factor": 1.0,
-        "global_rope_partial_rotary_factor": 1.0,
-        "use_bidirectional_attention": False,
-        "layer_norm_epsilon": 1e-6,
-        "dropout": 0.0,
-        "dtype": "float32",
-        "hidden_size_per_layer_input": None,
-        "num_kv_shared_layers": 0,
-        "global_layer_indices": None,
-        "use_double_wide_mlp": False,
-    }
-    values.update(overrides)
-    return TextBackboneArgs(**values)
+@keras.saving.register_keras_serializable(package="gemma4")
+class Gemma4Backbone(keras.Model):
+    """Subclassed Gemma4 text backbone owning all transformer weights once.
+
+    `call({token_ids, padding_mask})` is the full-sequence forward.
+    `call_with_cache(input_embedding, cache, index, ...)` is the cached
+    single/multi-step forward used for generation. Both share the same owned
+    decoder layers, token embedding and per-layer embedding table.
+    """
+
+    def __init__(self, config, name=BACKBONE_NAME, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.config = config
+        self.has_per_layer = bool(config.hidden_size_per_layer_input)
+        self.kv_source_map = build_kv_source_map(config)
+        self.token_embedding = build_token_embedding(
+            config.vocabulary_size, config.hidden_dim, config.dtype)
+        self.decoder_layers = build_decoder_layers(config)
+        self.final_normalization = build_rms_norm(
+            config.layer_norm_epsilon, config.dtype, "final_normalization")
+        if self.has_per_layer:
+            self.build_per_layer_embedding()
+
+    def build_per_layer_embedding(self):
+        config = self.config
+        dim = config.hidden_size_per_layer_input * config.num_layers
+        self.per_layer_embeddings = build_per_layer_embedding(
+            config.vocabulary_size, dim, config.dtype)
+        self.per_layer_model_projection = EinsumDense(
+            "btd,dn->btn", (None, dim), dtype=config.dtype,
+            name="per_layer_model_projection")
+        self.per_layer_projection_norm = build_rms_norm(
+            config.layer_norm_epsilon, config.dtype,
+            "per_layer_projection_norm")
+
+    def call(self, inputs):
+        token_ids, padding_mask = inputs["token_ids"], inputs["padding_mask"]
+        embedding = self.token_embedding(token_ids)
+        return self.forward_from_embedding(embedding, padding_mask, token_ids)
+
+    def forward_from_embedding(self, embedding, padding_mask, token_ids):
+        per_layer = self.per_layer_inputs(
+            embedding, self.per_layer_lookup(token_ids))
+        hidden = scale_embeddings(embedding, self.config.hidden_dim)
+        hidden = self.run_layers(hidden, padding_mask, per_layer)
+        return self.final_normalization(hidden)
+
+    def run_layers(self, hidden, padding_mask, per_layer):
+        layer_kvs = []
+        for index, layer in enumerate(self.decoder_layers):
+            shared = self.shared_kv(layer_kvs, index)
+            hidden, kv = layer(hidden, padding_mask=padding_mask,
+                               per_layer_embedding=per_layer[index],
+                               shared_kv=shared)
+            layer_kvs.append(kv)
+        return hidden
+
+    def shared_kv(self, layer_kvs, index):
+        source = self.kv_source_map.get(index)
+        return layer_kvs[source] if source is not None else None
+
+    def call_with_cache(self, input_embedding, cache, index, positions=None,
+                        per_layer_full=None):
+        per_layer = self.per_layer_inputs(input_embedding, per_layer_full)
+        hidden = scale_embeddings(input_embedding, self.config.hidden_dim)
+        hidden, updated = self.run_cached_layers(
+            hidden, cache, index, positions, per_layer)
+        updated = ops.cast(updated, self.config.dtype)
+        return self.final_normalization(hidden), updated
+
+    def run_cached_layers(self, hidden, cache, index, positions, per_layer):
+        updated_caches = []
+        for i, layer in enumerate(self.decoder_layers):
+            shared = self.shared_kv_cache(updated_caches, i)
+            hidden, layer_cache = layer.call_with_cache(
+                hidden, cache[:, i, ...], index, positions=positions,
+                per_layer_embedding=per_layer[i], shared_kv_cache=shared)
+            updated_caches.append(ops.expand_dims(layer_cache, axis=1))
+        return hidden, ops.concatenate(updated_caches, axis=1)
+
+    def shared_kv_cache(self, updated_caches, index):
+        source = self.kv_source_map.get(index)
+        if source is None:
+            return None
+        return ops.squeeze(updated_caches[source], axis=1)
+
+    def per_layer_lookup(self, token_ids):
+        if not self.has_per_layer:
+            return None
+        embedding = self.per_layer_embeddings(token_ids)
+        dim = self.config.hidden_size_per_layer_input
+        return scale_per_layer_embedding(embedding, dim, self.config.dtype)
+
+    def per_layer_inputs(self, unscaled_embedding, per_layer_full):
+        if not self.has_per_layer or per_layer_full is None:
+            return [None] * self.config.num_layers
+        projection = self.per_layer_model_projection(unscaled_embedding)
+        return self.combine_per_layer(projection, per_layer_full)
+
+    def combine_per_layer(self, projection_full, embedding_full):
+        dim = self.config.hidden_size_per_layer_input
+        scale = ops.cast(2 ** -0.5, self.config.dtype)
+        inputs = []
+        for index in range(self.config.num_layers):
+            projection = slice_per_layer(projection_full, index, dim)
+            embedding = slice_per_layer(embedding_full, index, dim)
+            normed = self.per_layer_projection_norm(projection)
+            inputs.append((normed + embedding) * scale)
+        return inputs
+
+    def build_cache(self, max_length, batch_size=1):
+        return build_empty_cache(self.config, max_length, batch_size)
+
+    def get_config(self):
+        config = super().get_config()
+        config["config"] = self.config._asdict()
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        config = dict(config)
+        config["config"] = TextBackboneArgs(**config["config"])
+        return cls(**config)
 
 
-def build_text_backbone(config, weights_path=None, name=BACKBONE_NAME):
-    token_embedding = build_token_embedding(
-        config.vocabulary_size, config.hidden_dim, config.dtype)
-    token_ids = Input((None,), dtype="int32", name="token_ids")
-    padding_mask = Input((None,), dtype="int32", name="padding_mask")
-    embedding = token_embedding(token_ids)
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
-    return build_backbone_from_embedding(
-        embedding, token_ids, padding_mask, inputs, config, name, weights_path)
-
-
-def build_backbone_from_embedding(embedding, token_ids, padding_mask, inputs,
-                                  config, name, weights_path=None):
-    hidden = scale_token_embeddings(embedding, config.hidden_dim)
-    embedding_output = hidden
-    per_layer = build_backbone_per_layer_embeddings(
-        config, token_ids, embedding)
-    kv_source = build_kv_source_map(config)
-    block_outputs, layer_kvs = [], []
-    for layer_index in range(config.num_layers):
-        block_name = "decoder_block_{}".format(layer_index)
-        source = kv_source.get(layer_index)
-        shared_kv = layer_kvs[source] if source is not None else None
-        args = (hidden, padding_mask, config, layer_index, block_name)
-        kwargs = {"per_layer_embedding": per_layer[layer_index],
-                  "shared_kv": shared_kv}
-        hidden, kv = decoder_block(*args, **kwargs)
-        block_outputs.append(hidden)
-        layer_kvs.append(kv)
-    norm_args = (config.layer_norm_epsilon, config.dtype,
-                 "final_normalization")
-    final_output = build_rms_norm(*norm_args)(hidden)
-    model = Model(inputs, final_output, name=name)
-    attach_intermediates(model, embedding_output, block_outputs, final_output)
-    if weights_path is not None:
-        model.load_weights(str(Path(weights_path)))
-    return model
-
-
-def build_backbone_per_layer_embeddings(config, token_ids, token_embedding):
-    if not config.hidden_size_per_layer_input:
-        return [None] * config.num_layers
-    p = config.hidden_size_per_layer_input
-    embedding = build_per_layer_embedding(
-        config.vocabulary_size, p * config.num_layers, config.dtype)
-    full_embedding = embedding(token_ids)
-    full_embedding = scale_per_layer_embedding(full_embedding, p, config.dtype)
-    projection = build_per_layer_model_projection(
-        token_embedding, config.num_layers, p, config.dtype)
-    args = (projection, full_embedding, config.num_layers, p,
-            config.layer_norm_epsilon, config.dtype)
-    return build_per_layer_combined_inputs(*args)
-
-
-def scale_per_layer_embedding(full_embedding, per_layer_dim, dtype):
-    scale = ops.cast(float(per_layer_dim) ** 0.5, dtype)
-    return ops.cast(full_embedding, dtype) * scale
-
-
-def attach_intermediates(model, embedding_output, block_outputs, final_output):
-    model._embedding_output = embedding_output
-    model._block_outputs = tuple(block_outputs)
-    model._final_output = final_output
-
-
-def compute_text_intermediates(model, token_ids, padding_mask):
-    outputs = [model._embedding_output]
-    outputs.extend(model._block_outputs)
-    outputs.append(model._final_output)
-    debug = Model(model.input, outputs, name="debug_intermediates")
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
-    results = debug(inputs)
-    embedding_output = results[0]
-    block_outputs = tuple(results[1:-1])
-    final_output = results[-1]
-    return TextIntermediates(embedding_output, block_outputs, final_output)
+def build_decoder_layers(config):
+    layers = []
+    for index in range(config.num_layers):
+        name = "decoder_block_{}".format(index)
+        layers.append(Gemma4DecoderLayer(config, index, name=name))
+    return layers
 
 
 def build_token_embedding(vocabulary_size, hidden_dim, dtype):
@@ -147,19 +155,21 @@ def build_token_embedding(vocabulary_size, hidden_dim, dtype):
     return ReversibleEmbedding(vocabulary_size, hidden_dim, **kwargs)
 
 
-def scale_token_embeddings(hidden, hidden_dim):
-    scale = ops.cast(hidden_dim ** 0.5, hidden.dtype)
-    return hidden * scale
-
-
 def build_per_layer_embedding(vocabulary_size, dim, dtype):
-    # Use zeros initializer to avoid a large float32 temporary buffer
-    # during construction (relevant when vocab_size is large).
-    # Pre-trained weights are always loaded from file, so the initial
-    # values do not matter.
+    # Zeros initializer avoids a large float32 temporary during construction;
+    # pretrained weights are always loaded from file afterwards.
     return Embedding(vocabulary_size, dim, dtype=dtype,
                      embeddings_initializer="zeros",
                      name="per_layer_embeddings")
+
+
+def scale_embeddings(hidden, hidden_dim):
+    return hidden * ops.cast(hidden_dim ** 0.5, hidden.dtype)
+
+
+def scale_per_layer_embedding(full_embedding, per_layer_dim, dtype):
+    scale = ops.cast(float(per_layer_dim) ** 0.5, dtype)
+    return ops.cast(full_embedding, dtype) * scale
 
 
 def slice_per_layer(tensor, layer_index, per_layer_dim):
@@ -168,360 +178,29 @@ def slice_per_layer(tensor, layer_index, per_layer_dim):
     return tensor[..., start:end]
 
 
-def build_per_layer_model_projection(hidden, num_layers, per_layer_dim, dtype):
-    """Project initial hidden state to (num_layers * per_layer_dim) dimensions.
-
-    This is the 'model projection' component of the per-layer input — it
-    provides a context-dependent conditioning signal derived from the scaled
-    token embedding (before any decoder blocks).
-    """
-    combined_dim = num_layers * per_layer_dim
-    equation = "btd,dn->btn"
-    name = "per_layer_model_projection"
-    projection = EinsumDense(
-        equation, (None, combined_dim), dtype=dtype, name=name)
-    return projection(hidden)
-
-
-def combine_projection_and_embedding(projection, embedding, scale):
-    return (projection + embedding) * scale
-
-
-def build_per_layer_combined_inputs(projection_full, embedding_full,
-                                     num_layers, per_layer_dim,
-                                     epsilon, dtype):
-    """Combine per-layer projection and token embedding.
-
-    For each layer i:
-        per_layer_i = (rms_norm(proj_i) + embedding_i) * 2^-0.5
-
-    The projection norm is shared across all layers.
-    """
-    projection_norm = build_rms_norm(
-        epsilon, dtype, "per_layer_projection_norm")
-    scale = ops.cast(2 ** -0.5, dtype)
-    inputs = []
-    for layer_index in range(num_layers):
-        projection = slice_per_layer(
-            projection_full, layer_index, per_layer_dim)
-        embedding = slice_per_layer(embedding_full, layer_index, per_layer_dim)
-        normed = projection_norm(projection)
-        combined = combine_projection_and_embedding(normed, embedding, scale)
-        inputs.append(combined)
-    return inputs
-
-
-def Gemma4PerLayerEmbeddingStep(
-        config, name="gemma4_per_layer_embedding_step"):
-    """Per-layer embedding lookup only (4.7 GB for E2B).
-
-    Kept as a separate Keras model so it can be built and loaded
-    before Gemma4DecoderStep.  Loading the large embedding table in
-    isolation (peak ~9.4 GB) avoids the ~14 GB peak that would occur
-    if it were part of the full 9.27 GB decoder step model.
-
-    Output shape: (batch, 1, num_layers * hidden_size_per_layer_input).
-    The output is pre-scaled by sqrt(hidden_size_per_layer_input).
-
-    Pass this output directly as the per_layer_full_embedding input
-    of Gemma4DecoderStep.
-    """
-    p = config.hidden_size_per_layer_input
-    token_ids = Input((1,), dtype="int32", name="token_ids")
-    per_layer_embedding = build_per_layer_embedding(
-        config.vocabulary_size, p * config.num_layers, config.dtype)
-    full_embedding = per_layer_embedding(token_ids)
-    full_embedding = scale_per_layer_embedding(
-        full_embedding, p, config.dtype)
-    return Model(token_ids, full_embedding, name=name)
-
-
-def Gemma4DecoderStep(config, name="gemma4_decoder_step"):
-    cache, cache_index = build_cache_inputs(config)
-    token_ids = Input((1,), dtype="int32", name="token_ids")
-    embedding = build_token_embedding(
-        config.vocabulary_size, config.hidden_dim, config.dtype)
-    hidden = embedding(token_ids)
-    per_layer = build_per_layer_input(config)
-    outputs = build_cached_step(
-        hidden, embedding, cache, cache_index, per_layer, config)
-    inputs = [token_ids, cache, cache_index]
-    if per_layer is not None:
-        inputs.append(per_layer)
-    return Model(inputs, list(outputs), name=name)
-
-
-def Gemma4MultimodalDecoderStep(
-        config, name="gemma4_multimodal_decoder_step"):
-    """Cached decoder step fed a precomputed (unscaled) input embedding.
-
-    Image positions feed the vision embedding (pre-scaled by hidden_dim**-0.5);
-    text positions feed the token embedding. Otherwise identical to
-    Gemma4DecoderStep.
-    """
-    cache, cache_index = build_cache_inputs(config)
-    input_embedding = Input(
-        (None, config.hidden_dim), dtype=config.dtype, name="input_embedding")
-    positions = Input((None,), dtype="int32", name="positions")
-    embedding = build_token_embedding(
-        config.vocabulary_size, config.hidden_dim, config.dtype)
-    per_layer = None
-    if config.hidden_size_per_layer_input:
-        dim = config.hidden_size_per_layer_input * config.num_layers
-        per_layer = Input(
-            (None, dim), dtype=config.dtype, name="per_layer_full_embedding")
-    outputs = build_cached_step(
-        input_embedding, embedding, cache, cache_index, per_layer, config,
-        positions=positions)
-    inputs = [input_embedding, cache, cache_index, positions]
-    if per_layer is not None:
-        inputs.append(per_layer)
-    return Model(inputs, list(outputs), name=name)
-
-
-def build_cache_inputs(config):
-    cache_head_dim = build_cache_head_dim(config)
-    cache_shape = (config.num_layers, 2, None,
-                   config.num_key_value_heads, cache_head_dim)
-    cache = Input(cache_shape, dtype=config.dtype, name="self_attention_cache")
-    cache_index = Input((), dtype="int32", name="cache_update_index")
-    return cache, cache_index
-
-
-def build_per_layer_input(config):
-    if not config.hidden_size_per_layer_input:
-        return None
-    dim = config.hidden_size_per_layer_input * config.num_layers
-    return Input((1, dim), dtype=config.dtype, name="per_layer_full_embedding")
-
-
-def build_cached_step(hidden, embedding, cache, cache_index, per_layer, config,
-                      positions=None):
-    index_scalar = extract_cache_index(cache_index)
-    per_layer_embeddings = None
-    if per_layer is not None:
-        p = config.hidden_size_per_layer_input
-        # Per-layer model projection of the UNSCALED embedding (before scaling).
-        projection_full = build_per_layer_model_projection(
-            hidden, config.num_layers, p, config.dtype)
-        per_layer_embeddings = build_per_layer_combined_inputs(
-            projection_full, per_layer, config.num_layers, p,
-            config.layer_norm_epsilon, config.dtype)
-    hidden = scale_token_embeddings(hidden, config.hidden_dim)
-    hidden, updated_cache = build_cached_decoder_blocks(
-        hidden, cache, index_scalar, config,
-        per_layer_embeddings=per_layer_embeddings, positions=positions)
-    updated_cache = ops.cast(updated_cache, config.dtype)
-    norm_args = (config.layer_norm_epsilon, config.dtype,
-                 "final_normalization")
-    hidden = build_rms_norm(*norm_args)(hidden)
-    logits = embedding(hidden, reverse=True)
-    logits = apply_soft_cap(logits, config.final_logit_soft_cap)
-    return logits, updated_cache
-
-
-def extract_cache_index(cache_index):
-    return ops.cast(cache_index[0], "int32")
-
-
-def squeeze_shared_cache(cache):
-    return ops.squeeze(cache, axis=1)
-
-
-def slice_layer_cache(cache, layer_index):
-    return cache[:, layer_index, ...]
-
-
-def expand_layer_cache(layer_cache):
-    return ops.expand_dims(layer_cache, axis=1)
-
-
-def concat_layer_caches(caches):
-    return ops.concatenate(caches, axis=1)
-
-
-def build_cached_decoder_blocks(hidden, cache, index, config,
-                                 per_layer_embeddings=None, positions=None):
-    kv_source_map = build_kv_source_map(config)
-    updated_caches = []
-    for layer_index in range(config.num_layers):
-        block_name = "decoder_block_{}".format(layer_index)
-        layer_cache = slice_layer_cache(cache, layer_index)
-        per_layer_embedding = None
-        if per_layer_embeddings is not None:
-            per_layer_embedding = per_layer_embeddings[layer_index]
-        shared_kv_cache = None
-        source = kv_source_map.get(layer_index)
-        if source is not None:
-            shared_kv_cache = squeeze_shared_cache(
-                updated_caches[source])
-        args = (hidden, layer_cache, index,
-                config, layer_index, block_name)
-        kwargs = {
-            "per_layer_embedding": per_layer_embedding,
-            "shared_kv_cache": shared_kv_cache,
-            "positions": positions,
-        }
-        hidden, layer_cache = cached_decoder_block(
-            *args, **kwargs)
-        updated_caches.append(expand_layer_cache(layer_cache))
-    updated = concat_layer_caches(updated_caches)
-    return hidden, updated
-
-
 def build_empty_cache(config, max_length, batch_size=1):
-    num_kv_heads = config.num_key_value_heads
     cache_head_dim = build_cache_head_dim(config)
-    args = (batch_size, config.num_layers, max_length, num_kv_heads,
-            cache_head_dim, config.dtype)
+    args = (batch_size, config.num_layers, max_length,
+            config.num_key_value_heads, cache_head_dim, config.dtype)
     return kv_cache.build(*args)
 
 
-GEMMA4_WEIGHTS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.24/"  # fmt: skip
-GEMMA4_CACHE = "paz/models/gemma4"
-# GitHub release assets are capped at 2 GB, so larger files are uploaded as
-# byte-identical parts and reassembled on download (scripts/shard_gemma4.py).
-PART_BYTES = 1_900_000_000
-GEMMA4_WEIGHT_FILES = (
-    "config.json", "tokenizer.json", "vision_config.json",
-    "vision_encoder.weights.h5", "decoder_step.weights.h5",
-    "embedding_step.weights.h5",
-)
-Gemma4Models = namedtuple(
-    "Gemma4", "config decoder_step per_layer_step vision_encoder")
-
-
-def Gemma4(model_name="gemma4_2b", weights="pretrained", models_path=None):
-    model_dir = resolve_dir(model_name, models_path)
-    config = load_config(model_dir / "config.json")
-    decoder_step = Gemma4MultimodalDecoderStep(config)
-    per_layer_step = build_per_layer_step(config)
-    vision_encoder = build_vision_encoder_from_dir(model_dir)
-    if weights is not None:
-        decoder_step.load_weights(str(model_dir / "decoder_step.weights.h5"))
-        load_optional_weights(model_dir, per_layer_step, vision_encoder)
-    return Gemma4Models(config, decoder_step, per_layer_step, vision_encoder)
-
-
-def resolve_dir(model_name, models_path):
-    if models_path is not None:
-        return Path(models_path)
-    return download_weights(model_name)
-
-
-def download_weights(model_name):
-    subdir = "{}/{}".format(GEMMA4_CACHE, model_name)
-    asset = "{}.manifest.json".format(model_name)
-    manifest_path = Path(get_file(
-        asset, GEMMA4_WEIGHTS_URL + asset, cache_subdir=subdir))
-    model_dir = manifest_path.parent
-    manifest = json.loads(manifest_path.read_text())
-    for filename, entry in manifest.items():
-        assemble_weights_file(model_dir / filename, entry, subdir)
-    return model_dir
-
-
-def assemble_weights_file(path, entry, subdir):
-    checksum = entry.get("sha256")
-    if is_complete(path, checksum):
-        return path
-    parts = []
-    for asset in entry["parts"]:
-        parts.append(get_file(
-            asset, GEMMA4_WEIGHTS_URL + asset, cache_subdir=subdir))
-    concatenate_parts(parts, path)
-    if checksum is not None and compute_sha256(path) != checksum:
-        raise ValueError("Checksum mismatch after assembling {}".format(path))
-    return path
-
-
-def is_complete(path, checksum):
-    if not path.exists():
-        return False
-    return checksum is None or compute_sha256(path) == checksum
-
-
-def concatenate_parts(parts, output):
-    with open(str(output), "wb") as merged:
-        for part in parts:
-            with open(str(part), "rb") as chunk:
-                shutil.copyfileobj(chunk, merged)
-    return output
-
-
-def compute_sha256(path):
-    digest = hashlib.sha256()
-    with open(str(path), "rb") as file:
-        for block in iter(lambda: file.read(1 << 20), b""):
-            digest.update(block)
-    return digest.hexdigest()
-
-
-def shard_weights(source_dir, model_name, output_dir, part_bytes=PART_BYTES):
-    """Split a local weights dir into <2 GB parts plus an upload manifest."""
-    source_dir, output_dir = Path(source_dir), Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    manifest = {}
-    for filename in GEMMA4_WEIGHT_FILES:
-        source = source_dir / filename
-        if not source.exists():
-            continue
-        prefix = "{}_{}".format(model_name, filename)
-        parts = split_file(source, output_dir, prefix, part_bytes)
-        manifest[filename] = {"parts": parts, "sha256": compute_sha256(source)}
-    manifest_path = output_dir / "{}.manifest.json".format(model_name)
-    manifest_path.write_text(json.dumps(manifest, indent=2))
-    return manifest_path
-
-
-def split_file(source, output_dir, prefix, part_bytes=PART_BYTES):
-    output_dir = Path(output_dir)
-    parts, index = [], 0
-    with open(str(source), "rb") as file:
-        while True:
-            block = file.read(part_bytes)
-            if not block:
-                break
-            asset = "{}.part{}".format(prefix, index)
-            (output_dir / asset).write_bytes(block)
-            parts.append(asset)
-            index = index + 1
-    return parts
-
-
-def build_per_layer_step(config):
-    if not config.hidden_size_per_layer_input:
-        return None
-    return Gemma4PerLayerEmbeddingStep(config)
-
-
-def build_vision_encoder_from_dir(model_dir):
-    path = Path(model_dir) / "vision_config.json"
-    if not path.exists():
-        return None
-    with open(str(path), encoding="utf-8") as file:
-        config = VisionEncoderArgs(**json.load(file))
-    return build_vision_encoder(config)
-
-
-def load_vision_encoder(model_dir, weights="pretrained"):
-    """Build and load just the vision encoder, on the current default device.
-
-    Use inside a `jax.default_device(...)` block to place it where you want,
-    then swap it into a bundle: `Gemma4(...)._replace(vision_encoder=vision)`.
-    """
-    model_dir = Path(model_dir)
-    vision_encoder = build_vision_encoder_from_dir(model_dir)
-    if weights is not None and vision_encoder is not None:
-        vision_encoder.load_weights(
-            str(model_dir / "vision_encoder.weights.h5"))
-    return vision_encoder
-
-
-def load_optional_weights(model_dir, per_layer_step, vision_encoder):
-    if per_layer_step is not None:
-        per_layer_step.load_weights(
-            str(model_dir / "embedding_step.weights.h5"))
-    if vision_encoder is not None:
-        vision_encoder.load_weights(
-            str(model_dir / "vision_encoder.weights.h5"))
+def build_text_backbone_args(**overrides):
+    values = {
+        "vocabulary_size": 256, "image_size": 8, "num_layers": 2,
+        "num_query_heads": 2, "num_key_value_heads": 1, "hidden_dim": 8,
+        "intermediate_dim": 16, "head_dim": 4,
+        "attention_logit_soft_cap": None, "final_logit_soft_cap": None,
+        "use_sliding_window_attention": True, "sliding_window_size": 16,
+        "sliding_window_pattern": 6, "global_head_dim": None,
+        "local_rope_wavelength": 10_000.0,
+        "global_rope_wavelength": 1_000_000.0,
+        "local_rope_scaling_factor": 1.0, "global_rope_scaling_factor": 1.0,
+        "global_rope_partial_rotary_factor": 1.0,
+        "use_bidirectional_attention": False, "layer_norm_epsilon": 1e-6,
+        "dropout": 0.0, "dtype": "float32", "hidden_size_per_layer_input": None,
+        "num_kv_shared_layers": 0, "global_layer_indices": None,
+        "use_double_wide_mlp": False,
+    }
+    values.update(overrides)
+    return TextBackboneArgs(**values)

--- a/paz/models/foundation/gemma4/model_test.py
+++ b/paz/models/foundation/gemma4/model_test.py
@@ -1,108 +1,103 @@
 import jax.numpy as jp
 
-from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
 from paz.models.foundation.gemma4.model import (
-    Gemma4DecoderStep, build_empty_cache, build_text_backbone,
-    build_text_backbone_args, compute_text_intermediates)
+    Gemma4Backbone, build_text_backbone_args)
+from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
+from paz.models.foundation.gemma4.configuration import build_kv_source_map
 
 
 def build_test_inputs():
     token_ids = jp.array([[1, 2, 3, 4, 0], [5, 6, 7, 0, 0]], dtype=jp.int32)
     padding_mask = jp.array([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]], dtype=jp.int32)
-    return token_ids, padding_mask
-
-
-def build_test_config():
-    return build_text_backbone_args(use_sliding_window_attention=False)
+    return {"token_ids": token_ids, "padding_mask": padding_mask}
 
 
 def assert_close(left, right, tol=1e-6):
-    diff = jp.max(jp.abs(left - right))
-    assert float(diff) <= tol
+    assert float(jp.max(jp.abs(left - right))) <= tol
 
 
-def test_runtime_backbone_builds_successfully():
+def test_backbone_builds_and_shapes():
     config = build_text_backbone_args()
-    model = build_text_backbone(config)
-    token_ids, padding_mask = build_test_inputs()
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
-    outputs = model(inputs)
-    assert outputs.shape == (2, 5, config.hidden_dim)
+    model = Gemma4Backbone(config)
+    output = model(build_test_inputs())
+    assert output.shape == (2, 5, config.hidden_dim)
 
 
-def test_runtime_backbone_save_and_load(tmp_path):
+def test_backbone_save_and_load(tmp_path):
     config = build_text_backbone_args()
-    model = build_text_backbone(config)
-    token_ids, padding_mask = build_test_inputs()
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
+    model = Gemma4Backbone(config)
+    inputs = build_test_inputs()
     output = model(inputs)
-    path = tmp_path / "gemma4_text_backbone.weights.h5"
+    path = tmp_path / "gemma4_backbone.weights.h5"
     model.save_weights(str(path))
-    loaded = build_text_backbone(config, weights_path=path)
+    loaded = Gemma4Backbone(config)
+    loaded(inputs)
+    loaded.load_weights(str(path))
     assert_close(output, loaded(inputs))
 
 
-def test_runtime_backbone_exposes_intermediates():
-    config = build_text_backbone_args()
-    model = build_text_backbone(config)
-    token_ids, padding_mask = build_test_inputs()
-    data = compute_text_intermediates(model, token_ids, padding_mask)
-    assert data.embedding_output.shape == (2, 5, config.hidden_dim)
-    assert len(data.block_outputs) == config.num_layers
-    assert data.final_output.shape == (2, 5, config.hidden_dim)
-
-
-def test_runtime_backbone_supports_per_layer_inputs():
+def test_backbone_supports_per_layer_inputs():
     config = build_text_backbone_args(hidden_size_per_layer_input=2)
-    model = build_text_backbone(config)
-    token_ids, padding_mask = build_test_inputs()
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
-    outputs = model(inputs)
-    assert outputs.shape == (2, 5, config.hidden_dim)
+    model = Gemma4Backbone(config)
+    output = model(build_test_inputs())
+    assert output.shape == (2, 5, config.hidden_dim)
 
 
-def test_runtime_backbone_runs_global_partial_rope():
+def test_backbone_runs_global_partial_rope():
     config = build_text_backbone_args(
-        num_layers=6, sliding_window_pattern=3, head_dim=16,
-        global_head_dim=16, global_rope_partial_rotary_factor=0.25)
-    model = build_text_backbone(config)
-    token_ids, padding_mask = build_test_inputs()
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
-    outputs = model(inputs)
-    assert outputs.shape == (2, 5, config.hidden_dim)
+        num_layers=6, sliding_window_pattern=3, head_dim=16, global_head_dim=16,
+        global_rope_partial_rotary_factor=0.25)
+    model = Gemma4Backbone(config)
+    output = model(build_test_inputs())
+    assert output.shape == (2, 5, config.hidden_dim)
 
 
-def test_decoder_step_output_shape():
-    config = build_test_config()
-    step_model = Gemma4DecoderStep(config)
-    cache = build_empty_cache(config, 8)
+def test_kv_source_map_shares_tail_layers():
+    config = build_text_backbone_args(
+        num_layers=6, num_kv_shared_layers=2, sliding_window_pattern=3)
+    source_map = build_kv_source_map(config)
+    # local layer 4 shares from local layer 3; global layer 5 from global 2.
+    assert source_map == {4: 3, 5: 2}
+    model = Gemma4Backbone(config)
+    assert model(build_test_inputs()).shape == (2, 5, config.hidden_dim)
+
+
+def full_feature_config():
+    return build_text_backbone_args(
+        num_layers=6, sliding_window_pattern=3, head_dim=8, global_head_dim=16,
+        hidden_size_per_layer_input=4, num_kv_shared_layers=2,
+        use_double_wide_mlp=True, global_rope_partial_rotary_factor=0.5,
+        use_sliding_window_attention=True, sliding_window_size=4,
+        final_logit_soft_cap=30.0, vocabulary_size=64, hidden_dim=16,
+        intermediate_dim=32, num_query_heads=4, num_key_value_heads=2)
+
+
+def test_prefill_parity_call_matches_call_with_cache():
+    config = full_feature_config()
+    model = Gemma4CausalLM(config)
+    token_ids = jp.array([[5, 10, 15, 20, 25, 30, 2, 40]], dtype=jp.int32)
+    length = token_ids.shape[1]
+    inputs = {"token_ids": token_ids, "padding_mask": jp.ones_like(token_ids)}
+    full = model(inputs)
+    cache = jp.asarray(model.build_cache(length))
+    for position in range(length):
+        token = token_ids[:, position:position + 1]
+        embedding = model.backbone.token_embedding(token)
+        per_layer = model.backbone.per_layer_lookup(token)
+        index = jp.array(position, dtype=jp.int32)
+        step_logits, cache = model.call_with_cache(
+            embedding, cache, index, None, per_layer)
+        assert_close(step_logits[0, 0], full[0, position], tol=1e-3)
+
+
+def test_causal_lm_cached_step_shapes():
+    config = build_text_backbone_args(hidden_size_per_layer_input=2)
+    model = Gemma4CausalLM(config)
     token = jp.array([[1]], dtype=jp.int32)
-    index = jp.array([0], dtype=jp.int32)
-    logits, new_cache = step_model([token, cache, index])
+    cache = jp.asarray(model.build_cache(8))
+    embedding = model.backbone.token_embedding(token)
+    per_layer = model.backbone.per_layer_lookup(token)
+    logits, new_cache = model.call_with_cache(
+        embedding, cache, jp.array(0, jp.int32), None, per_layer)
     assert logits.shape == (1, 1, config.vocabulary_size)
     assert new_cache.shape == cache.shape
-
-
-def test_cached_step_matches_full_sequence():
-    config = build_test_config()
-    full_model = Gemma4CausalLM(config)
-    step_model = Gemma4DecoderStep(config)
-    copy_decoder_step_weights(step_model, full_model)
-    token_ids = jp.array([[5, 10, 15]], dtype=jp.int32)
-    padding_mask = jp.ones_like(token_ids)
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask}
-    full_logits = full_model(inputs)
-    cache = build_empty_cache(config, 8)
-    for position in range(3):
-        token = token_ids[:, position:position + 1]
-        index = jp.array([position], dtype=jp.int32)
-        step_logits, cache = step_model([token, cache, index])
-    step_last = step_logits[0, 0, :]
-    full_last = full_logits[0, 2, :]
-    assert_close(step_last, full_last, tol=1e-3)
-
-
-def copy_decoder_step_weights(step_model, full_model):
-    full_by_path = {weight.path: weight for weight in full_model.weights}
-    for step_weight in step_model.weights:
-        step_weight.assign(full_by_path[step_weight.path])

--- a/paz/models/foundation/gemma4/multimodal.py
+++ b/paz/models/foundation/gemma4/multimodal.py
@@ -6,50 +6,42 @@ Mirrors keras_hub Gemma4Backbone's interleaving: image embeddings are pre-scaled
 by hidden_dim**-0.5 and the global sqrt(hidden_dim) scale is applied after
 interleaving (so image positions keep their natural magnitude).
 """
+import keras
 from keras import ops
-from keras.layers import Input, Lambda
 
-from paz.models.foundation.gemma4.model import (
-    build_backbone_from_embedding, build_token_embedding)
-from paz.models.foundation.gemma4.vision import (
-    build_vision_encoder, num_patches)
+from paz.models.foundation.gemma4.model import Gemma4Backbone
+from paz.models.foundation.gemma4.vision import build_vision_encoder
 
 MULTIMODAL_NAME = "gemma4_multimodal_backbone"
 
 
-def build_multimodal_backbone(config, vision_config, weights_path=None,
-                              name=MULTIMODAL_NAME):
-    token_embedding = build_token_embedding(
-        config.vocabulary_size, config.hidden_dim, config.dtype)
-    token_ids = Input((None,), dtype="int32", name="token_ids")
-    padding_mask = Input((None,), dtype="int32", name="padding_mask")
-    patch_dim = 3 * vision_config.patch_size ** 2
-    pixel_values = Input(
-        (num_patches(vision_config), patch_dim), name="pixel_values")
-    pixel_position_ids = Input(
-        (num_patches(vision_config), 2), dtype="int32",
-        name="pixel_position_ids")
-    vision_indices = Input((None,), dtype="int32", name="vision_indices")
-    embedding = build_image_text_embedding(
-        token_embedding(token_ids), pixel_values, pixel_position_ids,
-        vision_indices, vision_config, config.hidden_dim)
-    inputs = {"token_ids": token_ids, "padding_mask": padding_mask,
-              "pixel_values": pixel_values,
-              "pixel_position_ids": pixel_position_ids,
-              "vision_indices": vision_indices}
-    return build_backbone_from_embedding(
-        embedding, token_ids, padding_mask, inputs, config, name, weights_path)
+@keras.saving.register_keras_serializable(package="gemma4")
+class Gemma4MultimodalBackbone(keras.Model):
+    def __init__(self, config, vision_config, name=MULTIMODAL_NAME, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.config = config
+        self.backbone = Gemma4Backbone(config)
+        self.vision_encoder = build_vision_encoder(vision_config)
+
+    def call(self, inputs):
+        token_ids, padding_mask = inputs["token_ids"], inputs["padding_mask"]
+        text = self.backbone.token_embedding(token_ids)
+        images = self.encode_images(inputs)
+        embedding = interleave_embeddings(
+            images, text, inputs["vision_indices"])
+        return self.backbone.forward_from_embedding(
+            embedding, padding_mask, token_ids)
+
+    def encode_images(self, inputs):
+        images = self.vision_encoder({
+            "pixel_values": inputs["pixel_values"],
+            "pixel_position_ids": inputs["pixel_position_ids"]})
+        scale = ops.cast(float(self.config.hidden_dim) ** -0.5, images.dtype)
+        return ops.expand_dims(images * scale, axis=1)
 
 
-def build_image_text_embedding(text_embedding, pixel_values,
-                               pixel_position_ids, vision_indices,
-                               vision_config, hidden_dim):
-    vision = build_vision_encoder(vision_config)
-    images = vision({"pixel_values": pixel_values,
-                     "pixel_position_ids": pixel_position_ids})
-    images = images * ops.cast(float(hidden_dim) ** -0.5, images.dtype)
-    images = ops.expand_dims(images, axis=1)
-    return build_interleave(images, text_embedding, vision_indices)
+def build_multimodal_backbone(config, vision_config):
+    return Gemma4MultimodalBackbone(config, vision_config)
 
 
 def interleave_embeddings(image_embeddings, text_embeddings, vision_indices):
@@ -65,10 +57,3 @@ def interleave_embeddings(image_embeddings, text_embeddings, vision_indices):
     updated = ops.scatter_update(flat_text, indices, flat_image)
     updated = ops.scatter_update(updated, offset, zeroth)
     return ops.reshape(updated, (batch, seq, dim))
-
-
-def build_interleave(image_embeddings, text_embeddings, vision_indices):
-    dim = text_embeddings.shape[-1]
-    fn = lambda tensors: interleave_embeddings(*tensors)
-    inputs = [image_embeddings, text_embeddings, vision_indices]
-    return Lambda(fn, output_shape=(None, dim), name="interleave")(inputs)

--- a/paz/models/foundation/gemma4/multimodal_decoding.py
+++ b/paz/models/foundation/gemma4/multimodal_decoding.py
@@ -1,22 +1,25 @@
-"""Cached image->text generation for Gemma4.
+"""Cached image->text (and batched text) generation for Gemma4.
 
 Image embeddings are baked into the KV cache during prefill: each image
 placeholder position is fed its vision embedding (pre-scaled by
 hidden_dim**-0.5) instead of a token embedding, matching keras_hub. The whole
 prompt is prefilled in ONE forward (parallel prefill); decode is then a jitted
-jax.lax.while_loop, mirroring decoding.py's text KVDecoder. Uses
-Gemma4MultimodalDecoderStep, which takes a precomputed input embedding and the
-query positions.
+jax.lax.while_loop. All paths run over one Gemma4CausalLM through its
+`call_with_cache`; the jitted loop threads the model weights as explicit
+arguments via keras.StatelessScope so jax.jit does not constant-fold the
+multi-GB embedding tables into the executable.
 """
+import itertools
+
 import jax
 import jax.numpy as jp
 import numpy as np
+import keras
 from keras import ops
 
-from paz import call_stateless, snapshot_variables
+from paz import snapshot_variables
 
 from paz.models.transformers.search import discard, emit_token
-from paz.models.foundation.gemma4.model import build_empty_cache
 from paz.models.foundation.gemma4.sampling import sample_logits
 
 
@@ -24,95 +27,81 @@ def as_token(token):
     return jp.array([[int(token)]], dtype="int32")
 
 
-def build_prompt_rows(step_model, vision_embeddings, prompt_ids,
-                      vision_indices, per_layer_step):
-    embedding = step_model.get_layer("token_embedding")
+def build_prompt_rows(model, vision_embeddings, prompt_ids, vision_indices):
+    embedding = model.backbone.token_embedding
     ids = jp.array(prompt_ids, dtype="int32")[None]
     embeds = embedding(ids)[0]
-    per_layer = None
-    if per_layer_step is not None:
-        per_layer = per_layer_step(ids)[0]
-        zero_row = per_layer_row(per_layer_step, 0)
+    per_layer = model.backbone.per_layer_lookup(ids)
+    zero_row = per_layer_pad_row(model)
     for image_index, position in enumerate(vision_indices):
         row = jp.asarray(vision_embeddings[image_index])
         embeds = embeds.at[int(position)].set(row)
         if per_layer is not None:
-            per_layer = per_layer.at[int(position)].set(zero_row)
-    if per_layer is not None:
-        per_layer = per_layer[None]
+            per_layer = per_layer.at[0, int(position)].set(zero_row)
     return embeds[None], per_layer
 
 
-def per_layer_row(per_layer_step, token):
+def per_layer_pad_row(model):
     # Image positions reuse the pad-token (id 0) per-layer embedding, matching
     # keras_hub which zeroes the per-layer token ids at vision positions.
-    if per_layer_step is None:
+    if not model.backbone.has_per_layer:
         return None
-    return per_layer_step(as_token(token))[0, 0]
+    return model.backbone.per_layer_lookup(as_token(0))[0, 0]
 
 
-def call_step(step_model, embeds, cache, start, positions, per_layer):
-    index = jp.reshape(jp.asarray(start, dtype="int32"), (1,))
-    inputs = [embeds, cache, index, positions]
-    if per_layer is not None:
-        inputs.append(per_layer)
-    return step_model(inputs)
+def call_step(model, embeds, cache, start, positions, per_layer):
+    index = jp.asarray(start, dtype="int32")
+    return model.call_with_cache(embeds, cache, index, positions, per_layer)
 
 
-def generate(step_model, per_layer_step, vision_embeddings, config,
-             prompt_ids, vision_indices, stop_id, max_tokens):
+def generate(model, vision_embeddings, prompt_ids, vision_indices, stop_id,
+             max_tokens):
     """Single-sequence jitted greedy generation."""
     return run_cached_generate(
-        step_model, per_layer_step, vision_embeddings, config, prompt_ids,
-        vision_indices, stop_id, max_tokens, jax.random.PRNGKey(0),
-        select_greedy_token)
+        model, vision_embeddings, prompt_ids, vision_indices, stop_id,
+        max_tokens, jax.random.PRNGKey(0), select_greedy_token)
 
 
-def generate_eager(step_model, per_layer_step, vision_embeddings, config,
-                   prompt_ids, vision_indices, stop_id, max_tokens):
+def generate_sample(model, vision_embeddings, prompt_ids, vision_indices,
+                    stop_id, max_tokens, key, sampling):
+    """Single-sequence jitted sampling generation seeded by `key`."""
+    return run_cached_generate(
+        model, vision_embeddings, prompt_ids, vision_indices, stop_id,
+        max_tokens, key, build_token_sampler(sampling))
+
+
+def generate_eager(model, vision_embeddings, prompt_ids, vision_indices,
+                   stop_id, max_tokens):
     """Eager parallel prefill + Python greedy decode loop.
 
-    Prefills the whole prompt in ONE forward, then decodes token-by-token. The
-    full-program jit in `generate` constant-folds the multi-GB embedding tables
-    into the executable, which a modest host cannot afford alongside the
-    resident weights; keras compiles each step, so this is equally fast for
-    short outputs while staying within budget on the real E2B/E4B weights.
+    Prefills the whole prompt in one forward, then decodes token-by-token. Used
+    for the largest weights, where a full-program jit would constant-fold the
+    embedding tables and exhaust the host.
     """
     embeds, per_layer = build_prompt_rows(
-        step_model, vision_embeddings, prompt_ids, vision_indices,
-        per_layer_step)
+        model, vision_embeddings, prompt_ids, vision_indices)
     length = embeds.shape[1]
-    cache = jp.asarray(build_empty_cache(config, length + max_tokens))
+    cache = jp.asarray(model.build_cache(length + max_tokens))
     positions = jp.arange(length, dtype="int32")[None]
-    logits, cache = call_step(step_model, embeds, cache, 0, positions,
-                              per_layer)
+    logits, cache = call_step(model, embeds, cache, 0, positions, per_layer)
     token = int(jp.argmax(logits[0, -1]))
-    embedding = step_model.get_layer("token_embedding")
     out, index = [token], length
     while token != stop_id and len(out) < max_tokens:
-        per_layer = decode_per_layer(per_layer_step, token)
+        embeds = model.backbone.token_embedding(as_token(token))
+        per_layer = decode_per_layer(model, token)
+        positions = jp.array([[index]], dtype="int32")
         logits, cache = call_step(
-            step_model, embedding(as_token(token)), cache, index,
-            jp.array([[index]], dtype="int32"), per_layer)
+            model, embeds, cache, index, positions, per_layer)
         token = int(jp.argmax(logits[0, -1]))
         out.append(token)
         index += 1
     return trim_to_stop(out, stop_id)
 
 
-def decode_per_layer(per_layer_step, token):
-    if per_layer_step is None:
+def decode_per_layer(model, token):
+    if not model.backbone.has_per_layer:
         return None
-    return per_layer_step(as_token(token))
-
-
-def generate_sample(step_model, per_layer_step, vision_embeddings, config,
-                    prompt_ids, vision_indices, stop_id, max_tokens, key,
-                    sampling):
-    """Single-sequence jitted sampling generation seeded by `key`."""
-    return run_cached_generate(
-        step_model, per_layer_step, vision_embeddings, config, prompt_ids,
-        vision_indices, stop_id, max_tokens, key, build_token_sampler(sampling))
+    return model.backbone.per_layer_lookup(as_token(token))
 
 
 def select_greedy_token(logits, key):
@@ -123,26 +112,19 @@ def build_token_sampler(sampling):
     return lambda logits, key: sample_logits(logits, key, sampling)[0]
 
 
-def run_cached_generate(step_model, per_layer_step, vision_embeddings, config,
-                        prompt_ids, vision_indices, stop_id, max_tokens, key,
-                        select):
+def run_cached_generate(model, vision_embeddings, prompt_ids, vision_indices,
+                        stop_id, max_tokens, key, select):
     embeds, per_layer = build_prompt_rows(
-        step_model, vision_embeddings, prompt_ids, vision_indices,
-        per_layer_step)
+        model, vision_embeddings, prompt_ids, vision_indices)
     length = embeds.shape[1]
     max_length = length + max_tokens
-    cache = jp.asarray(build_empty_cache(config, max_length))
+    cache = jp.asarray(model.build_cache(max_length))
     positions = jp.arange(length, dtype="int32")[None]
-    logits, cache = call_step(
-        step_model, embeds, cache, 0, positions, per_layer)
+    logits, cache = call_step(model, embeds, cache, 0, positions, per_layer)
     key, first_key = jax.random.split(key)
     first = select(logits[:, -1], first_key)
-    decode = build_decode_loop(
-        step_model, per_layer_step, max_length, max_tokens, select)
-    variables = (
-        snapshot_variables(step_model),
-        snapshot_variables(step_model.get_layer("token_embedding")),
-        snapshot_variables(per_layer_step))
+    decode = build_decode_loop(model, max_length, max_tokens, select)
+    variables = snapshot_variables(model)
     buffer, count = decode(cache, first, jp.array(length, "int32"),
                            jp.array(stop_id, "int32"), key, variables)
     generated = ops.convert_to_numpy(buffer[:int(count)]).tolist()
@@ -155,40 +137,30 @@ def trim_to_stop(tokens, stop_id):
     return tokens
 
 
-def build_generator(step_model, per_layer_step, config, stop_id, max_tokens,
-                    max_seq, max_prompt, select=select_greedy_token,
-                    emit=discard):
+def build_generator(model, stop_id, max_tokens, max_seq, max_prompt,
+                    select=select_greedy_token, emit=discard):
     """Compile-once greedy generator for text and image prompts alike.
 
-    Returns `generate(prompt_ids, vision_embeddings, vision_indices)`. Image
-    placeholders in `prompt_ids` at `vision_indices` are fed the matching row
-    of `vision_embeddings`; text-only callers pass an empty (0, hidden) array
-    and empty indices. Every prompt is right-padded to `max_prompt`, so prefill
-    keeps one static shape and the Keras JIT compiles once; the decode loop is
-    a fixed `max_seq` cache, so it also compiles once and is reused across
-    calls. Causal attention keeps padded positions out of the real tokens, so
-    starting decode at the true prompt length is exact. `emit(token_id)` fires
-    per token (including the first) for streaming; pass `discard` to stay
-    silent.
+    Returns `generate(prompt_ids, vision_embeddings, vision_indices)`. Every
+    prompt is right-padded to `max_prompt` so prefill keeps one static shape and
+    the JIT compiles once; the decode loop uses a fixed `max_seq` cache. Causal
+    attention keeps padded positions out of the real tokens, so starting decode
+    at the true prompt length is exact. `emit(token_id)` fires per token for
+    streaming; pass `discard` to stay silent.
     """
     assert max_prompt + max_tokens <= max_seq
     positions = jp.arange(max_prompt, dtype="int32")[None]
     decode = build_streaming_decode_loop(
-        step_model, per_layer_step, max_seq, max_tokens, select, emit)
-    variables = (
-        snapshot_variables(step_model),
-        snapshot_variables(step_model.get_layer("token_embedding")),
-        snapshot_variables(per_layer_step))
+        model, max_seq, max_tokens, select, emit)
+    variables = snapshot_variables(model)
 
     def generate(prompt_ids, vision_embeddings, vision_indices):
         length = min(len(prompt_ids), max_prompt)
         padded = pad_prompt_ids(prompt_ids, max_prompt)
         embeds, per_layer = build_prompt_rows(
-            step_model, vision_embeddings, padded, vision_indices,
-            per_layer_step)
-        cache = jp.asarray(build_empty_cache(config, max_seq))
-        logits, cache = call_step(
-            step_model, embeds, cache, 0, positions, per_layer)
+            model, vision_embeddings, padded, vision_indices)
+        cache = jp.asarray(model.build_cache(max_seq))
+        logits, cache = call_step(model, embeds, cache, 0, positions, per_layer)
         first = select(logits[:, length - 1], None)
         emit(first)
         buffer, count = decode(
@@ -200,14 +172,12 @@ def build_generator(step_model, per_layer_step, config, stop_id, max_tokens,
     return generate
 
 
-def build_text_generator(step_model, per_layer_step, config, stop_id,
-                         max_tokens, max_seq, max_prompt,
+def build_text_generator(model, stop_id, max_tokens, max_seq, max_prompt,
                          select=select_greedy_token, emit=discard):
     """Text specialization of build_generator: `generate(prompt_ids)`."""
-    args = (step_model, per_layer_step, config, stop_id, max_tokens, max_seq,
-            max_prompt, select, emit)
+    args = (model, stop_id, max_tokens, max_seq, max_prompt, select, emit)
     generate = build_generator(*args)
-    no_vision = np.zeros((0, config.hidden_dim), "float32")
+    no_vision = np.zeros((0, model.config.hidden_dim), "float32")
 
     def generate_text(prompt_ids):
         return generate(prompt_ids, no_vision, [])
@@ -220,21 +190,17 @@ def pad_prompt_ids(prompt_ids, max_prompt):
     return prompt_ids + [0] * (max_prompt - len(prompt_ids))
 
 
-def build_decode_loop(step_model, per_layer_step, max_length, max_tokens,
-                      select):
+def build_decode_loop(model, max_length, max_tokens, select):
     return build_streaming_decode_loop(
-        step_model, per_layer_step, max_length, max_tokens, select, discard)
+        model, max_length, max_tokens, select, discard)
 
 
-def build_streaming_decode_loop(step_model, per_layer_step, max_length,
-                                max_tokens, select, emit):
-    """Like build_decode_loop but calls `emit(token_id)` per decoded token.
+def build_streaming_decode_loop(model, max_length, max_tokens, select, emit):
+    """Jitted decode loop calling `emit(token_id)` per decoded token.
 
     `emit` runs on the host from inside the jitted loop via jax.debug.callback,
     so tokens can be shown as they are produced. Pass `discard` for no output.
     """
-    embedding = step_model.get_layer("token_embedding")
-
     @jax.jit
     def decode(cache, first_token, start_index, stop_id, key, variables):
         buffer = jp.zeros((max_tokens,), dtype="int32").at[0].set(first_token)
@@ -242,9 +208,7 @@ def build_streaming_decode_loop(step_model, per_layer_step, max_length,
         state = (buffer, first_token, start_index, cache, count,
                  first_token == stop_id, key)
         cont = build_should_continue(max_tokens, max_length)
-        step = build_decode_step(
-            step_model, embedding, per_layer_step, stop_id, select, variables,
-            emit)
+        step = build_decode_step(model, stop_id, select, variables, emit)
         buffer, _, _, _, count, _, _ = jax.lax.while_loop(cont, step, state)
         return buffer, count
 
@@ -258,21 +222,12 @@ def build_should_continue(max_tokens, max_length):
     return check
 
 
-def build_decode_step(step_model, embedding, per_layer_step, stop_id, select,
-                      variables, emit):
-    step_vars, embedding_vars, per_layer_vars = variables
-
+def build_decode_step(model, stop_id, select, variables, emit):
     def step(state):
         buffer, token, index, cache, count, _, key = state
-        token2d = jp.reshape(token, (1, 1))
         positions = jp.reshape(index, (1, 1)).astype("int32")
-        embeds = call_stateless(embedding, embedding_vars, token2d)
-        inputs = [embeds, cache, jp.reshape(index, (1,)).astype("int32"),
-                  positions]
-        if per_layer_vars is not None:
-            inputs.append(
-                call_stateless(per_layer_step, per_layer_vars, token2d))
-        logits, cache = call_stateless(step_model, step_vars, inputs)
+        logits, cache = cached_step_stateless(
+            model, variables, token, cache, index, positions)
         key, step_key = jax.random.split(key)
         next_id = select(logits[:, 0, :], step_key)
         emit_token(emit, next_id)
@@ -282,22 +237,28 @@ def build_decode_step(step_model, embedding, per_layer_step, stop_id, select,
     return step
 
 
-def generate_batch(step_model, per_layer_step, config, prompts, key, sampling,
-                   stop_id, max_tokens):
-    """Batched sampling generation for equal-length text prompts.
+def cached_step_stateless(model, variables, token, cache, index, positions):
+    mapping = itertools.chain(
+        zip(model.trainable_variables, variables[0]),
+        zip(model.non_trainable_variables, variables[1]))
+    token2d = jp.reshape(token, (1, 1))
+    with keras.StatelessScope(state_mapping=mapping):
+        embeds = model.backbone.token_embedding(token2d)
+        per_layer = model.backbone.per_layer_lookup(token2d)
+        return model.call_with_cache(embeds, cache, index, positions, per_layer)
 
-    Each row is sampled independently with `sampling`; `key` seeds the draws.
-    """
+
+def generate_batch(model, prompts, key, sampling, stop_id, max_tokens):
+    """Batched sampling generation for equal-length text prompts."""
     select = build_sampler(sampling)
-    return run_batch_decode(step_model, per_layer_step, config, prompts, key,
-                            select, stop_id, max_tokens)
+    return run_batch_decode(
+        model, prompts, key, select, stop_id, max_tokens)
 
 
-def generate_batch_greedy(step_model, per_layer_step, config, prompts,
-                          stop_id, max_tokens):
+def generate_batch_greedy(model, prompts, stop_id, max_tokens):
     """Batched greedy (argmax) generation for equal-length text prompts."""
-    return run_batch_decode(step_model, per_layer_step, config, prompts, None,
-                            select_greedy, stop_id, max_tokens)
+    return run_batch_decode(
+        model, prompts, None, select_greedy, stop_id, max_tokens)
 
 
 def build_sampler(sampling):
@@ -315,31 +276,25 @@ def pick_token(select, logits, key):
     return key, select(logits, step_key)
 
 
-def run_batch_decode(step_model, per_layer_step, config, prompts, key, select,
-                     stop_id, max_tokens):
-    """Eager parallel prefill + lockstep decode over a (batch, length) grid.
-
-    All rows share query positions, so the cached attention broadcasts across
-    the batch. Returns one stop-trimmed token list per row.
-    """
+def run_batch_decode(model, prompts, key, select, stop_id, max_tokens):
+    """Eager parallel prefill + lockstep decode over a (batch, length) grid."""
     prompts = jp.asarray(prompts, dtype="int32")
     batch, length = prompts.shape
-    embeds, per_layer = build_text_batch_rows(
-        step_model, per_layer_step, prompts)
-    cache = jp.asarray(build_empty_cache(config, length + max_tokens, batch))
+    embeds = model.backbone.token_embedding(prompts)
+    per_layer = batch_per_layer(model, prompts)
+    cache = jp.asarray(model.build_cache(length + max_tokens, batch))
     positions = jp.arange(length, dtype="int32")[None]
-    logits, cache = call_step(
-        step_model, embeds, cache, 0, positions, per_layer)
+    logits, cache = call_step(model, embeds, cache, 0, positions, per_layer)
     key, token = pick_token(select, logits[:, -1], key)
-    embedding = step_model.get_layer("token_embedding")
     collected, index = [token], length
     finished = np.asarray(token) == stop_id
     while len(collected) < max_tokens and not finished.all():
         token2d = token[:, None]
-        per_layer = batch_per_layer(per_layer_step, token2d)
+        per_layer = batch_per_layer(model, token2d)
+        positions = jp.full((1, 1), index, dtype="int32")
         logits, cache = call_step(
-            step_model, embedding(token2d), cache, index,
-            jp.full((1, 1), index, dtype="int32"), per_layer)
+            model, model.backbone.token_embedding(token2d), cache, index,
+            positions, per_layer)
         key, token = pick_token(select, logits[:, -1], key)
         collected.append(token)
         finished = finished | (np.asarray(token) == stop_id)
@@ -347,17 +302,10 @@ def run_batch_decode(step_model, per_layer_step, config, prompts, key, select,
     return trim_rows(collected, stop_id)
 
 
-def build_text_batch_rows(step_model, per_layer_step, prompts):
-    embedding = step_model.get_layer("token_embedding")
-    embeds = embedding(prompts)
-    per_layer = batch_per_layer(per_layer_step, prompts)
-    return embeds, per_layer
-
-
-def batch_per_layer(per_layer_step, tokens):
-    if per_layer_step is None:
+def batch_per_layer(model, tokens):
+    if not model.backbone.has_per_layer:
         return None
-    return per_layer_step(tokens)
+    return model.backbone.per_layer_lookup(tokens)
 
 
 def trim_rows(collected, stop_id):
@@ -365,14 +313,12 @@ def trim_rows(collected, stop_id):
     return [trim_to_stop(row.tolist(), stop_id) for row in grid]
 
 
-def prefill_logits(step_model, per_layer_step, vision_embeddings, config,
-                   prompt_ids, vision_indices):
+def prefill_logits(model, vision_embeddings, prompt_ids, vision_indices):
     """Prefill the whole prompt in one forward; returns per-position logits."""
     embeds, per_layer = build_prompt_rows(
-        step_model, vision_embeddings, prompt_ids, vision_indices,
-        per_layer_step)
+        model, vision_embeddings, prompt_ids, vision_indices)
     length = embeds.shape[1]
-    cache = jp.asarray(build_empty_cache(config, length))
+    cache = jp.asarray(model.build_cache(length))
     positions = jp.arange(length, dtype="int32")[None]
-    logits, _ = call_step(step_model, embeds, cache, 0, positions, per_layer)
+    logits, _ = call_step(model, embeds, cache, 0, positions, per_layer)
     return logits

--- a/paz/models/foundation/gemma4/multimodal_decoding_test.py
+++ b/paz/models/foundation/gemma4/multimodal_decoding_test.py
@@ -3,18 +3,15 @@ import os
 os.environ.setdefault("KERAS_BACKEND", "jax")
 
 import numpy as np
-import keras
-from keras import Model
+import jax
+import jax.numpy as jp
 
 from paz.models.transformers.logits import soft_cap as apply_soft_cap
 from paz.models.foundation.gemma4.model import build_text_backbone_args
+from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
 from paz.models.foundation.gemma4.vision import (
-    build_vision_encoder, build_vision_encoder_args, num_patches)
-import jax
-
+    build_vision_encoder_args, num_patches)
 from paz.models.foundation.gemma4.multimodal import build_multimodal_backbone
-from paz.models.foundation.gemma4.model import (
-    Gemma4MultimodalDecoderStep, build_empty_cache)
 from paz.models.foundation.gemma4.multimodal_decoding import (
     prefill_logits, generate, generate_eager, generate_sample, generate_batch,
     generate_batch_greedy, build_prompt_rows, call_step, trim_to_stop,
@@ -23,30 +20,43 @@ from paz.models.foundation.gemma4.sampling import SamplingArgs
 
 TEXT = build_text_backbone_args(num_layers=2, sliding_window_pattern=2)
 VISION = build_vision_encoder_args(output_dim=TEXT.hidden_dim)
+SCALE = float(TEXT.hidden_dim) ** -0.5
 
 
-def last2(path):
-    path = path.replace("/dense/", "/")  # unwrap clippable einsum
-    return "/".join(path.split("/")[-2:])
+def build_multimodal():
+    model = build_multimodal_backbone(TEXT, VISION)
+    tokens, grid, pixels, indices = build_inputs()
+    model({"token_ids": tokens, "padding_mask": np.ones_like(tokens),
+           "pixel_values": pixels, "pixel_position_ids": grid,
+           "vision_indices": indices})
+    return model
 
 
-def transfer(source, target):
-    weights = {last2(w.path): np.asarray(keras.ops.convert_to_numpy(w))
-               for w in source.weights}
-    for variable in target.weights:
-        variable.assign(weights[last2(variable.path)].reshape(variable.shape))
+def causal_sharing(multimodal):
+    model = Gemma4CausalLM(TEXT)
+    model({"token_ids": jp.zeros((1, 1), "int32"),
+           "padding_mask": jp.ones((1, 1), "int32")})
+    for target, source in zip(model.backbone.weights,
+                              multimodal.backbone.weights):
+        target.assign(source)
+    return model
 
 
-def build_full_sequence_causal_lm():
-    backbone = build_multimodal_backbone(TEXT, VISION)
-    embedding = backbone.get_layer("token_embedding")
-    logits = apply_soft_cap(
-        embedding(backbone.output, reverse=True), TEXT.final_logit_soft_cap)
-    return Model(backbone.input, logits), backbone
+def full_sequence_logits(multimodal, inputs):
+    hidden = multimodal(inputs)
+    logits = multimodal.backbone.token_embedding(hidden, reverse=True)
+    return apply_soft_cap(logits, TEXT.final_logit_soft_cap)
 
 
-def build_inputs(pooled):
+def image_embeddings(multimodal, pixels, grid):
+    images = multimodal.vision_encoder(
+        {"pixel_values": pixels, "pixel_position_ids": grid})
+    return np.array(images)[0] * SCALE
+
+
+def build_inputs():
     side = VISION.image_size // VISION.patch_size
+    pooled = num_patches(VISION) // VISION.pool_size ** 2
     rng = np.random.default_rng(0)
     tokens = rng.integers(1, TEXT.vocabulary_size, (1, 12)).astype("int32")
     cols = np.tile(np.arange(side), side)
@@ -60,41 +70,33 @@ def build_inputs(pooled):
 
 
 def test_cached_multimodal_matches_full_sequence():
-    causal, backbone = build_full_sequence_causal_lm()
-    step = Gemma4MultimodalDecoderStep(TEXT)
-    vision = build_vision_encoder(VISION)
-    transfer(backbone, step)
-    transfer(backbone, vision)
-    pooled = num_patches(VISION) // VISION.pool_size ** 2
-    tokens, grid, pixels, vision_indices = build_inputs(pooled)
-    full_logits = np.array(causal({
-        "token_ids": tokens, "padding_mask": np.ones_like(tokens),
-        "pixel_values": pixels, "pixel_position_ids": grid,
-        "vision_indices": vision_indices}))[0]
-    scale = float(TEXT.hidden_dim) ** -0.5
-    image = np.array(vision(
-        {"pixel_values": pixels, "pixel_position_ids": grid}))[0] * scale
-    cached = np.array(prefill_logits(
-        step, None, image, TEXT, tokens[0], vision_indices[0]))[0]
-    assert float(np.max(np.abs(full_logits - cached))) < 1e-4
+    multimodal = build_multimodal()
+    model = causal_sharing(multimodal)
+    tokens, grid, pixels, indices = build_inputs()
+    inputs = {"token_ids": tokens, "padding_mask": np.ones_like(tokens),
+              "pixel_values": pixels, "pixel_position_ids": grid,
+              "vision_indices": indices}
+    full = np.array(full_sequence_logits(multimodal, inputs))[0]
+    image = image_embeddings(multimodal, pixels, grid)
+    cached = np.array(prefill_logits(model, image, tokens[0], indices[0]))[0]
+    assert float(np.max(np.abs(full - cached))) < 1e-4
 
 
-def reference_decode(step, per_layer_step, image, config, prompt_ids,
-                     vision_indices, stop_id, max_tokens):
-    import jax.numpy as jp
+def reference_decode(model, image, prompt_ids, vision_indices, stop_id,
+                     max_tokens):
     embeds, per_layer = build_prompt_rows(
-        step, image, prompt_ids, vision_indices, per_layer_step)
+        model, image, prompt_ids, vision_indices)
     length = embeds.shape[1]
-    cache = jp.asarray(build_empty_cache(config, length + max_tokens))
+    cache = jp.asarray(model.build_cache(length + max_tokens))
     positions = jp.arange(length, dtype="int32")[None]
-    logits, cache = call_step(step, embeds, cache, 0, positions, per_layer)
+    logits, cache = call_step(model, embeds, cache, 0, positions, per_layer)
     token = int(jp.argmax(logits[0, -1]))
-    embedding = step.get_layer("token_embedding")
     out, index = [token], length
     while token != stop_id and len(out) < max_tokens:
         positions = jp.array([[index]], dtype="int32")
         logits, cache = call_step(
-            step, embedding(as_token(token)), cache, index, positions, None)
+            model, model.backbone.token_embedding(as_token(token)), cache,
+            index, positions, None)
         token = int(jp.argmax(logits[0, -1]))
         out.append(token)
         index += 1
@@ -102,122 +104,102 @@ def reference_decode(step, per_layer_step, image, config, prompt_ids,
 
 
 def test_jitted_decode_matches_reference():
-    causal, backbone = build_full_sequence_causal_lm()
-    step = Gemma4MultimodalDecoderStep(TEXT)
-    vision = build_vision_encoder(VISION)
-    transfer(backbone, step)
-    transfer(backbone, vision)
-    pooled = num_patches(VISION) // VISION.pool_size ** 2
-    tokens, grid, pixels, vision_indices = build_inputs(pooled)
-    scale = float(TEXT.hidden_dim) ** -0.5
-    image = np.array(vision(
-        {"pixel_values": pixels, "pixel_position_ids": grid}))[0] * scale
+    multimodal = build_multimodal()
+    model = causal_sharing(multimodal)
+    tokens, grid, pixels, indices = build_inputs()
+    image = image_embeddings(multimodal, pixels, grid)
     stop = int(TEXT.vocabulary_size - 1)
-    args = (step, None, image, TEXT, tokens[0], vision_indices[0], stop, 5)
+    args = (model, image, tokens[0], indices[0], stop, 5)
     got = generate(*args)
-    reference = reference_decode(*args)
     assert len(got) >= 1
-    assert got == reference
+    assert got == reference_decode(*args)
 
 
-def build_text_step():
-    causal, backbone = build_full_sequence_causal_lm()
-    step = Gemma4MultimodalDecoderStep(TEXT)
-    transfer(backbone, step)
-    return step
+def build_text_model():
+    return causal_sharing(build_multimodal())
+
+
+NO_VISION = np.zeros((0, TEXT.hidden_dim), "float32")
 
 
 def test_generate_batch_greedy_matches_single_sequence():
-    step = build_text_step()
+    model = build_text_model()
     prompt = [2, 5, 9, 11, 7]
     stop = int(TEXT.vocabulary_size - 1)
-    no_vision = np.zeros((0, TEXT.hidden_dim), "float32")
-    single = generate(step, None, no_vision, TEXT, prompt, [], stop, 6)
+    single = generate(model, NO_VISION, prompt, [], stop, 6)
     prompts = np.array([prompt, prompt, prompt], dtype="int32")
-    rows = generate_batch_greedy(step, None, TEXT, prompts, stop, 6)
-    assert rows[0] == single
-    assert rows[1] == single and rows[2] == single
+    rows = generate_batch_greedy(model, prompts, stop, 6)
+    assert rows[0] == single and rows[1] == single and rows[2] == single
 
 
 def test_generate_eager_matches_jitted_greedy():
-    step = build_text_step()
+    model = build_text_model()
     prompt = [2, 5, 9, 11, 7]
     stop = int(TEXT.vocabulary_size - 1)
-    nov = np.zeros((0, TEXT.hidden_dim), "float32")
-    jitted = generate(step, None, nov, TEXT, prompt, [], stop, 6)
-    eager = generate_eager(step, None, nov, TEXT, prompt, [], stop, 6)
+    jitted = generate(model, NO_VISION, prompt, [], stop, 6)
+    eager = generate_eager(model, NO_VISION, prompt, [], stop, 6)
     assert eager == jitted
 
 
 def test_generator_with_vision_matches_eager_reference():
-    causal, backbone = build_full_sequence_causal_lm()
-    step = Gemma4MultimodalDecoderStep(TEXT)
-    vision = build_vision_encoder(VISION)
-    transfer(backbone, step)
-    transfer(backbone, vision)
-    pooled = num_patches(VISION) // VISION.pool_size ** 2
-    tokens, grid, pixels, vision_indices = build_inputs(pooled)
-    scale = float(TEXT.hidden_dim) ** -0.5
-    image = np.array(vision(
-        {"pixel_values": pixels, "pixel_position_ids": grid}))[0] * scale
+    multimodal = build_multimodal()
+    model = causal_sharing(multimodal)
+    tokens, grid, pixels, indices = build_inputs()
+    image = image_embeddings(multimodal, pixels, grid)
     stop = int(TEXT.vocabulary_size - 1)
-    prompt, indices = list(tokens[0]), list(vision_indices[0])
-    reference = generate_eager(step, None, image, TEXT, prompt, indices, stop, 5)
-    generate = build_generator(
-        step, None, TEXT, stop, max_tokens=5, max_seq=64, max_prompt=32)
-    assert generate(prompt, image, indices) == reference
+    prompt, vision_indices = list(tokens[0]), list(indices[0])
+    reference = generate_eager(model, image, prompt, vision_indices, stop, 5)
+    decode = build_generator(
+        model, stop, max_tokens=5, max_seq=64, max_prompt=32)
+    assert decode(prompt, image, vision_indices) == reference
 
 
 def test_text_generator_matches_reference_greedy():
-    step = build_text_step()
+    model = build_text_model()
     prompt = [2, 5, 9, 11, 7]
     stop = int(TEXT.vocabulary_size - 1)
-    nov = np.zeros((0, TEXT.hidden_dim), "float32")
-    reference = generate(step, None, nov, TEXT, prompt, [], stop, 6)
+    reference = generate(model, NO_VISION, prompt, [], stop, 6)
     decode = build_text_generator(
-        step, None, TEXT, stop, max_tokens=6, max_seq=64, max_prompt=16)
+        model, stop, max_tokens=6, max_seq=64, max_prompt=16)
     assert decode(prompt) == reference
 
 
 def test_text_generator_streams_tokens_in_order():
-    step = build_text_step()
+    model = build_text_model()
     prompt = [2, 5, 9, 11, 7]
     stop = int(TEXT.vocabulary_size - 1)
     seen = []
     decode = build_text_generator(
-        step, None, TEXT, stop, max_tokens=6, max_seq=64, max_prompt=16,
+        model, stop, max_tokens=6, max_seq=64, max_prompt=16,
         emit=lambda token_id: seen.append(int(token_id)))
     generated = decode(prompt)
     assert seen[:len(generated)] == generated
 
 
 def test_generate_sample_peaked_matches_greedy_and_is_seeded():
-    step = build_text_step()
+    model = build_text_model()
     prompt = [2, 5, 9, 11, 7]
     stop = int(TEXT.vocabulary_size - 1)
-    nov = np.zeros((0, TEXT.hidden_dim), "float32")
-    greedy = generate(step, None, nov, TEXT, prompt, [], stop, 6)
-    peaked = generate_sample(step, None, nov, TEXT, prompt, [], stop, 6,
+    greedy = generate(model, NO_VISION, prompt, [], stop, 6)
+    peaked = generate_sample(model, NO_VISION, prompt, [], stop, 6,
                              jax.random.PRNGKey(0), SamplingArgs(1.0, 1, 1.0))
     assert peaked == greedy  # top_k=1 == argmax (no float32 ties here)
     args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
-    a = generate_sample(step, None, nov, TEXT, prompt, [], stop, 8,
+    a = generate_sample(model, NO_VISION, prompt, [], stop, 8,
                         jax.random.PRNGKey(5), args)
-    b = generate_sample(step, None, nov, TEXT, prompt, [], stop, 8,
+    b = generate_sample(model, NO_VISION, prompt, [], stop, 8,
                         jax.random.PRNGKey(5), args)
     assert a == b
 
 
 def test_generate_batch_sampling_is_seeded_and_valid():
-    step = build_text_step()
+    model = build_text_model()
     stop = int(TEXT.vocabulary_size - 1)
     prompts = np.array([[2, 5, 9, 11, 7]] * 4, dtype="int32")
     args = SamplingArgs(temperature=1.0, top_k=0, top_p=1.0)
-    rows_a = generate_batch(step, None, TEXT, prompts,
-                            jax.random.PRNGKey(1), args, stop, 8)
-    rows_b = generate_batch(step, None, TEXT, prompts,
-                            jax.random.PRNGKey(1), args, stop, 8)
+    rows_a = generate_batch(model, prompts, jax.random.PRNGKey(1), args, stop, 8)
+    rows_b = generate_batch(model, prompts, jax.random.PRNGKey(1), args, stop, 8)
     assert rows_a == rows_b  # same key -> reproducible
-    flat = [t for row in rows_a for t in row]
-    assert all(0 <= t < TEXT.vocabulary_size for t in flat)
-    assert len({tuple(r) for r in rows_a}) > 1  # rows diverge under sampling
+    flat = [token for row in rows_a for token in row]
+    assert all(0 <= token < TEXT.vocabulary_size for token in flat)
+    assert len({tuple(row) for row in rows_a}) > 1  # rows diverge

--- a/paz/models/foundation/gemma4/pretrained.py
+++ b/paz/models/foundation/gemma4/pretrained.py
@@ -1,0 +1,169 @@
+"""Download and build pretrained Gemma4 bundles.
+
+One canonical text artifact (`backbone.weights.h5`) holds all transformer
+weights; the vision encoder stays a separate artifact. GitHub release assets are
+capped at 2 GB, so larger files are uploaded as byte-identical parts and
+reassembled on download (see `shard_weights`).
+"""
+import hashlib
+import json
+import shutil
+from collections import namedtuple
+from pathlib import Path
+
+import jax.numpy as jp
+from keras.utils import get_file
+
+from paz.models.foundation.gemma4.configuration import load_config
+from paz.models.foundation.gemma4.causal_lm import Gemma4CausalLM
+from paz.models.foundation.gemma4.vision import VisionEncoderArgs
+from paz.models.foundation.gemma4.vision import build_vision_encoder
+
+GEMMA4_WEIGHTS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.26/"  # fmt: skip
+GEMMA4_CACHE = "paz/models/gemma4"
+PART_BYTES = 1_900_000_000
+GEMMA4_WEIGHT_FILES = (
+    "config.json", "tokenizer.json", "vision_config.json",
+    "vision_encoder.weights.h5", "backbone.weights.h5",
+)
+Gemma4Models = namedtuple("Gemma4", "config model vision_encoder")
+
+
+def Gemma4(model_name="gemma4_2b", weights="pretrained", models_path=None):
+    model_dir = resolve_dir(model_name, models_path)
+    config = load_config(model_dir / "config.json")
+    model = build_causal_lm(config)
+    vision_encoder = build_vision_encoder_from_dir(model_dir)
+    if weights is not None:
+        model.backbone.load_weights(str(model_dir / "backbone.weights.h5"))
+        load_vision_weights(model_dir, vision_encoder)
+    return Gemma4Models(config, model, vision_encoder)
+
+
+def build_causal_lm(config):
+    model = Gemma4CausalLM(config)
+    materialize_weights(model, config)
+    return model
+
+
+def materialize_weights(model, config):
+    # Subclassed models create variables lazily; run one tiny forward so
+    # load_weights has variables to fill.
+    token_ids = jp.zeros((1, 1), dtype="int32")
+    padding_mask = jp.ones((1, 1), dtype="int32")
+    model({"token_ids": token_ids, "padding_mask": padding_mask})
+
+
+def resolve_dir(model_name, models_path):
+    if models_path is not None:
+        return Path(models_path)
+    return download_weights(model_name)
+
+
+def download_weights(model_name):
+    subdir = "{}/{}".format(GEMMA4_CACHE, model_name)
+    asset = "{}.manifest.json".format(model_name)
+    manifest_path = Path(get_file(
+        asset, GEMMA4_WEIGHTS_URL + asset, cache_subdir=subdir))
+    model_dir = manifest_path.parent
+    manifest = json.loads(manifest_path.read_text())
+    for filename, entry in manifest.items():
+        assemble_weights_file(model_dir / filename, entry, subdir)
+    return model_dir
+
+
+def assemble_weights_file(path, entry, subdir):
+    checksum = entry.get("sha256")
+    if is_complete(path, checksum):
+        return path
+    parts = []
+    for asset in entry["parts"]:
+        parts.append(get_file(
+            asset, GEMMA4_WEIGHTS_URL + asset, cache_subdir=subdir))
+    concatenate_parts(parts, path)
+    if checksum is not None and compute_sha256(path) != checksum:
+        raise ValueError("Checksum mismatch after assembling {}".format(path))
+    return path
+
+
+def is_complete(path, checksum):
+    if not path.exists():
+        return False
+    return checksum is None or compute_sha256(path) == checksum
+
+
+def concatenate_parts(parts, output):
+    with open(str(output), "wb") as merged:
+        for part in parts:
+            with open(str(part), "rb") as chunk:
+                shutil.copyfileobj(chunk, merged)
+    return output
+
+
+def compute_sha256(path):
+    digest = hashlib.sha256()
+    with open(str(path), "rb") as file:
+        for block in iter(lambda: file.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def shard_weights(source_dir, model_name, output_dir, part_bytes=PART_BYTES):
+    """Split a local weights dir into <2 GB parts plus an upload manifest."""
+    source_dir, output_dir = Path(source_dir), Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {}
+    for filename in GEMMA4_WEIGHT_FILES:
+        source = source_dir / filename
+        if not source.exists():
+            continue
+        prefix = "{}_{}".format(model_name, filename)
+        parts = split_file(source, output_dir, prefix, part_bytes)
+        manifest[filename] = {"parts": parts, "sha256": compute_sha256(source)}
+    manifest_path = output_dir / "{}.manifest.json".format(model_name)
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    return manifest_path
+
+
+def split_file(source, output_dir, prefix, part_bytes=PART_BYTES):
+    output_dir = Path(output_dir)
+    parts, index = [], 0
+    with open(str(source), "rb") as file:
+        while True:
+            block = file.read(part_bytes)
+            if not block:
+                break
+            asset = "{}.part{}".format(prefix, index)
+            (output_dir / asset).write_bytes(block)
+            parts.append(asset)
+            index = index + 1
+    return parts
+
+
+def build_vision_encoder_from_dir(model_dir):
+    path = Path(model_dir) / "vision_config.json"
+    if not path.exists():
+        return None
+    with open(str(path), encoding="utf-8") as file:
+        config = VisionEncoderArgs(**json.load(file))
+    return build_vision_encoder(config)
+
+
+def load_vision_encoder(model_dir, weights="pretrained"):
+    """Build and load just the vision encoder, on the current default device.
+
+    Use inside a `jax.default_device(...)` block to place it where you want,
+    then swap it into a bundle: `Gemma4(...)._replace(vision_encoder=vision)`.
+    """
+    model_dir = Path(model_dir)
+    vision_encoder = build_vision_encoder_from_dir(model_dir)
+    if weights is not None and vision_encoder is not None:
+        vision_encoder.load_weights(
+            str(model_dir / "vision_encoder.weights.h5"))
+    return vision_encoder
+
+
+def load_vision_weights(model_dir, vision_encoder):
+    if vision_encoder is not None:
+        vision_encoder.load_weights(
+            str(Path(model_dir) / "vision_encoder.weights.h5"))

--- a/scripts/migrate_gemma4_weights.py
+++ b/scripts/migrate_gemma4_weights.py
@@ -1,0 +1,84 @@
+"""Migrate the old split Gemma4 weights into one backbone.weights.h5.
+
+The published v0.24 assets (decoder_step.weights.h5 + embedding_step.weights.h5)
+were serialized from the old functional step models. Their h5 groups use
+class-auto names, so recovering the semantic role of each tensor needs the old
+model structure. This runs in two phases:
+
+  --phase dump   (run on the PRE-REFACTOR commit): loads the split weights into
+                 the old Gemma4DecoderStep + Gemma4PerLayerEmbeddingStep and
+                 saves each variable to an .npy keyed by its role.
+  --phase build  (run on this refactor): builds the new Gemma4Backbone and fills
+                 it from the role dump, then writes backbone.weights.h5.
+
+Keras-hub users do not need this; convert with conversion.convert instead. This
+path exists to re-export the already-downloaded weights offline.
+"""
+import argparse
+import re
+from pathlib import Path
+
+import numpy as np
+from keras import ops
+
+
+def role_key(path):
+    match = re.search(r"decoder_block_(\d+)", path)
+    if match:
+        rest = path[match.end():].lstrip("/_").replace("/", "_")
+        rest = rest.replace("attention_attention_output", "attention_output")
+        if "layer_scalar" in rest:
+            rest = "layer_scalar"
+        return "b{}:{}".format(int(match.group(1)), rest)
+    return "g:" + "_".join(path.split("/")[-2:])
+
+
+def dump_phase(model_dir, dump_dir):
+    from paz.models.foundation.gemma4.configuration import load_config
+    from paz.models.foundation.gemma4.model import (
+        Gemma4DecoderStep, Gemma4PerLayerEmbeddingStep)
+    config = load_config(model_dir / "config.json")
+    decoder = Gemma4DecoderStep(config)
+    decoder.load_weights(str(model_dir / "decoder_step.weights.h5"))
+    embedding = Gemma4PerLayerEmbeddingStep(config)
+    embedding.load_weights(str(model_dir / "embedding_step.weights.h5"))
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    for model in (decoder, embedding):
+        for weight in model.weights:
+            array = np.asarray(ops.convert_to_numpy(weight))
+            np.save(dump_dir / (safe(role_key(weight.path)) + ".npy"), array)
+
+
+def build_phase(model_dir, dump_dir):
+    import ml_dtypes
+    from paz.models.foundation.gemma4.configuration import load_config
+    from paz.models.foundation.gemma4.model import Gemma4Backbone
+    import jax.numpy as jp
+    config = load_config(model_dir / "config.json")
+    backbone = Gemma4Backbone(config)
+    backbone({"token_ids": jp.zeros((1, 1), "int32"),
+              "padding_mask": jp.ones((1, 1), "int32")})
+    for weight in backbone.weights:
+        array = np.load(dump_dir / (safe(role_key(weight.path)) + ".npy"))
+        if array.dtype == np.dtype("V2"):
+            array = array.view(ml_dtypes.bfloat16)
+        weight.assign(array.reshape(weight.shape))
+    backbone.save_weights(str(model_dir / "backbone.weights.h5"))
+
+
+def safe(key):
+    return key.replace(":", "__")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Migrate Gemma4 split weights")
+    add = parser.add_argument
+    add("--phase", required=True, choices=("dump", "build"))
+    add("--model_dir", required=True)
+    add("--dump_dir", required=True)
+    args = parser.parse_args()
+    model_dir, dump_dir = Path(args.model_dir), Path(args.dump_dir)
+    if args.phase == "dump":
+        dump_phase(model_dir, dump_dir)
+    else:
+        build_phase(model_dir, dump_dir)


### PR DESCRIPTION
## Why

Gemma4 was built in a functional graph-building style, so it existed as **two
independent `Model` objects with two independent weight sets**: the
full-sequence backbone (`build_text_backbone` / `Gemma4CausalLM`, scoring) and
the single-step generation stack (`Gemma4DecoderStep` /
`Gemma4MultimodalDecoderStep` + `Gemma4PerLayerEmbeddingStep`, generation). The
shipped pretrained weights existed only for the generation stack; the
full-sequence path had no artifact. Same architecture, two serialized variable
sets — a forced consequence of the functional style.

## What changed

Moved Gemma4 to a KerasHub-shaped, subclassed backbone that owns all transformer
weights exactly once, with two explicit call paths sharing them:

- `Gemma4Backbone(keras.Model)` — owns the token embedding, per-layer embedding
  table, the `Gemma4DecoderLayer` list and the final norm. `call({token_ids,
  padding_mask})` is the full-sequence forward; `call_with_cache(input_embedding,
  cache, index, ...)` is the cached single/multi-step forward. Two explicit
  methods, no `cache=None` behavior flag.
- `Gemma4DecoderLayer(keras.layers.Layer)` — creates its sublayers once and
  threads them into pure helpers in `layers/attention.py` (the transformer math
  is reused, not rewritten).
- `Gemma4CausalLM` — wraps the backbone with reverse-embedding logits + final
  soft-cap; drives generation through `call_with_cache`.

There is now **one canonical text artifact**, `backbone.weights.h5` (the vision
encoder stays a separate artifact). The per-layer embedding table is folded into
the backbone. The jitted decode passes weights as explicit args via
`keras.StatelessScope` (matching keras-hub), so `jax.jit` does not constant-fold
the multi-GB tables. Loader/sharding moved to `pretrained.py` (this also fixes
the stale `scripts/shard_gemma4.py` import). `conversion.py` writes the single
artifact; `scripts/migrate_gemma4_weights.py` re-exports the old split weights
offline.

Every capability is preserved and covered by tests: per-layer input embeddings,
KV-sharing, per-layer sliding-window vs global attention, dual RoPE
wavelengths/partial rotary, cache-head-dim padding, soft-cap, bf16 + float16
guard, multimodal image-embedding injection, and both `gemma4_2b` / `gemma4_4b`.

## New public API

- `paz.models.Gemma4(name)` → bundle `(config, model, vision_encoder)` where
  `model` is a `Gemma4CausalLM`.
- `paz.models.Gemma4Backbone`, `paz.models.Gemma4CausalLM`.
- `paz.applications.GenerateGemma4`, `DescribeImageGemma4` (+ 2B/4B wrappers) —
  unchanged signatures.

## Re-shipped weights

Re-exported gemma4_2b and gemma4_4b to the single-backbone format and published
to a **new** altamira-data release **v0.26** (`backbone.weights.h5` sharded +
manifest + vision encoder + config + tokenizer + Gemma NOTICE);
`GEMMA4_WEIGHTS_URL` points there. The old **v0.24** release is left intact as
the rollback path.

## Verification

- Full suite green: `pytest paz/models/foundation/gemma4/` — 42 passed, 4
  skipped (keras-hub-gated + the opt-in weights test), on the JAX backend.
- Prefill parity (new test): `call` at position *t* matches `call_with_cache`
  after feeding tokens 0…*t* (exact in float32) — the check that would have
  caught the original split-weights gap.
- Pretrained parity (gemma4_2b and gemma4_4b): migrated weights reproduce the
  pre-refactor goldens — greedy decode identical ("The capital of Germany is
  **Berlin**."), per-position argmax matches.
- End-to-end on real weights: `GenerateGemma4` (jitted stateless path) and
  `DescribeImageGemma4` (multimodal) both correct.
- Clean-room: a fresh download of the published v0.26 assets loads into the new
  backbone and reproduces the goldens.
