### PR TITLE
Fix degenerate softmax warning during Gemma4 weight materialization

### DIFF
--- a/paz/models/foundation/gemma4/pretrained.py
+++ b/paz/models/foundation/gemma4/pretrained.py
@@ -48,9 +48,10 @@ def build_causal_lm(config):
 
 def materialize_weights(model, config):
     # Subclassed models create variables lazily; run one tiny forward so
-    # load_weights has variables to fill.
-    token_ids = jp.zeros((1, 1), dtype="int32")
-    padding_mask = jp.ones((1, 1), dtype="int32")
+    # load_weights has variables to fill. A seq_len of 2 keeps attention's
+    # key axis above size 1, avoiding a degenerate all-ones softmax.
+    token_ids = jp.zeros((1, 2), dtype="int32")
+    padding_mask = jp.ones((1, 2), dtype="int32")
     model({"token_ids": token_ids, "padding_mask": padding_mask})
 
 


### PR DESCRIPTION
## Summary
`materialize_weights` ran a dummy forward pass with `seq_len=1` to force
lazy variable creation before `load_weights()`. That collapsed attention's
key axis to size 1, triggering Keras's "softmax over an axis of size 1"
warning during every `Gemma4(...)` build. Bump the warmup to `seq_len=2` so
the softmax runs over a real key axis.

## Verification
- `pytest paz/models/foundation/gemma4/`: 41 passed, 4 skipped, 1 failed.
  The failure (`model_test.py::test_prefill_parity_call_matches_call_with_cache`)
  is a pre-existing, unseeded numerical-tolerance flake — confirmed identical
  failure on the unmodified base commit.
- Opt-in real-weights test
  (`gemma4_test.py::test_gemma4_generates_capital_of_germany`,
  `GEMMA4_WEIGHTS_TEST=1`): fails identically before and after this change,
  due to a local weights cache that predates the PR #402 backbone refactor
  (stale variable names), not this change.
- `pyflakes` on the changed file: clean.