### PR TITLE
Depth Anything 3 weight hosting + pretrained estimators

### DIFF
--- a/examples/depth_anything3/estimate_metric.py
+++ b/examples/depth_anything3/estimate_metric.py
@@ -16,13 +16,13 @@ from paz.applications import EstimateDepthAnything3MetricLarge
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--weights", required=True)
+    parser.add_argument("--weights", default="pretrained")
     parser.add_argument("--image", required=True)
     parser.add_argument("--focal_length", type=float, required=True)
     parser.add_argument("--image_size", type=int, default=518)
     args = parser.parse_args()
 
-    settings = args.weights, args.focal_length, args.image_size
+    settings = args.focal_length, args.weights, args.image_size
     estimate = EstimateDepthAnything3MetricLarge(*settings)
     depth_meters, sky = estimate(paz.image.load(args.image))
 

--- a/examples/depth_anything3/estimate_multi_view.py
+++ b/examples/depth_anything3/estimate_multi_view.py
@@ -13,7 +13,7 @@ from paz.applications import EstimateDepthAnything3Small
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--weights", required=True)
+    parser.add_argument("--weights", default="pretrained")
     parser.add_argument("--images", nargs="+", required=True)
     parser.add_argument("--image_size", type=int, default=518)
     args = parser.parse_args()

--- a/examples/depth_anything3/estimate_single_view.py
+++ b/examples/depth_anything3/estimate_single_view.py
@@ -13,7 +13,7 @@ from paz.applications import EstimateDepthAnything3MonoLarge
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--weights", required=True)
+    parser.add_argument("--weights", default="pretrained")
     parser.add_argument("--image", required=True)
     parser.add_argument("--image_size", type=int, default=518)
     parser.add_argument("--output", default="depth.png")

--- a/paz/applications/depth_estimators.py
+++ b/paz/applications/depth_estimators.py
@@ -2,8 +2,8 @@
 
 Preprocessing happens outside the compiled model: images are resized to a
 fixed square resolution (a multiple of the patch size), scaled to [0, 1], and
-ImageNet-normalized. Weights come from a converted ``.weights.h5`` file; pass
-its path explicitly until hosting is available.
+ImageNet-normalized. ``weights="pretrained"`` (the default) downloads the
+hosted weights; pass a local ``.weights.h5`` path to override.
 
 Any-view estimators return, in order:
 ``depth, depth_confidence, extrinsics, intrinsics, rays, ray_confidence``.
@@ -16,15 +16,18 @@ from keras import ops
 from paz.backend.image import resize_opencv, standardize
 from paz.models import DepthAnything3Small, DepthAnything3Base
 from paz.models import DepthAnything3MonoLarge, DepthAnything3MetricLarge
+from paz.models.foundation.depth_anything3 import pretrained
 
 
-def EstimateDepthAnything3Small(weights_path, image_size=518):
-    args = DepthAnything3Small, weights_path, image_size
+def EstimateDepthAnything3Small(weights="pretrained", image_size=518):
+    path = resolve_weights(weights, "da3_small")
+    args = DepthAnything3Small, path, image_size
     return build_any_view_estimator(*args)
 
 
-def EstimateDepthAnything3Base(weights_path, image_size=518):
-    args = DepthAnything3Base, weights_path, image_size
+def EstimateDepthAnything3Base(weights="pretrained", image_size=518):
+    path = resolve_weights(weights, "da3_base")
+    args = DepthAnything3Base, path, image_size
     return build_any_view_estimator(*args)
 
 
@@ -39,8 +42,9 @@ def build_any_view_estimator(builder, weights_path, image_size):
     return estimate
 
 
-def EstimateDepthAnything3MonoLarge(weights_path, image_size=518):
-    model = load_mono_model(DepthAnything3MonoLarge, weights_path, image_size)
+def EstimateDepthAnything3MonoLarge(weights="pretrained", image_size=518):
+    path = resolve_weights(weights, "da3_mono_large")
+    model = load_mono_model(DepthAnything3MonoLarge, path, image_size)
 
     def estimate(image):
         return model(preprocess_batch(image, image_size))
@@ -48,15 +52,22 @@ def EstimateDepthAnything3MonoLarge(weights_path, image_size=518):
     return estimate
 
 
-def EstimateDepthAnything3MetricLarge(weights_path, focal_length,
+def EstimateDepthAnything3MetricLarge(focal_length, weights="pretrained",
                                       image_size=518):
-    model = load_mono_model(DepthAnything3MetricLarge, weights_path, image_size)
+    path = resolve_weights(weights, "da3_metric_large")
+    model = load_mono_model(DepthAnything3MetricLarge, path, image_size)
 
     def estimate(image):
         depth, sky = model(preprocess_batch(image, image_size))
         return focal_length * depth / 300.0, sky
 
     return estimate
+
+
+def resolve_weights(weights, model_name):
+    if weights == "pretrained":
+        return pretrained.download_weights(model_name)
+    return weights
 
 
 def load_mono_model(builder, weights_path, image_size):

--- a/paz/models/foundation/depth_anything3/NOTICE.md
+++ b/paz/models/foundation/depth_anything3/NOTICE.md
@@ -1,0 +1,6 @@
+# Depth Anything 3 — attribution
+
+Weights converted from the official Depth Anything 3 checkpoints (ByteDance
+Seed, Apache-2.0, https://github.com/ByteDance-Seed/Depth-Anything-3, commit
+`e74fd796`) with a DINOv2 backbone (Meta, Apache-2.0). Only the Apache-2.0
+checkpoints (SMALL, BASE, MONO-LARGE, METRIC-LARGE) are converted here.

--- a/paz/models/foundation/depth_anything3/convert.py
+++ b/paz/models/foundation/depth_anything3/convert.py
@@ -17,6 +17,7 @@ from paz.models.foundation.depth_anything3 import port_weights
 
 UPSTREAM = "https://github.com/ByteDance-Seed/Depth-Anything-3"
 UPSTREAM_COMMIT = "e74fd796e96b7e781a5506fd8503b6bd7232513c"
+LICENSE = "Apache-2.0"
 IMAGE_SHAPE = (518, 518, 3)
 SMALL = ("depth-anything/DA3-SMALL", models.DepthAnything3Small, 384,
          "da3_small_paz_jax")
@@ -80,7 +81,7 @@ def verify_reload(model, reloaded, path, image_shape, views):
 def write_metadata(output_directory, repository, stem, state, path):
     checkpoint = find_checkpoint(repository)
     metadata = dict(repository=repository, upstream=UPSTREAM,
-                    upstream_commit=UPSTREAM_COMMIT,
+                    upstream_commit=UPSTREAM_COMMIT, license=LICENSE,
                     source_sha256=sha256(checkpoint),
                     converted_sha256=sha256(path))
     with open(os.path.join(output_directory, f"{stem}.json"), "w") as opened:

--- a/paz/models/foundation/depth_anything3/pretrained.py
+++ b/paz/models/foundation/depth_anything3/pretrained.py
@@ -1,0 +1,20 @@
+"""Download pretrained Depth Anything 3 weights from the paz data release.
+
+Each model is a single ``.weights.h5`` asset built at the 518x518 process
+resolution. See NOTICE.md for upstream attribution and licensing.
+"""
+from keras.utils import get_file
+
+WEIGHTS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.27/"  # fmt: skip
+CACHE = "paz/models/depth_anything3"
+WEIGHTS = {
+    "da3_small": "da3_small_paz_jax.weights.h5",
+    "da3_base": "da3_base_paz_jax.weights.h5",
+    "da3_mono_large": "da3_mono_large_paz_jax.weights.h5",
+    "da3_metric_large": "da3_metric_large_paz_jax.weights.h5",
+}
+
+
+def download_weights(model_name):
+    asset = WEIGHTS[model_name]
+    return get_file(asset, WEIGHTS_URL + asset, cache_subdir=CACHE)


### PR DESCRIPTION
Release-side follow-up to the DA3 port (#401): host the converted weights and
make the estimators download them by default, plus the deferred licensing.

## Hosting
- Uploaded the four Apache-2.0 models to `oarriaga/altamira-data` **v0.27** as
  single `.weights.h5` assets (SMALL, BASE, MONO-LARGE, METRIC-LARGE; built at
  518x518, all under GitHub's 2 GB limit), each with a `.json` provenance
  record (source repo, upstream commit, license, SHA-256).
- `depth_anything3/pretrained.py`: `download_weights(model_name)` fetches an
  asset via `keras.utils.get_file` (whisper/xfeat/gemma pattern).

## API
- `EstimateDepthAnything3Small/Base/MonoLarge/MetricLarge` default to
  `weights="pretrained"` (auto-download), local `.weights.h5` path overrides —
  Gemma/SSD convention. Metric takes `focal_length` first. Examples default
  `--weights pretrained`.

## Licensing
- Re-added the Apache-2.0 `license` field to the conversion metadata and added
  `NOTICE.md` crediting ByteDance Seed (Depth Anything 3) and Meta (DINOv2),
  both Apache-2.0. Only Apache-2.0 checkpoints are converted/hosted.

## Verification (`KERAS_BACKEND=jax`)
- End-to-end: `EstimateDepthAnything3Small()` downloads from v0.27, loads, runs
  — finite depth, correct intrinsics.
- `pytest paz/models/foundation/depth_anything3 paz/applications/depth_estimators_test.py`
  — 11 passed, 4 skipped (opt-in reference). 80-column and pyflakes clean.
