### PR TITLE
Port SONIC deploy actor from Keras to paz style

### DIFF
--- a/examples/sonic/README.md
+++ b/examples/sonic/README.md
@@ -1,0 +1,134 @@
+# SONIC in MuJoCo
+
+This example runs the ported PAZ SONIC actor directly with the Keras JAX
+backend. It imports the released ONNX parameters into the PAZ architecture,
+then closes the loop around the original 43-DoF G1 MuJoCo plant: 29 SONIC
+body joints plus the two 7-DoF Dex3 hands.
+
+The demo intentionally uses the deployment observation layout and controller
+constants. It does not call the older Python Keras model or ONNX Runtime for
+inference.
+
+Startup matches the deployment workflow: three seconds of pose
+initialization, then two seconds of paused batch-1 policy ticks to build
+history. The original elastic band is released and playback starts
+automatically.
+
+## Install
+
+From the PAZ repository:
+
+    python3 -m pip install -e '.[sonic]'
+
+The demo also needs a local GR00T-WholeBodyControl repository. It reads the
+release policy and motions from gear_sonic_deploy and the original 43-DoF
+MuJoCo plant from gear_sonic. It automatically finds that repository when it
+is a sibling of PAZ, as in the current worktrees.
+
+For another layout, pass the location explicitly:
+
+    python3 examples/sonic/mujoco_demo.py \
+        --sonic-root /path/to/gear_sonic_deploy
+
+SONIC_DEPLOY_DIR can be set instead of passing the flag every time.
+
+## Run
+
+Launch the GUI in reference-motion mode:
+
+    python3 examples/sonic/mujoco_demo.py
+
+Select a motion by a case-insensitive part of its name:
+
+    python3 examples/sonic/mujoco_demo.py --motion macarena
+
+Start in virtual 3-point teleoperation mode:
+
+    python3 examples/sonic/mujoco_demo.py \
+        --mode teleop --motion walking
+
+The first launch compiles the actor with JAX and can take several seconds.
+Only run one copy on a memory-constrained GPU. CPU execution is available with:
+
+    JAX_PLATFORM_NAME=cpu python3 examples/sonic/mujoco_demo.py
+
+## Controls
+
+| Key | Action |
+| --- | --- |
+| Space | Pause or resume the reference stream |
+| Left bracket / right bracket | Previous or next bundled motion |
+| Comma / period | Step one frame while paused |
+| 1 | Full G1 reference-motion encoder |
+| 2 | 3-point teleoperation encoder |
+| 3 | SMPL human-motion encoder, when the clip provides SMPL data |
+| G | Toggle the original simulator elastic band |
+| V | Hide or show reference targets |
+| R | Reset the current motion and controller history |
+| H | Print the controls in the terminal |
+| Esc | Close MuJoCo |
+
+The upper-left HUD shows the PAZ backend, encoder mode, motion, frame,
+controller phase, playback state, and elastic-band state. Cyan points show
+G1 body targets. Blue, red, and yellow points show the left hand, right hand,
+and head targets in teleoperation mode. SMPL joints are magenta.
+
+## Supported SONIC inputs
+
+The released actor has three encoder branches:
+
+- G1 mode consumes ten future full-body joint states and anchor orientations.
+  It works with every bundled example clip.
+- Teleoperation mode consumes future lower-body states plus the two wrist and
+  head targets. Without a headset, this demo follows the original controller's
+  fallback and derives those three targets from the bundled motion. This makes
+  the branch reproducible and easy to inspect.
+- SMPL mode consumes ten frames of 24 root-local human joints, root
+  orientations, and G1 wrist joints. The bundled release has no SMPL sample,
+  so the GUI enables this branch only when the selected motion directory has a
+  smpl_joints.csv file. It must contain a header and one 72-value row per
+  motion frame in the release's 24-joint ordering. Missing human joints are
+  never replaced by synthetic zeros.
+
+The elastic band is active only during initialization and policy warmup. The
+demo releases it before the first playback tick, so the default rollout is
+unassisted. Press G to restore it for inspection or recovery. Press R to reset
+the physics, controller history, and startup workflow.
+
+## Headless validation
+
+The same entry point provides a deterministic smoke test without a window:
+
+    python3 examples/sonic/mujoco_demo.py \
+        --headless --steps 2600 --mode g1 --motion squat
+
+    python3 examples/sonic/mujoco_demo.py \
+        --headless --steps 2000 --mode teleop --motion walking
+
+The focused observation and controller tests are:
+
+    pytest -q examples/sonic/simulation_test.py
+
+## Tick-by-tick parity
+
+The comparator consumes logs written by the original C++ controller. Enable
+both its split state logs and headerless policy-input log:
+
+    ./target/release/g1_deploy_onnx_ref lo \
+        policy/release/model_decoder.onnx reference/example \
+        --obs-config policy/release/observation_config.yaml \
+        --encoder-file policy/release/model_encoder.onnx \
+        --disable-crc-check --enable-csv-logs \
+        --logs-dir /tmp/sonic-cpp/state \
+        --policy-input-logfile /tmp/sonic-cpp/policy_input.csv
+
+After capturing one motion, replay every logged tick through PAZ:
+
+    python3 examples/sonic/compare_controller_log.py \
+        --logs-dir /tmp/sonic-cpp/state \
+        --policy-input-logfile /tmp/sonic-cpp/policy_input.csv
+
+The script independently checks the 930-value policy history, the 64-value
+encoder token, and the next 29-value action. It preserves the deployment
+batch size of one because batching can change an FSQ code at a rounding
+boundary.

--- a/examples/sonic/compare_controller_log.py
+++ b/examples/sonic/compare_controller_log.py
@@ -1,0 +1,159 @@
+"""Replay original C++ SONIC controller logs through PAZ tick by tick."""
+
+import argparse
+import csv
+import os
+from pathlib import Path
+import sys
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import jax
+import numpy as np
+
+from paz.models.foundation.sonic.conversion import port_sonic_weights
+from paz.models.foundation.sonic.layout import load_release_observation_layout
+
+from simulation import build_encoder_obs
+from simulation import build_history_buffer
+from simulation import build_history_entry_from_state
+from simulation import build_policy_tail
+from simulation import compute_heading_state
+from simulation import load_motion_clip
+
+
+def load_signal(logs_dir, name):
+    path = logs_dir / f"{name}.csv"
+    values = np.loadtxt(path, delimiter=",", skiprows=1)
+    return values[:, 5:].astype(np.float32)
+
+
+def load_policy_input(path):
+    values = np.genfromtxt(path, delimiter=",")
+    if values.ndim == 1:
+        values = values[None, :]
+    if np.isnan(values[:, -1]).all():
+        values = values[:, :-1]
+    return values.astype(np.float32)
+
+
+def load_motion_name(path):
+    with path.open(newline="", encoding="utf-8") as log_file:
+        names = [row["motion_name"] for row in csv.DictReader(log_file)]
+    unique_names = set(names)
+    if len(unique_names) != 1:
+        raise ValueError(
+            "A parity log must contain exactly one motion, got "
+            f"{sorted(unique_names)}")
+    return names[0]
+
+
+def print_result(name, errors, tolerance):
+    tick = int(np.argmax(errors))
+    maximum = float(errors[tick])
+    result = "PASS" if maximum <= tolerance else "FAIL"
+    print(
+        f"{name:16} max={maximum:.9g} tick={tick:4d} "
+        f"tolerance={tolerance:.3g} {result}")
+    return maximum <= tolerance
+
+
+if __name__ == "__main__":
+    repositories = Path(__file__).resolve().parents[3]
+    default_root = repositories / "GR00T-WholeBodyControl"
+    default_root = default_root / "gear_sonic_deploy"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sonic-root", type=Path, default=default_root)
+    parser.add_argument("--logs-dir", type=Path, required=True)
+    parser.add_argument("--policy-input-logfile", type=Path, required=True)
+    parser.add_argument("--tail-tolerance", type=float, default=1e-4)
+    parser.add_argument("--token-tolerance", type=float, default=1e-6)
+    parser.add_argument("--action-tolerance", type=float, default=1e-4)
+    args = parser.parse_args()
+
+    sonic_root = args.sonic_root.expanduser().resolve()
+    logs_dir = args.logs_dir.expanduser().resolve()
+    release_dir = sonic_root / "policy" / "release"
+    layout = load_release_observation_layout(
+        release_dir / "observation_config.yaml")
+    encoder, decoder, _ = port_sonic_weights(
+        layout,
+        release_dir / "model_encoder.onnx",
+        release_dir / "model_decoder.onnx",
+    )
+
+    q = load_signal(logs_dir, "q")
+    dq = load_signal(logs_dir, "dq")
+    action = load_signal(logs_dir, "action")
+    base_quat = load_signal(logs_dir, "base_quat")
+    base_ang_vel = load_signal(logs_dir, "base_ang_vel")
+    cpp_tokens = load_signal(logs_dir, "token_state")
+    playing = load_signal(logs_dir, "motion_playing")[:, 0].astype(bool)
+    encoder_modes = load_signal(logs_dir, "encoder_mode")[:, 0].astype(int)
+    cpp_policy_input = load_policy_input(args.policy_input_logfile)
+    row_counts = {
+        len(values) for values in (
+            q, dq, action, base_quat, base_ang_vel, cpp_tokens,
+            playing, encoder_modes, cpp_policy_input)
+    }
+    if len(row_counts) != 1:
+        parser.error(f"C++ log row counts disagree: {sorted(row_counts)}")
+    unique_modes = set(encoder_modes.tolist())
+    if len(unique_modes) != 1:
+        parser.error(
+            f"A parity log must contain one mode, got {unique_modes}")
+    mode_id = unique_modes.pop()
+    mode_names = {0: "g1", 1: "teleop", 2: "smpl"}
+    if mode_id not in mode_names:
+        parser.error(f"Unsupported encoder mode ID in log: {mode_id}")
+    mode_name = mode_names[mode_id]
+
+    motion_name = load_motion_name(logs_dir / "motion_name.csv")
+    clip = load_motion_clip(
+        sonic_root / "reference" / "example" / motion_name)
+    heading = compute_heading_state(base_quat[0], clip.body_quat[0, 0])
+    history = build_history_buffer()
+    frame = 0
+    encoder_observations = []
+    policy_tails = []
+    for tick in range(len(q)):
+        history.append(build_history_entry_from_state(
+            base_quat[tick], base_ang_vel[tick], q[tick], dq[tick],
+            action[tick]))
+        policy_tails.append(build_policy_tail(layout, history)[0])
+        encoder_observations.append(build_encoder_obs(
+            layout, mode_name, clip, frame, playing[tick], base_quat[tick],
+            heading)[0])
+        if playing[tick]:
+            frame += 1
+            if frame >= clip.num_frames:
+                frame = 0
+
+    encoder_observations = np.asarray(
+        encoder_observations, dtype=np.float32)
+    policy_tails = np.asarray(policy_tails, dtype=np.float32)
+    encoder_fn = jax.jit(encoder)
+    decoder_fn = jax.jit(decoder)
+    paz_tokens = np.concatenate([
+        np.asarray(encoder_fn(observation[None, :]))
+        for observation in encoder_observations
+    ])
+    paz_actions = np.concatenate([
+        np.asarray(decoder_fn(policy_input[None, :]))
+        for policy_input in cpp_policy_input
+    ])
+    tail_errors = np.max(
+        np.abs(policy_tails - cpp_policy_input[:, 64:]), axis=1)
+    token_errors = np.max(np.abs(paz_tokens - cpp_tokens), axis=1)
+    action_errors = np.max(
+        np.abs(paz_actions[:-1] - action[1:]), axis=1)
+
+    print(f"Compared {len(q)} {mode_name} ticks for {motion_name}")
+    passed = [
+        print_result("policy history", tail_errors, args.tail_tolerance),
+        print_result("encoder token", token_errors, args.token_tolerance),
+        print_result("decoder action", action_errors, args.action_tolerance),
+    ]
+    if not all(passed):
+        sys.exit(1)

--- a/examples/sonic/compare_controller_log.py
+++ b/examples/sonic/compare_controller_log.py
@@ -11,7 +11,7 @@ os.environ.setdefault("KERAS_BACKEND", "jax")
 import jax
 import numpy as np
 
-from paz.models.foundation.sonic.conversion import port_sonic_weights
+from paz.models.foundation.sonic.conversion import port_weights
 from paz.models.foundation.sonic.layout import load_release_observation_layout
 
 from simulation import build_encoder_obs
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     release_dir = sonic_root / "policy" / "release"
     layout = load_release_observation_layout(
         release_dir / "observation_config.yaml")
-    encoder, decoder, _ = port_sonic_weights(
+    encoder, decoder, _ = port_weights(
         layout,
         release_dir / "model_encoder.onnx",
         release_dir / "model_decoder.onnx",

--- a/examples/sonic/mujoco_demo.py
+++ b/examples/sonic/mujoco_demo.py
@@ -12,7 +12,7 @@ import mujoco
 import mujoco.viewer
 import numpy as np
 
-from paz.models.foundation.sonic.conversion import port_sonic_weights
+from paz.models.foundation.sonic.conversion import port_weights
 from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import compute_policy_tail_dim
 from paz.models.foundation.sonic.layout import load_release_observation_layout
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     print(f"Loading PAZ SONIC weights from {release_dir}")
     config_path = release_dir / "observation_config.yaml"
     layout = load_release_observation_layout(config_path)
-    _, _, actor = port_sonic_weights(
+    _, _, actor = port_weights(
         layout,
         release_dir / "model_encoder.onnx",
         release_dir / "model_decoder.onnx",

--- a/examples/sonic/mujoco_demo.py
+++ b/examples/sonic/mujoco_demo.py
@@ -1,0 +1,422 @@
+"""Interactive MuJoCo demonstration of the PAZ SONIC actor."""
+
+import argparse
+import os
+from pathlib import Path
+import time
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import jax
+import mujoco
+import mujoco.viewer
+import numpy as np
+
+from paz.models.foundation.sonic.conversion import port_sonic_weights
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.layout import compute_policy_tail_dim
+from paz.models.foundation.sonic.layout import load_release_observation_layout
+
+from simulation import DEFAULT_ANGLES
+from simulation import NUM_JOINTS
+from simulation import apply_support_force
+from simulation import build_encoder_obs
+from simulation import build_history_buffer
+from simulation import build_history_entry_from_state
+from simulation import build_policy_tail
+from simulation import check_mode_available
+from simulation import clamp_frame
+from simulation import clear_viewer_markers
+from simulation import compute_action_targets
+from simulation import compute_hand_pd_torque
+from simulation import compute_heading_state
+from simulation import compute_pd_torque
+from simulation import compute_reference_markers
+from simulation import find_joint_addresses
+from simulation import load_motion_set
+from simulation import update_viewer_markers
+
+
+INIT_SECONDS = 3.0
+CONTROL_WARMUP_SECONDS = 2.0
+
+
+def interpolate_targets(start, end, ratio):
+    start = np.asarray(start, dtype=np.float32)
+    end = np.asarray(end, dtype=np.float32)
+    return start * (np.float32(1.0) - ratio) + end * ratio
+
+
+def find_motion_index(clips, requested):
+    try:
+        return int(requested) % len(clips)
+    except ValueError:
+        pass
+    for index, clip in enumerate(clips):
+        if requested.lower() in clip.name.lower():
+            return index
+    raise ValueError(f"No motion name contains {requested!r}")
+
+
+def print_controls():
+    print("\nSONIC / PAZ MuJoCo controls")
+    print("  space       pause or resume")
+    print("  [ / ]       previous or next motion")
+    print("  , / .       previous or next frame while paused")
+    print("  1 / 2 / 3   G1, 3-point teleop, or SMPL encoder")
+    print("  g           toggle the original elastic band")
+    print("  v           hide or show reference targets")
+    print("  r           reset the current motion")
+    print("  h           print these controls")
+    print("  Esc         close the viewer\n")
+
+
+def update_hud(viewer, state):
+    if viewer is None or not hasattr(viewer, "set_texts"):
+        return
+    clip = state["clip"]
+    support = "elastic band on" if state["support_enabled"] else "free"
+    playback = "playing" if state["play"] else "paused"
+    labels = "SONIC / PAZ\nmode\nmotion\nframe\ncontroller\nsupport"
+    values = (
+        "Keras + JAX\n"
+        f"{state['mode']}\n"
+        f"{clip.name}\n"
+        f"{state['frame'] + 1} / {clip.num_frames}\n"
+        f"{state['phase']} / {playback}\n"
+        f"{support}"
+    )
+    controls = "space play  [ ] motion  1 2 3 mode  g assist  h help"
+    texts = [
+        (None, mujoco.mjtGridPos.mjGRID_TOPLEFT, labels, values),
+        (None, mujoco.mjtGridPos.mjGRID_BOTTOMLEFT, controls, ""),
+    ]
+    viewer.set_texts(texts)
+
+
+def sleep_to_rate(last_time, timestep):
+    next_time = last_time + timestep
+    now = time.perf_counter()
+    if next_time > now:
+        time.sleep(next_time - now)
+        return next_time
+    return now
+
+
+def close_viewer(viewer):
+    viewer.close()
+    # launch_passive owns a daemon render thread. Give it time to destroy its
+    # GLFW resources before Python unloads MuJoCo during a scripted shutdown.
+    time.sleep(0.25)
+
+
+if __name__ == "__main__":
+    repositories = Path(__file__).resolve().parents[3]
+    sibling_deploy = repositories / "GR00T-WholeBodyControl"
+    sibling_deploy = sibling_deploy / "gear_sonic_deploy"
+    default_root = os.environ.get("SONIC_DEPLOY_DIR", sibling_deploy)
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sonic-root",
+        type=Path,
+        default=default_root,
+        help="gear_sonic_deploy directory (or set SONIC_DEPLOY_DIR)",
+    )
+    parser.add_argument("--mode", choices=("g1", "teleop", "smpl"),
+                        default="g1")
+    parser.add_argument(
+        "--motion",
+        default="0",
+        help="zero-based motion index or a unique part of its name",
+    )
+    parser.add_argument("--sim-dt", type=float, default=0.005)
+    parser.add_argument("--control-dt", type=float, default=0.02)
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--steps", type=int)
+    parser.add_argument("--start-paused", action="store_true")
+    parser.add_argument("--no-realtime", action="store_true")
+    args = parser.parse_args()
+
+    sonic_root = args.sonic_root.expanduser().resolve()
+    release_dir = sonic_root / "policy" / "release"
+    scene_path = sonic_root.parent / "gear_sonic" / "data"
+    scene_path = scene_path / "robot_model/model_data/g1/scene_43dof.xml"
+    motion_dir = sonic_root / "reference" / "example"
+    required_paths = (
+        release_dir / "observation_config.yaml",
+        release_dir / "model_encoder.onnx",
+        release_dir / "model_decoder.onnx",
+        scene_path,
+        motion_dir,
+    )
+    missing = [str(path) for path in required_paths if not path.exists()]
+    if missing:
+        parser.error(
+            "SONIC deployment assets are missing: " + ", ".join(missing))
+    if args.control_dt < args.sim_dt:
+        parser.error("--control-dt must be at least --sim-dt")
+
+    print(f"Loading PAZ SONIC weights from {release_dir}")
+    config_path = release_dir / "observation_config.yaml"
+    layout = load_release_observation_layout(config_path)
+    _, _, actor = port_sonic_weights(
+        layout,
+        release_dir / "model_encoder.onnx",
+        release_dir / "model_decoder.onnx",
+    )
+    clips = load_motion_set(motion_dir)
+    motion_index = find_motion_index(clips, args.motion)
+    available, reason = check_mode_available(clips[motion_index], args.mode)
+    if not available:
+        parser.error(f"Cannot start in {args.mode} mode: {reason}")
+
+    model = mujoco.MjModel.from_xml_path(str(scene_path))
+    data = mujoco.MjData(model)
+    model.opt.timestep = args.sim_dt
+    pelvis_id = model.body("pelvis").id
+    joints = find_joint_addresses(model)
+    if joints.hand_qpos.size != 14:
+        parser.error(
+            "The original SONIC simulator scene must contain 14 hand joints")
+    policy_steps = max(1, int(round(args.control_dt / args.sim_dt)))
+    action_fn = jax.jit(
+        lambda encoder_obs, policy_tail: actor(
+            {
+                "encoder_obs": encoder_obs,
+                "policy_obs_tail": policy_tail,
+            },
+            training=False,
+        )
+    )
+    print("Compiling the PAZ actor for JAX (first launch can take a moment)")
+    empty_encoder = np.zeros(
+        (1, compute_encoder_input_dim(layout)), dtype=np.float32)
+    empty_tail = np.zeros(
+        (1, compute_policy_tail_dim(layout)), dtype=np.float32)
+    np.asarray(action_fn(empty_encoder, empty_tail))
+
+    state = {
+        "clip": clips[motion_index],
+        "motion_index": motion_index,
+        "mode": args.mode,
+        "frame": 0,
+        "play": not args.start_paused,
+        "pending_reset": True,
+        "pending_frame": 0,
+        "history": build_history_buffer(),
+        "last_action": np.zeros(NUM_JOINTS, np.float32),
+        "q_target": np.zeros(NUM_JOINTS, np.float32),
+        "startup_q": np.zeros(NUM_JOINTS, np.float32),
+        "startup_step": 0,
+        "control_tick": 0,
+        "phase": "resetting",
+        "heading": None,
+        "support_enabled": True,
+        "auto_release": True,
+        "show_markers": True,
+    }
+    init_steps = max(1, int(round(INIT_SECONDS / args.control_dt)))
+    warmup_steps = max(
+        1, int(round(CONTROL_WARMUP_SECONDS / args.control_dt)))
+
+    def reset_state():
+        mujoco.mj_resetData(model, data)
+        data.qvel[:] = 0.0
+        data.ctrl[:] = 0.0
+        data.xfrc_applied[:] = 0.0
+        mujoco.mj_forward(model, data)
+        state["frame"] = 0
+        state["history"] = build_history_buffer()
+        state["last_action"] = np.zeros(NUM_JOINTS, np.float32)
+        joint_q = data.qpos[joints.body_qpos]
+        state["q_target"] = joint_q.astype(np.float32)
+        state["startup_q"] = state["q_target"].copy()
+        state["startup_step"] = 0
+        state["control_tick"] = 0
+        state["phase"] = "initializing"
+        state["support_enabled"] = True
+        state["auto_release"] = True
+        state["heading"] = None
+
+    def select_motion(offset):
+        new_index = (state["motion_index"] + offset) % len(clips)
+        new_clip = clips[new_index]
+        available, reason = check_mode_available(new_clip, state["mode"])
+        if not available:
+            print(f"{new_clip.name}: {state['mode']} unavailable ({reason})")
+            return
+        state["motion_index"] = new_index
+        state["clip"] = new_clip
+        state["pending_reset"] = True
+        print(f"Motion: {new_clip.name}")
+
+    def select_mode(mode_name):
+        available, reason = check_mode_available(state["clip"], mode_name)
+        if not available:
+            print(f"{mode_name} mode unavailable: {reason}")
+            return
+        state["mode"] = mode_name
+        state["pending_reset"] = True
+        print(f"Encoder mode: {mode_name}")
+
+    def key_callback(keycode):
+        try:
+            key = chr(keycode).lower()
+        except ValueError:
+            key = ""
+        if key == " ":
+            state["play"] = not state["play"]
+        elif key == "[":
+            select_motion(-1)
+        elif key == "]":
+            select_motion(1)
+        elif key == ",":
+            state["play"] = False
+            state["pending_frame"] = -1
+        elif key == ".":
+            state["play"] = False
+            state["pending_frame"] = 1
+        elif key == "1":
+            select_mode("g1")
+        elif key == "2":
+            select_mode("teleop")
+        elif key == "3":
+            select_mode("smpl")
+        elif key == "g":
+            state["support_enabled"] = not state["support_enabled"]
+            state["auto_release"] = False
+        elif key == "v":
+            state["show_markers"] = not state["show_markers"]
+        elif key == "r":
+            state["pending_reset"] = True
+        elif key == "h":
+            print_controls()
+
+    viewer = None
+    if not args.headless:
+        viewer = mujoco.viewer.launch_passive(
+            model,
+            data,
+            key_callback=key_callback,
+            show_left_ui=False,
+            show_right_ui=False,
+        )
+        viewer.cam.azimuth = 120
+        viewer.cam.elevation = -20
+        viewer.cam.distance = 3.0
+        viewer.cam.lookat = np.asarray([0.0, 0.0, 0.8])
+
+    print_controls()
+    reset_state()
+    state["pending_reset"] = False
+    update_hud(viewer, state)
+    max_steps = args.steps
+    if args.headless and max_steps is None:
+        max_steps = 1500
+    realtime = not args.headless and not args.no_realtime
+    last_time = time.perf_counter()
+    step = 0
+    try:
+        while True:
+            if max_steps is not None and step >= max_steps:
+                break
+            if viewer is not None and not viewer.is_running():
+                break
+            if state["pending_reset"]:
+                reset_state()
+                state["pending_reset"] = False
+                state["pending_frame"] = 0
+            if step % policy_steps == 0:
+                if state["pending_frame"]:
+                    frame = state["frame"] + state["pending_frame"]
+                    state["frame"] = clamp_frame(frame, state["clip"])
+                    state["pending_frame"] = 0
+                    state["heading"] = compute_heading_state(
+                        data.qpos[3:7],
+                        state["clip"].body_quat[state["frame"], 0],
+                    )
+                if state["startup_step"] < init_steps:
+                    state["startup_step"] += 1
+                    ratio = np.float32(
+                        state["startup_step"] / init_steps)
+                    state["q_target"] = interpolate_targets(
+                        state["startup_q"], DEFAULT_ANGLES, ratio)
+                    state["phase"] = "initializing"
+                else:
+                    joint_q = data.qpos[joints.body_qpos]
+                    joint_dq = data.qvel[joints.body_dof]
+                    if state["heading"] is None:
+                        state["heading"] = compute_heading_state(
+                            data.qpos[3:7],
+                            state["clip"].body_quat[state["frame"], 0],
+                        )
+                    entry = build_history_entry_from_state(
+                        data.qpos[3:7], data.qvel[3:6], joint_q,
+                        joint_dq, state["last_action"])
+                    state["history"].append(entry)
+                    warming_up = state["control_tick"] < warmup_steps
+                    play_for_obs = state["play"] and not warming_up
+                    encoder_obs = build_encoder_obs(
+                        layout, state["mode"], state["clip"],
+                        state["frame"], play_for_obs, data.qpos[3:7],
+                        state["heading"],
+                    )
+                    policy_tail = build_policy_tail(
+                        layout, state["history"])
+                    action = np.asarray(
+                        action_fn(encoder_obs, policy_tail))[0]
+                    action = action.astype(np.float32)
+                    state["q_target"] = compute_action_targets(action)
+                    state["last_action"] = action
+                    state["control_tick"] += 1
+                    if warming_up:
+                        state["phase"] = "policy warmup"
+                        if state["control_tick"] == warmup_steps:
+                            if state["auto_release"]:
+                                state["support_enabled"] = False
+                    elif state["play"]:
+                        state["phase"] = "running"
+                        if state["frame"] < state["clip"].num_frames - 1:
+                            state["frame"] += 1
+                        else:
+                            state["play"] = False
+                    else:
+                        state["phase"] = "paused"
+                if viewer is not None:
+                    if state["show_markers"]:
+                        points = compute_reference_markers(
+                            state["mode"], state["clip"], state["frame"],
+                            data.qpos[:3], data.qpos[3:7])
+                        update_viewer_markers(
+                            viewer, points, state["mode"])
+                    else:
+                        clear_viewer_markers(viewer)
+                    update_hud(viewer, state)
+
+            apply_support_force(
+                model, data, pelvis_id, float(state["support_enabled"]))
+            joint_q = data.qpos[joints.body_qpos]
+            joint_dq = data.qvel[joints.body_dof]
+            data.ctrl[joints.body_actuator] = compute_pd_torque(
+                state["q_target"], joint_q, joint_dq)
+            hand_q = data.qpos[joints.hand_qpos]
+            hand_dq = data.qvel[joints.hand_dof]
+            data.ctrl[joints.hand_actuator] = compute_hand_pd_torque(
+                hand_q, hand_dq)
+            mujoco.mj_step(model, data)
+            if not np.isfinite(data.qpos).all():
+                raise RuntimeError("MuJoCo state became non-finite")
+            if viewer is not None and step % policy_steps == 0:
+                viewer.sync()
+            if realtime:
+                last_time = sleep_to_rate(last_time, args.sim_dt)
+            step += 1
+    finally:
+        if viewer is not None:
+            close_viewer(viewer)
+
+    print(
+        f"Completed {step} simulation steps; mode={state['mode']}, "
+        f"motion={state['clip'].name}, pelvis_z={data.qpos[2]:.3f}"
+    )

--- a/examples/sonic/simulation.py
+++ b/examples/sonic/simulation.py
@@ -1,0 +1,722 @@
+"""MuJoCo support code for the PAZ SONIC demonstration."""
+
+from collections import deque
+from collections import namedtuple
+from pathlib import Path
+import re
+
+import mujoco
+import numpy as np
+
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.layout import compute_policy_tail_dim
+from paz.models.foundation.sonic.layout import find_encoder_span
+
+
+MotionClip = namedtuple(
+    "MotionClip",
+    "name joint_pos joint_vel body_pos body_quat body_indices "
+    "smpl_joints num_frames",
+)
+HistoryEntry = namedtuple(
+    "HistoryEntry",
+    "base_quat base_ang_vel body_q body_dq last_action",
+)
+HeadingState = namedtuple(
+    "HeadingState",
+    "init_base_quat init_ref_root_quat delta_heading",
+)
+JointAddresses = namedtuple(
+    "JointAddresses",
+    "body_qpos body_dof body_actuator hand_qpos hand_dof hand_actuator",
+)
+
+NUM_JOINTS = 29
+ROOT_QPOS_OFFSET = 7
+ROOT_QVEL_OFFSET = 6
+HISTORY_FRAMES = 10
+
+SCENE_FROM_POLICY = np.asarray(
+    [
+        0, 3, 6, 9, 13, 17, 1, 4, 7, 10, 14, 18, 2, 5, 8,
+        11, 15, 19, 21, 23, 25, 27, 12, 16, 20, 22, 24, 26, 28,
+    ],
+    dtype=np.int32,
+)
+POLICY_FROM_SCENE = np.asarray(
+    [
+        0, 6, 12, 1, 7, 13, 2, 8, 14, 3, 9, 15, 22, 4, 10,
+        16, 23, 5, 11, 17, 24, 18, 25, 19, 26, 20, 27, 21, 28,
+    ],
+    dtype=np.int32,
+)
+LOWER_BODY_POLICY = np.asarray(
+    [0, 3, 6, 9, 13, 17, 1, 4, 7, 10, 14, 18], dtype=np.int32)
+WRIST_POLICY = np.asarray([23, 24, 25, 26, 27, 28], dtype=np.int32)
+VR_BODY_IDS = np.asarray([28, 29, 9], dtype=np.int32)
+VR_OFFSETS = np.asarray(
+    [[0.18, -0.025, 0.0], [0.18, 0.025, 0.0], [0.0, 0.0, 0.35]],
+    dtype=np.float32,
+)
+
+DEFAULT_ANGLES = np.asarray(
+    [
+        -0.312, 0.0, 0.0, 0.669, -0.363, 0.0,
+        -0.312, 0.0, 0.0, 0.669, -0.363, 0.0,
+        0.0, 0.0, 0.0, 0.2, 0.2, 0.0,
+        0.6, 0.0, 0.0, 0.0, 0.2, -0.2,
+        0.0, 0.6, 0.0, 0.0, 0.0,
+    ],
+    dtype=np.float32,
+)
+
+NATURAL_FREQ = 10.0 * 2.0 * np.pi
+DAMPING_RATIO = 2.0
+ARMATURE_5020 = 0.003609725
+ARMATURE_7520_14 = 0.010177520
+ARMATURE_7520_22 = 0.025101925
+ARMATURE_4010 = 0.00425
+STIFFNESS_5020 = ARMATURE_5020 * NATURAL_FREQ ** 2
+STIFFNESS_7520_14 = ARMATURE_7520_14 * NATURAL_FREQ ** 2
+STIFFNESS_7520_22 = ARMATURE_7520_22 * NATURAL_FREQ ** 2
+STIFFNESS_4010 = ARMATURE_4010 * NATURAL_FREQ ** 2
+DAMPING_5020 = 2.0 * DAMPING_RATIO * ARMATURE_5020 * NATURAL_FREQ
+DAMPING_7520_14 = (
+    2.0 * DAMPING_RATIO * ARMATURE_7520_14 * NATURAL_FREQ)
+DAMPING_7520_22 = (
+    2.0 * DAMPING_RATIO * ARMATURE_7520_22 * NATURAL_FREQ)
+DAMPING_4010 = 2.0 * DAMPING_RATIO * ARMATURE_4010 * NATURAL_FREQ
+EFFORT_5020 = 25.0
+EFFORT_7520_14 = 88.0
+EFFORT_7520_22 = 139.0
+EFFORT_4010 = 5.0
+
+ACTION_SCALE = np.asarray(
+    [
+        0.25 * EFFORT_7520_22 / STIFFNESS_7520_22,
+        0.25 * EFFORT_7520_22 / STIFFNESS_7520_22,
+        0.25 * EFFORT_7520_14 / STIFFNESS_7520_14,
+        0.25 * EFFORT_7520_22 / STIFFNESS_7520_22,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_7520_22 / STIFFNESS_7520_22,
+        0.25 * EFFORT_7520_22 / STIFFNESS_7520_22,
+        0.25 * EFFORT_7520_14 / STIFFNESS_7520_14,
+        0.25 * EFFORT_7520_22 / STIFFNESS_7520_22,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_7520_14 / STIFFNESS_7520_14,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_4010 / STIFFNESS_4010,
+        0.25 * EFFORT_4010 / STIFFNESS_4010,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_5020 / STIFFNESS_5020,
+        0.25 * EFFORT_4010 / STIFFNESS_4010,
+        0.25 * EFFORT_4010 / STIFFNESS_4010,
+    ],
+    dtype=np.float32,
+)
+KPS = np.asarray(
+    [
+        STIFFNESS_7520_22, STIFFNESS_7520_22, STIFFNESS_7520_14,
+        STIFFNESS_7520_22, 2 * STIFFNESS_5020, 2 * STIFFNESS_5020,
+        STIFFNESS_7520_22, STIFFNESS_7520_22, STIFFNESS_7520_14,
+        STIFFNESS_7520_22, 2 * STIFFNESS_5020, 2 * STIFFNESS_5020,
+        STIFFNESS_7520_14, 2 * STIFFNESS_5020, 2 * STIFFNESS_5020,
+        STIFFNESS_5020, STIFFNESS_5020, STIFFNESS_5020,
+        STIFFNESS_5020, STIFFNESS_5020, STIFFNESS_4010,
+        STIFFNESS_4010, STIFFNESS_5020, STIFFNESS_5020,
+        STIFFNESS_5020, STIFFNESS_5020, STIFFNESS_5020,
+        STIFFNESS_4010, STIFFNESS_4010,
+    ],
+    dtype=np.float32,
+)
+KDS = np.asarray(
+    [
+        DAMPING_7520_22, DAMPING_7520_22, DAMPING_7520_14,
+        DAMPING_7520_22, 2 * DAMPING_5020, 2 * DAMPING_5020,
+        DAMPING_7520_22, DAMPING_7520_22, DAMPING_7520_14,
+        DAMPING_7520_22, 2 * DAMPING_5020, 2 * DAMPING_5020,
+        DAMPING_7520_14, 2 * DAMPING_5020, 2 * DAMPING_5020,
+        DAMPING_5020, DAMPING_5020, DAMPING_5020,
+        DAMPING_5020, DAMPING_5020, DAMPING_4010,
+        DAMPING_4010, DAMPING_5020, DAMPING_5020,
+        DAMPING_5020, DAMPING_5020, DAMPING_5020,
+        DAMPING_4010, DAMPING_4010,
+    ],
+    dtype=np.float32,
+)
+EFFORT_LIMITS = np.asarray(
+    [
+        88, 88, 88, 139, 50, 50, 88, 88, 88, 139, 50, 50,
+        88, 50, 50, 25, 25, 25, 25, 25, 5, 5, 25, 25, 25, 25,
+        25, 5, 5,
+    ],
+    dtype=np.float32,
+)
+HAND_EFFORT_LIMITS = np.asarray(
+    [2.45, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7] * 2,
+    dtype=np.float32,
+)
+
+
+SUPPORT_POINT = np.asarray([0.0, 0.0, 1.0], dtype=np.float64)
+SUPPORT_KP_POS = 10000.0
+SUPPORT_KD_POS = 1000.0
+SUPPORT_KP_ANG = 1000.0
+SUPPORT_KD_ANG = 10.0
+
+
+def load_motion_set(motion_dir):
+    motion_dir = Path(motion_dir)
+    clip_paths = sorted(
+        path for path in motion_dir.iterdir()
+        if path.is_dir() and (path / "joint_pos.csv").exists())
+    clips = tuple(load_motion_clip(path) for path in clip_paths)
+    if not clips:
+        raise ValueError(f"No SONIC motion folders found in {motion_dir}")
+    return clips
+
+
+def load_motion_clip(clip_path):
+    clip_path = Path(clip_path)
+    joint_pos = load_csv_array(clip_path / "joint_pos.csv")
+    joint_vel = load_csv_array(clip_path / "joint_vel.csv")
+    body_pos = load_csv_array(clip_path / "body_pos.csv")
+    body_quat = load_csv_array(clip_path / "body_quat.csv")
+    num_frames = joint_pos.shape[0]
+    body_pos = body_pos.reshape(num_frames, -1, 3)
+    body_quat = body_quat.reshape(num_frames, -1, 4)
+    body_indices = load_body_indices(clip_path / "metadata.txt")
+    smpl_path = clip_path / "smpl_joints.csv"
+    smpl_joints = None
+    if smpl_path.exists():
+        smpl_joints = load_csv_array(smpl_path).reshape(num_frames, 24, 3)
+    arrays = joint_vel, body_pos, body_quat
+    if any(array.shape[0] != num_frames for array in arrays):
+        raise ValueError(f"Inconsistent frame counts in {clip_path}")
+    if body_pos.shape[1] != body_indices.size:
+        raise ValueError(f"Body index count does not match {clip_path}")
+    args = (
+        clip_path.name, joint_pos, joint_vel, body_pos, body_quat,
+        body_indices, smpl_joints, num_frames,
+    )
+    return MotionClip(*args)
+
+
+def load_csv_array(path):
+    values = np.loadtxt(path, delimiter=",", skiprows=1, dtype=np.float32)
+    if values.ndim == 1:
+        values = values[None, :]
+    return values
+
+
+def load_body_indices(metadata_path):
+    text = Path(metadata_path).read_text(encoding="utf-8")
+    match = re.search(r"Body part indexes:\s*\[([^]]+)\]", text, re.S)
+    if match is None:
+        raise ValueError(f"No body indexes found in {metadata_path}")
+    return np.fromstring(match.group(1), sep=" ", dtype=np.int32)
+
+
+def find_mode(layout, mode_name):
+    for mode in layout.encoder_modes:
+        if mode.name == mode_name:
+            return mode
+    raise KeyError(f"Unknown SONIC mode: {mode_name}")
+
+
+def check_mode_available(clip, mode_name):
+    if mode_name == "smpl" and clip.smpl_joints is None:
+        return False, "clip has no smpl_joints.csv"
+    if mode_name == "teleop":
+        missing = set(VR_BODY_IDS) - set(clip.body_indices)
+        if missing:
+            return False, f"clip is missing VR body IDs {sorted(missing)}"
+    return True, ""
+
+
+def build_encoder_obs(
+    layout, mode_name, clip, frame, play, base_quat, heading_state
+):
+    available, reason = check_mode_available(clip, mode_name)
+    if not available:
+        raise ValueError(f"Cannot use {mode_name} mode: {reason}")
+    if mode_name == "g1":
+        return build_g1_encoder_obs(
+            layout, clip, frame, play, base_quat, heading_state)
+    if mode_name == "teleop":
+        return build_teleop_encoder_obs(
+            layout, clip, frame, play, base_quat, heading_state)
+    if mode_name == "smpl":
+        return build_smpl_encoder_obs(
+            layout, clip, frame, play, base_quat, heading_state)
+    raise KeyError(f"Unsupported SONIC mode: {mode_name}")
+
+
+def build_empty_encoder_obs(layout, mode_name):
+    obs = np.zeros((compute_encoder_input_dim(layout),), dtype=np.float32)
+    mode = find_mode(layout, mode_name)
+    span = find_encoder_span(layout, layout.mode_observation_name)
+    obs[span.start] = np.float32(mode.mode_id)
+    return obs
+
+
+def build_g1_encoder_obs(
+    layout, clip, frame, play, base_quat, heading_state
+):
+    obs = build_empty_encoder_obs(layout, "g1")
+    write_span(
+        obs, layout, "motion_joint_positions_10frame_step5",
+        gather_motion_values(clip.joint_pos, clip, frame, play, 10, 5),
+    )
+    velocities = gather_motion_values(
+        clip.joint_vel, clip, frame, play, 10, 5)
+    if not play:
+        velocities[:] = 0.0
+    write_span(
+        obs, layout, "motion_joint_velocities_10frame_step5",
+        velocities,
+    )
+    orientations = compute_anchor_orientations(
+        clip, frame, play, 10, 5, base_quat, heading_state)
+    write_span(
+        obs, layout, "motion_anchor_orientation_10frame_step5",
+        orientations,
+    )
+    return obs[None, :]
+
+
+def build_teleop_encoder_obs(
+    layout, clip, frame, play, base_quat, heading_state
+):
+    obs = build_empty_encoder_obs(layout, "teleop")
+    positions = gather_motion_values(
+        clip.joint_pos[:, LOWER_BODY_POLICY], clip, frame, play, 10, 5)
+    velocities = gather_motion_values(
+        clip.joint_vel[:, LOWER_BODY_POLICY], clip, frame, play, 10, 5)
+    if not play:
+        velocities[:] = 0.0
+    vr_positions, vr_orientations = compute_vr_targets(clip, frame)
+    anchor = compute_anchor_orientations(
+        clip, frame, play, 1, 1, base_quat, heading_state)
+    write_span(
+        obs, layout, "motion_joint_positions_lowerbody_10frame_step5",
+        positions,
+    )
+    write_span(
+        obs, layout, "motion_joint_velocities_lowerbody_10frame_step5",
+        velocities,
+    )
+    write_span(obs, layout, "vr_3point_local_target", vr_positions)
+    write_span(
+        obs, layout, "vr_3point_local_orn_target", vr_orientations)
+    write_span(obs, layout, "motion_anchor_orientation", anchor)
+    return obs[None, :]
+
+
+def build_smpl_encoder_obs(
+    layout, clip, frame, play, base_quat, heading_state
+):
+    obs = build_empty_encoder_obs(layout, "smpl")
+    smpl = gather_motion_values(
+        clip.smpl_joints.reshape(clip.num_frames, -1),
+        clip, frame, play, 10, 1,
+    )
+    orientations = compute_anchor_orientations(
+        clip, frame, play, 10, 1, base_quat, heading_state)
+    wrists = gather_motion_values(
+        clip.joint_pos[:, WRIST_POLICY], clip, frame, play, 10, 1)
+    write_span(obs, layout, "smpl_joints_10frame_step1", smpl)
+    write_span(
+        obs, layout, "smpl_anchor_orientation_10frame_step1",
+        orientations,
+    )
+    write_span(
+        obs, layout, "motion_joint_positions_wrists_10frame_step1",
+        wrists,
+    )
+    return obs[None, :]
+
+
+def write_span(obs, layout, name, values):
+    span = find_encoder_span(layout, name)
+    values = np.asarray(values, dtype=np.float32).reshape(-1)
+    if values.size != span.dim:
+        raise ValueError(
+            f"Observation {name} needs {span.dim} values, got "
+            f"{values.size}")
+    obs[span.start:span.end] = values
+
+
+def gather_motion_values(values, clip, frame, play, num_frames, step_size):
+    frames = compute_future_frames(
+        clip, frame, play, num_frames, step_size)
+    return values[frames].reshape(-1).astype(np.float32)
+
+
+def compute_future_frames(clip, frame, play, num_frames, step_size):
+    if not play:
+        return np.full((num_frames,), clamp_frame(frame, clip), np.int32)
+    frames = frame + np.arange(num_frames, dtype=np.int32) * step_size
+    return np.minimum(frames, clip.num_frames - 1)
+
+
+def compute_anchor_orientations(
+    clip, frame, play, num_frames, step_size, base_quat, heading_state
+):
+    values = []
+    apply_delta = compute_apply_delta_heading(heading_state)
+    frames = compute_future_frames(
+        clip, frame, play, num_frames, step_size)
+    for frame_id in frames:
+        ref_root = clip.body_quat[frame_id, 0]
+        new_ref = quat_mul(apply_delta, ref_root)
+        relative = quat_mul(quat_conjugate(base_quat), new_ref)
+        values.append(quat_to_sixd(relative))
+    return np.concatenate(values).astype(np.float32)
+
+
+def compute_vr_targets(clip, frame):
+    storage_ids = []
+    for body_id in VR_BODY_IDS:
+        matches = np.flatnonzero(clip.body_indices == body_id)
+        if matches.size == 0:
+            raise ValueError(f"Motion {clip.name} has no body ID {body_id}")
+        storage_ids.append(int(matches[0]))
+    root_pos = clip.body_pos[frame, 0]
+    root_quat = clip.body_quat[frame, 0]
+    root_inv = quat_conjugate(root_quat)
+    positions = []
+    orientations = []
+    for storage_id, offset in zip(storage_ids, VR_OFFSETS):
+        body_pos = clip.body_pos[frame, storage_id]
+        body_quat = clip.body_quat[frame, storage_id]
+        point = body_pos + quat_rotate(body_quat, offset)
+        positions.append(quat_rotate(root_inv, point - root_pos))
+        orientations.append(quat_mul(root_inv, body_quat))
+    args = np.concatenate(positions), np.concatenate(orientations)
+    return tuple(value.astype(np.float32) for value in args)
+
+
+def build_history_buffer():
+    return deque(maxlen=HISTORY_FRAMES)
+
+
+def build_history_entry(qpos, qvel, last_action):
+    joint_q = qpos[ROOT_QPOS_OFFSET:ROOT_QPOS_OFFSET + NUM_JOINTS]
+    joint_dq = qvel[ROOT_QVEL_OFFSET:ROOT_QVEL_OFFSET + NUM_JOINTS]
+    return build_history_entry_from_state(
+        qpos[3:7], qvel[3:6], joint_q, joint_dq, last_action)
+
+
+def build_history_entry_from_state(
+    base_quat, base_ang_vel, joint_q, joint_dq, last_action
+):
+    body_q = joint_q[POLICY_FROM_SCENE]
+    body_dq = joint_dq[POLICY_FROM_SCENE]
+    body_q = body_q - DEFAULT_ANGLES[POLICY_FROM_SCENE]
+    args = (
+        np.asarray(base_quat, dtype=np.float32),
+        np.asarray(base_ang_vel, dtype=np.float32),
+        body_q.astype(np.float32),
+        body_dq.astype(np.float32),
+        np.asarray(last_action, dtype=np.float32),
+    )
+    return HistoryEntry(*args)
+
+
+def build_policy_tail(layout, history):
+    entries = list(history)[-HISTORY_FRAMES:]
+    while len(entries) < HISTORY_FRAMES:
+        entries.insert(0, compute_zero_entry())
+    tail_dim = compute_policy_tail_dim(layout)
+    policy_tail = np.zeros((tail_dim,), dtype=np.float32)
+    for span in layout.policy_spans[1:]:
+        values = compute_policy_values(entries, span.name)
+        start = span.start - layout.token_dim
+        policy_tail[start:start + span.dim] = values
+    return policy_tail[None, :]
+
+
+def compute_policy_values(entries, name):
+    if name == "his_base_angular_velocity_10frame_step1":
+        return flatten_entry_values(entries, "base_ang_vel")
+    if name == "his_body_joint_positions_10frame_step1":
+        return flatten_entry_values(entries, "body_q")
+    if name == "his_body_joint_velocities_10frame_step1":
+        return flatten_entry_values(entries, "body_dq")
+    if name == "his_last_actions_10frame_step1":
+        return flatten_entry_values(entries, "last_action")
+    if name == "his_gravity_dir_10frame_step1":
+        values = [compute_gravity_dir(entry.base_quat) for entry in entries]
+        return np.concatenate(values).astype(np.float32)
+    raise ValueError(f"Unsupported policy observation: {name}")
+
+
+def flatten_entry_values(entries, field):
+    return np.concatenate(
+        [getattr(entry, field) for entry in entries]).astype(np.float32)
+
+
+def compute_zero_entry():
+    args = (
+        np.asarray([0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        np.zeros((3,), dtype=np.float32),
+        np.zeros((NUM_JOINTS,), dtype=np.float32),
+        np.zeros((NUM_JOINTS,), dtype=np.float32),
+        np.zeros((NUM_JOINTS,), dtype=np.float32),
+    )
+    return HistoryEntry(*args)
+
+
+def compute_heading_state(base_quat, ref_root_quat, delta_heading=0.0):
+    args = (
+        np.asarray(base_quat, dtype=np.float32),
+        np.asarray(ref_root_quat, dtype=np.float32),
+        np.float32(delta_heading),
+    )
+    return HeadingState(*args)
+
+
+def compute_apply_delta_heading(heading_state):
+    init_heading = compute_heading_quat(heading_state.init_base_quat)
+    ref_heading_inv = compute_heading_quat_inv(
+        heading_state.init_ref_root_quat)
+    apply_delta = quat_mul(init_heading, ref_heading_inv)
+    if heading_state.delta_heading != 0.0:
+        apply_delta = quat_mul(
+            yaw_to_quat(heading_state.delta_heading), apply_delta)
+    return apply_delta
+
+
+def compute_action_targets(action_policy):
+    scene_action = np.asarray(action_policy)[SCENE_FROM_POLICY]
+    return DEFAULT_ANGLES + scene_action * ACTION_SCALE
+
+
+def compute_pd_torque(q_target, joint_q, joint_dq):
+    torques = KPS * (q_target - joint_q) - KDS * joint_dq
+    return np.clip(torques, -EFFORT_LIMITS, EFFORT_LIMITS)
+
+
+def compute_hand_pd_torque(joint_q, joint_dq):
+    torques = -1.5 * joint_q - 0.1 * joint_dq
+    return np.clip(torques, -HAND_EFFORT_LIMITS, HAND_EFFORT_LIMITS)
+
+
+def find_joint_addresses(model):
+    body_names = (
+        "hip", "knee", "ankle", "waist", "shoulder", "elbow", "wrist")
+    body_joint_ids = []
+    hand_joint_ids = []
+    for joint_id in range(model.njnt):
+        name = model.joint(joint_id).name or ""
+        if any(part in name for part in body_names):
+            body_joint_ids.append(joint_id)
+        elif "hand" in name:
+            hand_joint_ids.append(joint_id)
+    if len(body_joint_ids) != NUM_JOINTS:
+        raise ValueError(
+            f"Expected {NUM_JOINTS} SONIC body joints, got "
+            f"{len(body_joint_ids)}")
+    actuator_by_joint = {
+        int(model.actuator_trnid[index, 0]): index
+        for index in range(model.nu)
+    }
+
+    def addresses(joint_ids):
+        joint_ids = np.asarray(joint_ids, dtype=np.int32)
+        qpos = model.jnt_qposadr[joint_ids].astype(np.int32)
+        dof = model.jnt_dofadr[joint_ids].astype(np.int32)
+        actuator = np.asarray(
+            [actuator_by_joint[int(index)] for index in joint_ids],
+            dtype=np.int32,
+        )
+        return qpos, dof, actuator
+
+    body = addresses(body_joint_ids)
+    hand = addresses(hand_joint_ids)
+    return JointAddresses(*(body + hand))
+
+
+def apply_support_force(model, data, body_id, strength=1.0):
+    if strength <= 0.0:
+        data.xfrc_applied[body_id] = 0.0
+        return
+    pose = np.zeros((13,), dtype=np.float64)
+    pose[:3] = data.xpos[body_id]
+    pose[3:7] = data.xquat[body_id]
+    args = model, data, mujoco.mjtObj.mjOBJ_BODY, body_id, pose[7:13], 0
+    mujoco.mj_objectVelocity(*args)
+    pose[7:10], pose[10:13] = pose[10:13].copy(), pose[7:10].copy()
+    data.xfrc_applied[body_id] = compute_support_wrench(pose, strength)
+
+
+def compute_support_wrench(pose, strength=1.0):
+    pos = pose[:3]
+    quat = pose[3:7]
+    lin_vel = pose[7:10]
+    ang_vel = pose[10:13]
+    force = SUPPORT_KP_POS * (SUPPORT_POINT - pos)
+    force = force - SUPPORT_KD_POS * lin_vel
+    torque = -SUPPORT_KP_ANG * quat_to_rotvec(quat)
+    torque = torque - SUPPORT_KD_ANG * ang_vel
+    return np.float64(strength) * np.concatenate([force, torque])
+
+
+def compute_reference_markers(mode_name, clip, frame, root_pos, root_quat):
+    if mode_name == "teleop":
+        local_points, _ = compute_vr_targets(clip, frame)
+        local_points = local_points.reshape(-1, 3)
+    elif mode_name == "smpl":
+        local_points = clip.smpl_joints[frame]
+    else:
+        ref_root_pos = clip.body_pos[frame, 0]
+        ref_root_inv = quat_conjugate(clip.body_quat[frame, 0])
+        local_points = [
+            quat_rotate(ref_root_inv, point - ref_root_pos)
+            for point in clip.body_pos[frame]
+        ]
+    return np.asarray(
+        [root_pos + quat_rotate(root_quat, point) for point in local_points])
+
+
+def update_viewer_markers(viewer, points, mode_name):
+    if viewer is None or viewer.user_scn is None:
+        return
+    points = np.asarray(points)
+    with viewer.lock():
+        scene = viewer.user_scn
+        scene.ngeom = min(points.shape[0], scene.maxgeom)
+        colors = compute_marker_colors(mode_name, scene.ngeom)
+        radius = 0.045 if mode_name == "teleop" else 0.025
+        size = np.asarray([radius, radius, radius], dtype=np.float64)
+        identity = np.eye(3, dtype=np.float64).reshape(-1)
+        for index in range(scene.ngeom):
+            mujoco.mjv_initGeom(
+                scene.geoms[index], mujoco.mjtGeom.mjGEOM_SPHERE,
+                size, points[index], identity, colors[index])
+
+
+def clear_viewer_markers(viewer):
+    if viewer is None or viewer.user_scn is None:
+        return
+    with viewer.lock():
+        viewer.user_scn.ngeom = 0
+
+
+def compute_marker_colors(mode_name, count):
+    if mode_name == "teleop":
+        palette = np.asarray(
+            [[0.2, 0.5, 1.0, 0.85], [1.0, 0.3, 0.2, 0.85],
+             [1.0, 0.85, 0.1, 0.85]],
+            dtype=np.float32,
+        )
+        return palette[np.arange(count) % len(palette)]
+    color = [0.9, 0.2, 1.0, 0.65]
+    if mode_name == "g1":
+        color = [0.1, 0.85, 1.0, 0.55]
+    return np.tile(np.asarray(color, np.float32), (count, 1))
+
+
+def clamp_frame(frame, clip):
+    return max(0, min(int(frame), clip.num_frames - 1))
+
+
+def compute_gravity_dir(base_quat):
+    down = np.asarray([0.0, 0.0, -1.0], dtype=np.float32)
+    return quat_rotate(quat_conjugate(base_quat), down)
+
+
+def quat_to_rotvec(quat):
+    quat = np.asarray(quat, dtype=np.float64)
+    quat = quat / np.linalg.norm(quat)
+    if quat[0] < 0.0:
+        quat = -quat
+    vector = quat[1:]
+    sin_half = np.linalg.norm(vector)
+    if sin_half < 1e-8:
+        return np.zeros((3,), dtype=np.float64)
+    axis = vector / sin_half
+    angle = 2.0 * np.arctan2(sin_half, quat[0])
+    return axis * angle
+
+
+def compute_heading_quat(quat):
+    return yaw_to_quat(compute_yaw(quat))
+
+
+def compute_heading_quat_inv(quat):
+    return quat_conjugate(compute_heading_quat(quat))
+
+
+def compute_yaw(quat):
+    w, x, y, z = quat
+    top = 2.0 * (w * z + x * y)
+    bottom = 1.0 - 2.0 * (y * y + z * z)
+    return np.arctan2(top, bottom)
+
+
+def yaw_to_quat(yaw):
+    half_yaw = 0.5 * yaw
+    return np.asarray(
+        [np.cos(half_yaw), 0.0, 0.0, np.sin(half_yaw)],
+        dtype=np.float32,
+    )
+
+
+def quat_conjugate(quat):
+    w, x, y, z = quat
+    return np.asarray([w, -x, -y, -z], dtype=np.float32)
+
+
+def quat_mul(left, right):
+    lw, lx, ly, lz = left
+    rw, rx, ry, rz = right
+    args = (
+        lw * rw - lx * rx - ly * ry - lz * rz,
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+    )
+    return np.asarray(args, dtype=np.float32)
+
+
+def quat_rotate(quat, vector):
+    quat = np.asarray(quat, dtype=np.float32)
+    vector = np.asarray(vector, dtype=np.float32)
+    quat_vector = quat[1:]
+    first = vector * (2.0 * quat[0] * quat[0] - 1.0)
+    second = np.cross(quat_vector, vector) * quat[0] * 2.0
+    third = quat_vector * np.dot(quat_vector, vector) * 2.0
+    return (first + second + third).astype(np.float32)
+
+
+def quat_to_sixd(quat):
+    matrix = quat_to_matrix(quat)
+    return matrix[:, :2].reshape(-1).astype(np.float32)
+
+
+def quat_to_matrix(quat):
+    w, x, y, z = quat
+    xx, yy, zz = x * x, y * y, z * z
+    xy, xz, yz = x * y, x * z, y * z
+    wx, wy, wz = w * x, w * y, w * z
+    return np.asarray(
+        [
+            [1 - 2 * (yy + zz), 2 * (xy - wz), 2 * (xz + wy)],
+            [2 * (xy + wz), 1 - 2 * (xx + zz), 2 * (yz - wx)],
+            [2 * (xz - wy), 2 * (yz + wx), 1 - 2 * (xx + yy)],
+        ],
+        dtype=np.float32,
+    )

--- a/examples/sonic/simulation_test.py
+++ b/examples/sonic/simulation_test.py
@@ -1,0 +1,206 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from simulation import DEFAULT_ANGLES
+from simulation import HistoryEntry
+from simulation import MotionClip
+from simulation import build_encoder_obs
+from simulation import build_history_buffer
+from simulation import build_history_entry
+from simulation import build_history_entry_from_state
+from simulation import build_policy_tail
+from simulation import check_mode_available
+from simulation import compute_heading_state
+from simulation import compute_reference_markers
+from simulation import compute_support_wrench
+from simulation import compute_hand_pd_torque
+from simulation import compute_pd_torque
+from simulation import compute_vr_targets
+from simulation import load_body_indices
+from paz.models.foundation.sonic.layout import EncoderModeLayout
+from paz.models.foundation.sonic.layout import ObservationSpan
+from paz.models.foundation.sonic.layout import SonicObservationLayout
+from paz.models.foundation.sonic.layout import find_encoder_span
+
+
+def build_spans(names_and_dims, start=0):
+    spans = []
+    offset = start
+    for name, dim in names_and_dims:
+        spans.append(ObservationSpan(name, offset, offset + dim, dim))
+        offset += dim
+    return tuple(spans)
+
+
+def build_release_layout():
+    policy_dims = (
+        ("token_state", 64),
+        ("his_base_angular_velocity_10frame_step1", 30),
+        ("his_body_joint_positions_10frame_step1", 290),
+        ("his_body_joint_velocities_10frame_step1", 290),
+        ("his_last_actions_10frame_step1", 290),
+        ("his_gravity_dir_10frame_step1", 30),
+    )
+    encoder_dims = (
+        ("encoder_mode_4", 4),
+        ("motion_joint_positions_10frame_step5", 290),
+        ("motion_joint_velocities_10frame_step5", 290),
+        ("motion_root_z_position_10frame_step5", 10),
+        ("motion_root_z_position", 1),
+        ("motion_anchor_orientation", 6),
+        ("motion_anchor_orientation_10frame_step5", 60),
+        ("motion_joint_positions_lowerbody_10frame_step5", 120),
+        ("motion_joint_velocities_lowerbody_10frame_step5", 120),
+        ("vr_3point_local_target", 9),
+        ("vr_3point_local_orn_target", 12),
+        ("smpl_joints_10frame_step1", 720),
+        ("smpl_anchor_orientation_10frame_step1", 60),
+        ("motion_joint_positions_wrists_10frame_step1", 60),
+    )
+    modes = tuple(
+        EncoderModeLayout(name, mode_id, (), ())
+        for mode_id, name in enumerate(("g1", "teleop", "smpl"))
+    )
+    return SonicObservationLayout(
+        build_spans(policy_dims), build_spans(encoder_dims), modes, 64)
+
+
+def build_clip(include_smpl=True):
+    num_frames = 60
+    frame_values = np.arange(num_frames, dtype=np.float32)[:, None]
+    joint_pos = frame_values + np.arange(29, dtype=np.float32)[None, :]
+    joint_vel = np.ones_like(joint_pos)
+    body_indices = np.asarray([0, 9, 28, 29], dtype=np.int32)
+    body_pos = np.zeros((num_frames, 4, 3), dtype=np.float32)
+    body_pos[:, 1] = [0.0, 0.0, 0.7]
+    body_pos[:, 2] = [0.3, 0.2, 1.0]
+    body_pos[:, 3] = [0.3, -0.2, 1.0]
+    body_quat = np.zeros((num_frames, 4, 4), dtype=np.float32)
+    body_quat[..., 0] = 1.0
+    smpl_joints = None
+    if include_smpl:
+        joints = np.arange(72, dtype=np.float32).reshape(1, 24, 3)
+        smpl_joints = np.tile(joints, (num_frames, 1, 1))
+    args = (
+        "synthetic", joint_pos, joint_vel, body_pos, body_quat,
+        body_indices, smpl_joints, num_frames,
+    )
+    return MotionClip(*args)
+
+
+def build_heading(clip):
+    identity = np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    return identity, compute_heading_state(identity, clip.body_quat[0, 0])
+
+
+@pytest.mark.parametrize("mode_name, mode_id", [
+    ("g1", 0), ("teleop", 1), ("smpl", 2),
+])
+def test_build_encoder_obs_covers_release_modes(mode_name, mode_id):
+    layout = build_release_layout()
+    clip = build_clip()
+    base_quat, heading = build_heading(clip)
+    obs = build_encoder_obs(
+        layout, mode_name, clip, 2, True, base_quat, heading)
+    mode_span = find_encoder_span(layout, "encoder_mode_4")
+    assert obs.shape == (1, 1762)
+    assert obs[0, mode_span.start] == mode_id
+    assert np.isfinite(obs).all()
+
+
+def test_teleop_targets_match_original_root_local_construction():
+    clip = build_clip()
+    positions, orientations = compute_vr_targets(clip, 0)
+    expected_positions = np.asarray(
+        [[0.48, 0.175, 1.0], [0.48, -0.175, 1.0], [0.0, 0.0, 1.05]],
+        dtype=np.float32,
+    )
+    expected_orientations = np.tile(
+        np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32), (3, 1))
+    assert np.allclose(positions.reshape(3, 3), expected_positions)
+    assert np.array_equal(orientations.reshape(3, 4), expected_orientations)
+
+
+def test_smpl_mode_is_data_gated():
+    clip = build_clip(include_smpl=False)
+    available, reason = check_mode_available(clip, "smpl")
+    assert available is False
+    assert "smpl_joints.csv" in reason
+
+
+def test_policy_tail_has_release_shape_and_latest_action():
+    layout = build_release_layout()
+    history = build_history_buffer()
+    identity = np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    for index in range(10):
+        action = np.full((29,), index, dtype=np.float32)
+        entry = HistoryEntry(
+            identity, np.zeros(3, np.float32), DEFAULT_ANGLES,
+            np.zeros(29, np.float32), action)
+        history.append(entry)
+    tail = build_policy_tail(layout, history)
+    assert tail.shape == (1, 930)
+    last_action_span = layout.policy_spans[4]
+    start = last_action_span.start - layout.token_dim
+    actions = tail[0, start:start + last_action_span.dim].reshape(10, 29)
+    assert np.array_equal(actions[-1], np.full(29, 9, np.float32))
+
+
+def test_reference_marker_counts_match_mode_targets():
+    clip = build_clip()
+    identity = np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    root_pos = np.zeros(3, dtype=np.float32)
+    assert compute_reference_markers(
+        "g1", clip, 0, root_pos, identity).shape == (4, 3)
+    assert compute_reference_markers(
+        "teleop", clip, 0, root_pos, identity).shape == (3, 3)
+    assert compute_reference_markers(
+        "smpl", clip, 0, root_pos, identity).shape == (24, 3)
+
+
+def test_support_wrench_is_zero_at_assisted_pose():
+    pose = np.zeros(13, dtype=np.float64)
+    pose[:3] = [0.0, 0.0, 1.0]
+    pose[3] = 1.0
+    assert np.allclose(compute_support_wrench(pose), 0.0)
+
+
+def test_load_body_indices_supports_wrapped_metadata(tmp_path):
+    metadata = tmp_path / "metadata.txt"
+    metadata.write_text(
+        "Body part indexes:\n[ 0  4 10 18\n  5 11 19  9 28 29]\n",
+        encoding="utf-8",
+    )
+    expected = np.asarray([0, 4, 10, 18, 5, 11, 19, 9, 28, 29])
+    assert np.array_equal(load_body_indices(metadata), expected)
+
+
+def test_explicit_state_history_matches_contiguous_scene():
+    qpos = np.arange(36, dtype=np.float32)
+    qpos[3:7] = [1.0, 0.0, 0.0, 0.0]
+    qvel = np.arange(35, dtype=np.float32)
+    last_action = np.arange(29, dtype=np.float32)
+    contiguous = build_history_entry(qpos, qvel, last_action)
+    explicit = build_history_entry_from_state(
+        qpos[3:7], qvel[3:6], qpos[7:36], qvel[6:35], last_action)
+    for field in HistoryEntry._fields:
+        assert np.array_equal(getattr(explicit, field),
+                              getattr(contiguous, field))
+
+
+def test_pd_torque_uses_original_simulator_limits():
+    target = np.full(29, 1000.0, dtype=np.float32)
+    torque = compute_pd_torque(
+        target, np.zeros(29, np.float32), np.zeros(29, np.float32))
+    expected = np.asarray(
+        [88, 88, 88, 139, 50, 50, 88, 88, 88, 139, 50, 50,
+         88, 50, 50, 25, 25, 25, 25, 25, 5, 5, 25, 25, 25, 25,
+         25, 5, 5], dtype=np.float32)
+    assert np.array_equal(torque, expected)
+    hand_torque = compute_hand_pd_torque(
+        np.full(14, -1000.0), np.zeros(14))
+    expected_hand = np.asarray(
+        [2.45, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7] * 2, dtype=np.float32)
+    assert np.array_equal(hand_torque, expected_hand)

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -37,6 +37,7 @@ from .foundation.whisper.model import Whisper
 from .foundation.gemma4.pretrained import Gemma4
 from .foundation.gemma4.model import Gemma4Backbone
 from .foundation.gemma4.causal_lm import Gemma4CausalLM
+from .foundation.sonic.pretrained import Sonic
 from .feature.xfeat.model import XFeatModel
 from .feature.xfeat.model import XFeat
 from .feature.lightglue.model import LighterGlue

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -37,7 +37,7 @@ from .foundation.whisper.model import Whisper
 from .foundation.gemma4.pretrained import Gemma4
 from .foundation.gemma4.model import Gemma4Backbone
 from .foundation.gemma4.causal_lm import Gemma4CausalLM
-from .foundation.sonic.pretrained import Sonic
+from .foundation.sonic.pretrained import SONIC
 from .feature.xfeat.model import XFeatModel
 from .feature.xfeat.model import XFeat
 from .feature.lightglue.model import LighterGlue

--- a/paz/models/foundation/sonic/conftest.py
+++ b/paz/models/foundation/sonic/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"

--- a/paz/models/foundation/sonic/conftest.py
+++ b/paz/models/foundation/sonic/conftest.py
@@ -1,3 +1,35 @@
 import os
 
 os.environ["KERAS_BACKEND"] = "jax"
+
+import pytest
+
+from paz.models.foundation.sonic.layout import EncoderModeLayout
+from paz.models.foundation.sonic.layout import ObservationSpan
+from paz.models.foundation.sonic.layout import SonicObservationLayout
+
+
+@pytest.fixture
+def toy_layout():
+    # token_dim must stay 64 (2 * 32) to satisfy compute_release_fsq's
+    # fixed reshape in paz.models.foundation.sonic.model.
+    token_dim = 64
+    mode_span = ObservationSpan("encoder_mode_4", 0, 4, 4)
+    flat_span = ObservationSpan("motion_root_z_position", 4, 5, 1)
+    temporal_span = ObservationSpan(
+        "motion_anchor_orientation_10frame_step5", 5, 65, 60)
+    flat_mode = EncoderModeLayout(
+        "flat", 0, ("encoder_mode_4", "motion_root_z_position"),
+        (flat_span,))
+    temporal_mode = EncoderModeLayout(
+        "temporal", 1,
+        ("encoder_mode_4", "motion_anchor_orientation_10frame_step5"),
+        (temporal_span,), temporal_frames=10)
+    policy_spans = (
+        ObservationSpan("token_state", 0, token_dim, token_dim),
+        ObservationSpan("policy_tail", token_dim, token_dim + 6, 6),
+    )
+    encoder_spans = (mode_span, flat_span, temporal_span)
+    modes = (flat_mode, temporal_mode)
+    return SonicObservationLayout(policy_spans, encoder_spans, modes,
+                                   token_dim)

--- a/paz/models/foundation/sonic/conftest.py
+++ b/paz/models/foundation/sonic/conftest.py
@@ -16,20 +16,19 @@ def toy_layout():
     token_dim = 64
     mode_span = ObservationSpan("encoder_mode_4", 0, 4, 4)
     flat_span = ObservationSpan("motion_root_z_position", 4, 5, 1)
-    temporal_span = ObservationSpan(
-        "motion_anchor_orientation_10frame_step5", 5, 65, 60)
-    flat_mode = EncoderModeLayout(
-        "flat", 0, ("encoder_mode_4", "motion_root_z_position"),
-        (flat_span,))
+    temporal_name = "motion_anchor_orientation_10frame_step5"
+    temporal_span = ObservationSpan(temporal_name, 5, 65, 60)
+    flat_required = "encoder_mode_4", "motion_root_z_position"
+    flat_mode = EncoderModeLayout("flat", 0, flat_required, (flat_span,))
+    temporal_required = "encoder_mode_4", temporal_name
+    temporal_args = (temporal_required, (temporal_span,))
     temporal_mode = EncoderModeLayout(
-        "temporal", 1,
-        ("encoder_mode_4", "motion_anchor_orientation_10frame_step5"),
-        (temporal_span,), temporal_frames=10)
-    policy_spans = (
-        ObservationSpan("token_state", 0, token_dim, token_dim),
-        ObservationSpan("policy_tail", token_dim, token_dim + 6, 6),
-    )
+        "temporal", 1, *temporal_args, temporal_frames=10)
+    token_state = ObservationSpan("token_state", 0, token_dim, token_dim)
+    tail_end = token_dim + 6
+    policy_tail = ObservationSpan("policy_tail", token_dim, tail_end, 6)
+    policy_spans = (token_state, policy_tail)
     encoder_spans = (mode_span, flat_span, temporal_span)
     modes = (flat_mode, temporal_mode)
-    return SonicObservationLayout(policy_spans, encoder_spans, modes,
-                                   token_dim)
+    args = policy_spans, encoder_spans, modes, token_dim
+    return SonicObservationLayout(*args)

--- a/paz/models/foundation/sonic/conversion.py
+++ b/paz/models/foundation/sonic/conversion.py
@@ -1,0 +1,122 @@
+"""Import released SONIC ONNX weights into the ported Keras models."""
+
+from argparse import ArgumentParser
+from pathlib import Path
+import re
+import shutil
+
+import onnx
+from onnx import numpy_helper
+
+from paz.models.foundation.sonic.layout import compute_decoder_input_dim
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.layout import load_release_observation_layout
+from paz.models.foundation.sonic.model import build_sonic_actor
+from paz.models.foundation.sonic.model import build_sonic_decoder
+from paz.models.foundation.sonic.model import build_sonic_encoder
+
+_ENCODER_BRANCH_PATTERN = re.compile(
+    r"^module\.encoders\.(?P<branch>[^.]+)\.module\.(?P<layer>\d+)"
+    r"\.(?P<kind>weight|bias)$")
+_DECODER_NODE_PATTERN = re.compile(
+    r"^/g1_dyn/module/module\.(?P<layer>\d+)/MatMul$")
+
+
+def port_sonic_weights(layout, encoder_onnx_path, decoder_onnx_path):
+    encoder = build_sonic_encoder(layout)
+    decoder = build_sonic_decoder(layout)
+    check_input_dim(encoder, compute_encoder_input_dim(layout), "encoder")
+    check_input_dim(decoder, compute_decoder_input_dim(layout), "decoder")
+    apply_encoder_weights(encoder, load_onnx_model(encoder_onnx_path))
+    apply_decoder_weights(decoder, load_onnx_model(decoder_onnx_path))
+    actor = build_sonic_actor(layout, encoder, decoder)
+    return encoder, decoder, actor
+
+
+def check_input_dim(model, expected_dim, name):
+    input_dim = model.input_shape[-1]
+    if input_dim != expected_dim:
+        raise ValueError(
+            f"{name} input mismatch: expected {expected_dim}, got "
+            f"{input_dim}")
+
+
+def load_onnx_model(model_path):
+    return onnx.load(str(model_path))
+
+
+def load_onnx_initializers(model):
+    return {tensor.name: numpy_helper.to_array(tensor)
+            for tensor in model.graph.initializer}
+
+
+def apply_encoder_weights(encoder, encoder_onnx):
+    initializers = load_onnx_initializers(encoder_onnx)
+    for name, value in initializers.items():
+        match = _ENCODER_BRANCH_PATTERN.match(name)
+        if match is None:
+            continue
+        branch, layer = match.group("branch"), match.group("layer")
+        layer_name = f"{branch}_module_{layer}"
+        set_dense_weight(encoder.get_layer(layer_name), match.group("kind"),
+                          value)
+
+
+def set_dense_weight(layer, kind, value):
+    kernel, bias = layer.get_weights()
+    if kind == "weight":
+        kernel = value.transpose(1, 0)
+    else:
+        bias = value
+    layer.set_weights([kernel, bias])
+
+
+def apply_decoder_weights(decoder, decoder_onnx):
+    initializers = load_onnx_initializers(decoder_onnx)
+    kernel_names = find_decoder_kernel_names(decoder_onnx)
+    for layer_id, kernel_name in kernel_names.items():
+        layer = decoder.get_layer(f"g1_dyn_module_{layer_id}")
+        bias_name = f"module.decoders.g1_dyn.module.{layer_id}.bias"
+        layer.set_weights(
+            [initializers[kernel_name], initializers[bias_name]])
+
+
+def find_decoder_kernel_names(decoder_onnx):
+    kernel_names = {}
+    for node in decoder_onnx.graph.node:
+        match = _DECODER_NODE_PATTERN.match(node.name)
+        if match is not None:
+            kernel_names[int(match.group("layer"))] = node.input[1]
+    return kernel_names
+
+
+def save_ported_weights(encoder, decoder, obs_config_path, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    encoder.save_weights(output_dir / "sonic_encoder.weights.h5")
+    decoder.save_weights(output_dir / "sonic_decoder.weights.h5")
+    shutil.copy(obs_config_path, output_dir / "observation_config.yaml")
+    return output_dir
+
+
+def build_argument_parser():
+    parser = ArgumentParser()
+    parser.add_argument("--obs_config", required=True)
+    parser.add_argument("--encoder_onnx", required=True)
+    parser.add_argument("--decoder_onnx", required=True)
+    parser.add_argument("--output_dir", default="~/.keras/paz/models/sonic")
+    return parser
+
+
+def main():
+    args = build_argument_parser().parse_args()
+    layout = load_release_observation_layout(args.obs_config)
+    encoder, decoder, _ = port_sonic_weights(
+        layout, args.encoder_onnx, args.decoder_onnx)
+    output_dir = save_ported_weights(
+        encoder, decoder, args.obs_config, Path(args.output_dir).expanduser())
+    print(f"Saved ported SONIC weights to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/paz/models/foundation/sonic/conversion.py
+++ b/paz/models/foundation/sonic/conversion.py
@@ -35,9 +35,7 @@ def port_weights(layout, encoder_onnx_path, decoder_onnx_path):
 def check_input_dim(model, expected_dim, name):
     input_dim = model.input_shape[-1]
     if input_dim != expected_dim:
-        raise ValueError(
-            f"{name} input mismatch: expected {expected_dim}, got "
-            f"{input_dim}")
+        raise ValueError(f"{name} dim mismatch: {input_dim} != {expected_dim}")
 
 
 def load_onnx_model(model_path):
@@ -45,8 +43,10 @@ def load_onnx_model(model_path):
 
 
 def load_onnx_initializers(model):
-    return {tensor.name: numpy_helper.to_array(tensor)
-            for tensor in model.graph.initializer}
+    initializers = {}
+    for tensor in model.graph.initializer:
+        initializers[tensor.name] = numpy_helper.to_array(tensor)
+    return initializers
 
 
 def apply_encoder_weights(encoder, encoder_onnx):
@@ -55,10 +55,11 @@ def apply_encoder_weights(encoder, encoder_onnx):
         match = _ENCODER_BRANCH_PATTERN.match(name)
         if match is None:
             continue
-        branch, layer = match.group("branch"), match.group("layer")
-        layer_name = f"{branch}_module_{layer}"
-        set_dense_weight(encoder.get_layer(layer_name), match.group("kind"),
-                          value)
+        branch, layer_id = match.group("branch"), match.group("layer")
+        layer_name = f"{branch}_module_{layer_id}"
+        layer = encoder.get_layer(layer_name)
+        kind = match.group("kind")
+        set_dense_weight(layer, kind, value)
 
 
 def set_dense_weight(layer, kind, value):
@@ -76,8 +77,8 @@ def apply_decoder_weights(decoder, decoder_onnx):
     for layer_id, kernel_name in kernel_names.items():
         layer = decoder.get_layer(f"g1_dyn_module_{layer_id}")
         bias_name = f"module.decoders.g1_dyn.module.{layer_id}.bias"
-        layer.set_weights(
-            [initializers[kernel_name], initializers[bias_name]])
+        weights = [initializers[kernel_name], initializers[bias_name]]
+        layer.set_weights(weights)
 
 
 def find_decoder_kernel_names(decoder_onnx):
@@ -109,10 +110,10 @@ def build_argument_parser():
 def main():
     args = build_argument_parser().parse_args()
     layout = load_release_observation_layout(args.obs_config)
-    encoder, decoder, _ = port_weights(
-        layout, args.encoder_onnx, args.decoder_onnx)
-    output_dir = save_ported_weights(
-        encoder, decoder, Path(args.output_dir).expanduser())
+    encoder_onnx, decoder_onnx = args.encoder_onnx, args.decoder_onnx
+    encoder, decoder, _ = port_weights(layout, encoder_onnx, decoder_onnx)
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir = save_ported_weights(encoder, decoder, output_dir)
     print(f"Saved ported SONIC weights to {output_dir}")
 
 

--- a/paz/models/foundation/sonic/conversion.py
+++ b/paz/models/foundation/sonic/conversion.py
@@ -11,9 +11,9 @@ from onnx import numpy_helper
 from paz.models.foundation.sonic.layout import compute_decoder_input_dim
 from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import load_release_observation_layout
-from paz.models.foundation.sonic.model import build_sonic_actor
-from paz.models.foundation.sonic.model import build_sonic_decoder
-from paz.models.foundation.sonic.model import build_sonic_encoder
+from paz.models.foundation.sonic.model import build_actor
+from paz.models.foundation.sonic.model import build_decoder
+from paz.models.foundation.sonic.model import build_encoder
 
 _ENCODER_BRANCH_PATTERN = re.compile(
     r"^module\.encoders\.(?P<branch>[^.]+)\.module\.(?P<layer>\d+)"
@@ -22,14 +22,14 @@ _DECODER_NODE_PATTERN = re.compile(
     r"^/g1_dyn/module/module\.(?P<layer>\d+)/MatMul$")
 
 
-def port_sonic_weights(layout, encoder_onnx_path, decoder_onnx_path):
-    encoder = build_sonic_encoder(layout)
-    decoder = build_sonic_decoder(layout)
+def port_weights(layout, encoder_onnx_path, decoder_onnx_path):
+    encoder = build_encoder(layout)
+    decoder = build_decoder(layout)
     check_input_dim(encoder, compute_encoder_input_dim(layout), "encoder")
     check_input_dim(decoder, compute_decoder_input_dim(layout), "decoder")
     apply_encoder_weights(encoder, load_onnx_model(encoder_onnx_path))
     apply_decoder_weights(decoder, load_onnx_model(decoder_onnx_path))
-    actor = build_sonic_actor(layout, encoder, decoder)
+    actor = build_actor(layout, encoder, decoder)
     return encoder, decoder, actor
 
 
@@ -111,7 +111,7 @@ def build_argument_parser():
 def main():
     args = build_argument_parser().parse_args()
     layout = load_release_observation_layout(args.obs_config)
-    encoder, decoder, _ = port_sonic_weights(
+    encoder, decoder, _ = port_weights(
         layout, args.encoder_onnx, args.decoder_onnx)
     output_dir = save_ported_weights(
         encoder, decoder, args.obs_config, Path(args.output_dir).expanduser())

--- a/paz/models/foundation/sonic/conversion.py
+++ b/paz/models/foundation/sonic/conversion.py
@@ -3,7 +3,6 @@
 from argparse import ArgumentParser
 from pathlib import Path
 import re
-import shutil
 
 import onnx
 from onnx import numpy_helper
@@ -90,12 +89,11 @@ def find_decoder_kernel_names(decoder_onnx):
     return kernel_names
 
 
-def save_ported_weights(encoder, decoder, obs_config_path, output_dir):
+def save_ported_weights(encoder, decoder, output_dir):
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     encoder.save_weights(output_dir / "sonic_encoder.weights.h5")
     decoder.save_weights(output_dir / "sonic_decoder.weights.h5")
-    shutil.copy(obs_config_path, output_dir / "observation_config.yaml")
     return output_dir
 
 
@@ -114,7 +112,7 @@ def main():
     encoder, decoder, _ = port_weights(
         layout, args.encoder_onnx, args.decoder_onnx)
     output_dir = save_ported_weights(
-        encoder, decoder, args.obs_config, Path(args.output_dir).expanduser())
+        encoder, decoder, Path(args.output_dir).expanduser())
     print(f"Saved ported SONIC weights to {output_dir}")
 
 

--- a/paz/models/foundation/sonic/conversion_test.py
+++ b/paz/models/foundation/sonic/conversion_test.py
@@ -4,8 +4,8 @@ from onnx import numpy_helper
 
 from paz.models.foundation.sonic.conversion import apply_decoder_weights
 from paz.models.foundation.sonic.conversion import apply_encoder_weights
-from paz.models.foundation.sonic.model import build_sonic_decoder
-from paz.models.foundation.sonic.model import build_sonic_encoder
+from paz.models.foundation.sonic.model import build_decoder
+from paz.models.foundation.sonic.model import build_encoder
 from paz.models.foundation.sonic.model import build_toy_layout
 
 
@@ -52,7 +52,7 @@ def build_fake_decoder_onnx(decoder):
 
 def test_apply_encoder_weights_matches_injected_values():
     layout = build_toy_layout()
-    encoder = build_sonic_encoder(layout)
+    encoder = build_encoder(layout)
     encoder_onnx, expected = build_fake_encoder_onnx(encoder, "flat")
     apply_encoder_weights(encoder, encoder_onnx)
     for layer_name, (kernel, bias) in expected.items():
@@ -63,7 +63,7 @@ def test_apply_encoder_weights_matches_injected_values():
 
 def test_apply_decoder_weights_matches_injected_values():
     layout = build_toy_layout()
-    decoder = build_sonic_decoder(layout)
+    decoder = build_decoder(layout)
     decoder_onnx, expected = build_fake_decoder_onnx(decoder)
     apply_decoder_weights(decoder, decoder_onnx)
     for layer_name, (kernel, bias) in expected.items():

--- a/paz/models/foundation/sonic/conversion_test.py
+++ b/paz/models/foundation/sonic/conversion_test.py
@@ -1,0 +1,72 @@
+import numpy as np
+from onnx import helper
+from onnx import numpy_helper
+
+from paz.models.foundation.sonic.conversion import apply_decoder_weights
+from paz.models.foundation.sonic.conversion import apply_encoder_weights
+from paz.models.foundation.sonic.model import build_sonic_decoder
+from paz.models.foundation.sonic.model import build_sonic_encoder
+from paz.models.foundation.sonic.model import build_toy_layout
+
+
+def find_dense_layers(model, prefix):
+    return [layer for layer in model.layers if layer.name.startswith(prefix)]
+
+
+def build_fake_encoder_onnx(encoder, branch):
+    initializers, expected = [], {}
+    for layer in find_dense_layers(encoder, f"{branch}_module_"):
+        layer_id = layer.name.rsplit("_", 1)[-1]
+        in_dim, out_dim = layer.get_weights()[0].shape
+        rng = np.random.default_rng(int(layer_id))
+        weight = rng.normal(size=(out_dim, in_dim)).astype("float32")
+        bias = rng.normal(size=(out_dim,)).astype("float32")
+        prefix = f"module.encoders.{branch}.module.{layer_id}"
+        initializers.append(numpy_helper.from_array(weight, f"{prefix}.weight"))
+        initializers.append(numpy_helper.from_array(bias, f"{prefix}.bias"))
+        expected[layer.name] = (weight.transpose(1, 0), bias)
+    graph = helper.make_graph([], "encoder", [], [], initializer=initializers)
+    return helper.make_model(graph), expected
+
+
+def build_fake_decoder_onnx(decoder):
+    initializers, nodes, expected = [], [], {}
+    for layer in find_dense_layers(decoder, "g1_dyn_module_"):
+        layer_id = layer.name.rsplit("_", 1)[-1]
+        in_dim, out_dim = layer.get_weights()[0].shape
+        rng = np.random.default_rng(int(layer_id))
+        weight = rng.normal(size=(in_dim, out_dim)).astype("float32")
+        bias = rng.normal(size=(out_dim,)).astype("float32")
+        kernel_name = f"kernel_{layer_id}"
+        bias_name = f"module.decoders.g1_dyn.module.{layer_id}.bias"
+        initializers.append(numpy_helper.from_array(weight, kernel_name))
+        initializers.append(numpy_helper.from_array(bias, bias_name))
+        node_name = f"/g1_dyn/module/module.{layer_id}/MatMul"
+        nodes.append(helper.make_node(
+            "MatMul", ["x", kernel_name], ["y"], name=node_name))
+        expected[layer.name] = (weight, bias)
+    graph = helper.make_graph(
+        nodes, "decoder", [], [], initializer=initializers)
+    return helper.make_model(graph), expected
+
+
+def test_apply_encoder_weights_matches_injected_values():
+    layout = build_toy_layout()
+    encoder = build_sonic_encoder(layout)
+    encoder_onnx, expected = build_fake_encoder_onnx(encoder, "flat")
+    apply_encoder_weights(encoder, encoder_onnx)
+    for layer_name, (kernel, bias) in expected.items():
+        actual_kernel, actual_bias = encoder.get_layer(layer_name).get_weights()
+        assert np.array_equal(actual_kernel, kernel)
+        assert np.array_equal(actual_bias, bias)
+
+
+def test_apply_decoder_weights_matches_injected_values():
+    layout = build_toy_layout()
+    decoder = build_sonic_decoder(layout)
+    decoder_onnx, expected = build_fake_decoder_onnx(decoder)
+    apply_decoder_weights(decoder, decoder_onnx)
+    for layer_name, (kernel, bias) in expected.items():
+        actual_kernel, actual_bias = decoder.get_layer(layer_name).get_weights()
+        assert np.array_equal(actual_kernel, kernel)
+        assert np.array_equal(actual_bias, bias)

--- a/paz/models/foundation/sonic/conversion_test.py
+++ b/paz/models/foundation/sonic/conversion_test.py
@@ -6,7 +6,6 @@ from paz.models.foundation.sonic.conversion import apply_decoder_weights
 from paz.models.foundation.sonic.conversion import apply_encoder_weights
 from paz.models.foundation.sonic.model import build_decoder
 from paz.models.foundation.sonic.model import build_encoder
-from paz.models.foundation.sonic.model import build_toy_layout
 
 
 def find_dense_layers(model, prefix):
@@ -50,9 +49,8 @@ def build_fake_decoder_onnx(decoder):
     return helper.make_model(graph), expected
 
 
-def test_apply_encoder_weights_matches_injected_values():
-    layout = build_toy_layout()
-    encoder = build_encoder(layout)
+def test_apply_encoder_weights_matches_injected_values(toy_layout):
+    encoder = build_encoder(toy_layout)
     encoder_onnx, expected = build_fake_encoder_onnx(encoder, "flat")
     apply_encoder_weights(encoder, encoder_onnx)
     for layer_name, (kernel, bias) in expected.items():
@@ -61,9 +59,8 @@ def test_apply_encoder_weights_matches_injected_values():
         assert np.array_equal(actual_bias, bias)
 
 
-def test_apply_decoder_weights_matches_injected_values():
-    layout = build_toy_layout()
-    decoder = build_decoder(layout)
+def test_apply_decoder_weights_matches_injected_values(toy_layout):
+    decoder = build_decoder(toy_layout)
     decoder_onnx, expected = build_fake_decoder_onnx(decoder)
     apply_decoder_weights(decoder, decoder_onnx)
     for layer_name, (kernel, bias) in expected.items():

--- a/paz/models/foundation/sonic/layout.py
+++ b/paz/models/foundation/sonic/layout.py
@@ -115,20 +115,20 @@ def load_release_observation_layout(obs_config_path):
     check_policy_spans(policy_spans, token_dim)
     check_encoder_spans(encoder_spans)
     encoder_span_map = {span.name: span for span in encoder_spans}
-    mode_configs = encoder_config.get("encoder_modes", [])
-    encoder_modes = [
-        load_encoder_mode(mode_config, encoder_span_map)
-        for mode_config in mode_configs
-    ]
+    encoder_modes = load_encoder_modes(encoder_config, encoder_span_map)
+    return SonicObservationLayout(
+        policy_spans, encoder_spans, encoder_modes, token_dim)
+
+
+def load_encoder_modes(encoder_config, encoder_span_map):
+    encoder_modes = []
+    for mode_config in encoder_config.get("encoder_modes", []):
+        mode = load_encoder_mode(mode_config, encoder_span_map)
+        encoder_modes.append(mode)
     if not encoder_modes:
         raise ValueError("No encoder_modes found in observation config")
-    args = (
-        policy_spans,
-        encoder_spans,
-        tuple(sorted(encoder_modes, key=lambda mode: mode.mode_id)),
-        token_dim,
-    )
-    return SonicObservationLayout(*args)
+    sorted_modes = sorted(encoder_modes, key=lambda mode: mode.mode_id)
+    return tuple(sorted_modes)
 
 
 def load_yaml(obs_config_path):
@@ -145,8 +145,7 @@ def check_policy_spans(policy_spans, token_dim):
         raise ValueError(f"Expected 'token_state' first, got {name}")
     if policy_spans[0].dim != token_dim:
         dim = policy_spans[0].dim
-        raise ValueError(
-            f"token_state dimension mismatch: expected {token_dim}, got {dim}")
+        raise ValueError(f"token_state dim mismatch: {dim} != {token_dim}")
 
 
 def check_encoder_spans(encoder_spans):
@@ -158,24 +157,20 @@ def check_encoder_spans(encoder_spans):
 
 
 def load_encoder_mode(mode_config, encoder_span_map):
-    required_observations = tuple(mode_config.get("required_observations", []))
-    feature_spans = tuple(
-        encoder_span_map[name]
-        for name in required_observations
-        if name != "encoder_mode_4"
-    )
+    required_observations = tuple(
+        mode_config.get("required_observations", []))
+    feature_spans = []
+    for name in required_observations:
+        if name != "encoder_mode_4":
+            feature_spans.append(encoder_span_map[name])
+    feature_spans = tuple(feature_spans)
     temporal_frames = compute_temporal_frames(required_observations)
     feature_groups = compute_feature_groups(
         mode_config["name"], feature_spans, encoder_span_map)
-    args = (
-        mode_config["name"],
-        int(mode_config["mode_id"]),
-        required_observations,
-        feature_spans,
-        temporal_frames,
-        feature_groups,
-    )
-    return EncoderModeLayout(*args)
+    return EncoderModeLayout(
+        mode_config["name"], int(mode_config["mode_id"]),
+        required_observations, feature_spans, temporal_frames,
+        feature_groups)
 
 
 def compute_temporal_frames(required_observations):
@@ -195,10 +190,11 @@ def compute_temporal_frames(required_observations):
 def compute_feature_groups(mode_name, feature_spans, encoder_span_map):
     if mode_name not in _RELEASE_ENCODER_GROUPS:
         return tuple((span,) for span in feature_spans)
-    return tuple(
-        tuple(encoder_span_map[name] for name in group)
-        for group in _RELEASE_ENCODER_GROUPS[mode_name]
-    )
+    feature_groups = []
+    for group in _RELEASE_ENCODER_GROUPS[mode_name]:
+        spans = tuple(encoder_span_map[name] for name in group)
+        feature_groups.append(spans)
+    return tuple(feature_groups)
 
 
 def resolve_observation_dim(name, token_dim):
@@ -216,8 +212,7 @@ def resolve_observation_dim(name, token_dim):
 
 
 def load_enabled_spans(observation_entries, token_dim):
-    spans = []
-    offset = 0
+    spans, offset = [], 0
     for entry in observation_entries:
         if not entry.get("enabled", False):
             continue

--- a/paz/models/foundation/sonic/layout.py
+++ b/paz/models/foundation/sonic/layout.py
@@ -117,21 +117,22 @@ def load_release_observation_layout(obs_config_path):
 def build_observation_layout(config):
     encoder_config = config.get("encoder", {})
     token_dim = int(encoder_config["dimension"])
-    policy_spans = load_enabled_spans(config.get("observations", []), token_dim)
-    encoder_spans = load_enabled_spans(
-        encoder_config.get("encoder_observations", []), 0)
+    observations = config.get("observations", [])
+    policy_spans = load_enabled_spans(observations, token_dim)
+    encoder_observations = encoder_config.get("encoder_observations", [])
+    encoder_spans = load_enabled_spans(encoder_observations, 0)
     check_policy_spans(policy_spans, token_dim)
     check_encoder_spans(encoder_spans)
-    encoder_span_map = {span.name: span for span in encoder_spans}
-    encoder_modes = load_encoder_modes(encoder_config, encoder_span_map)
-    return SonicObservationLayout(
-        policy_spans, encoder_spans, encoder_modes, token_dim)
+    span_map = {span.name: span for span in encoder_spans}
+    encoder_modes = load_encoder_modes(encoder_config, span_map)
+    args = policy_spans, encoder_spans, encoder_modes, token_dim
+    return SonicObservationLayout(*args)
 
 
-def load_encoder_modes(encoder_config, encoder_span_map):
+def load_encoder_modes(encoder_config, span_map):
     encoder_modes = []
     for mode_config in encoder_config.get("encoder_modes", []):
-        mode = load_encoder_mode(mode_config, encoder_span_map)
+        mode = load_encoder_mode(mode_config, span_map)
         encoder_modes.append(mode)
     if not encoder_modes:
         raise ValueError("No encoder_modes found in observation config")
@@ -164,21 +165,21 @@ def check_encoder_spans(encoder_spans):
         raise ValueError(f"Expected 'encoder_mode_4' first, got {name}")
 
 
-def load_encoder_mode(mode_config, encoder_span_map):
-    required_observations = tuple(
-        mode_config.get("required_observations", []))
+def load_encoder_mode(mode_config, span_map):
+    required = mode_config.get("required_observations", [])
+    required_observations = tuple(required)
     feature_spans = []
     for name in required_observations:
         if name != "encoder_mode_4":
-            feature_spans.append(encoder_span_map[name])
+            feature_spans.append(span_map[name])
     feature_spans = tuple(feature_spans)
     temporal_frames = compute_temporal_frames(required_observations)
-    feature_groups = compute_feature_groups(
-        mode_config["name"], feature_spans, encoder_span_map)
-    return EncoderModeLayout(
-        mode_config["name"], int(mode_config["mode_id"]),
-        required_observations, feature_spans, temporal_frames,
-        feature_groups)
+    mode_name = mode_config["name"]
+    feature_groups = compute_feature_groups(mode_name, feature_spans, span_map)
+    mode_id = int(mode_config["mode_id"])
+    args = (mode_name, mode_id, required_observations, feature_spans,
+            temporal_frames, feature_groups)
+    return EncoderModeLayout(*args)
 
 
 def compute_temporal_frames(required_observations):
@@ -199,13 +200,13 @@ def compute_temporal_frames(required_observations):
     return temporal_frames
 
 
-def compute_feature_groups(mode_name, feature_spans, encoder_span_map):
+def compute_feature_groups(mode_name, feature_spans, span_map):
     if mode_name not in _RELEASE_ENCODER_GROUPS:
         feature_groups = tuple((span,) for span in feature_spans)
     else:
         groups = []
         for group in _RELEASE_ENCODER_GROUPS[mode_name]:
-            spans = tuple(encoder_span_map[name] for name in group)
+            spans = tuple(span_map[name] for name in group)
             groups.append(spans)
         feature_groups = tuple(groups)
     return feature_groups

--- a/paz/models/foundation/sonic/layout.py
+++ b/paz/models/foundation/sonic/layout.py
@@ -1,0 +1,228 @@
+"""Observation-layout helpers for the ported SONIC deploy actor."""
+
+from collections import namedtuple
+from pathlib import Path
+import re
+
+import yaml
+
+_MULTI_FRAME_PATTERN = re.compile(
+    r"^(?P<base>.+)_(?P<frames>\d+)frame_step\d+$")
+
+_BASE_OBSERVATION_DIMS = {
+    "encoder_mode": 3,
+    "encoder_mode_4": 4,
+    "his_base_angular_velocity": 3,
+    "his_body_joint_positions": 29,
+    "his_body_joint_velocities": 29,
+    "his_gravity_dir": 3,
+    "his_last_actions": 29,
+    "motion_anchor_orientation": 6,
+    "motion_joint_positions": 29,
+    "motion_joint_positions_lowerbody": 12,
+    "motion_joint_positions_wrists": 6,
+    "motion_joint_velocities": 29,
+    "motion_joint_velocities_lowerbody": 12,
+    "motion_root_z_position": 1,
+    "smpl_anchor_orientation": 6,
+    "smpl_joints": 72,
+    "token_state": 0,
+    "vr_3point_local_orn_target": 12,
+    "vr_3point_local_target": 9,
+}
+
+_RELEASE_ENCODER_GROUPS = {
+    "g1": (
+        ("motion_joint_positions_10frame_step5",
+         "motion_joint_velocities_10frame_step5"),
+        ("motion_anchor_orientation_10frame_step5",),
+    ),
+    "smpl": (
+        ("smpl_joints_10frame_step1",),
+        ("smpl_anchor_orientation_10frame_step1",),
+        ("motion_joint_positions_wrists_10frame_step1",),
+    ),
+}
+
+ObservationSpan = namedtuple("ObservationSpan", "name start end dim")
+
+EncoderModeLayout = namedtuple(
+    "EncoderModeLayout",
+    "name mode_id required_observations feature_spans "
+    "temporal_frames feature_groups",
+    defaults=(None, ()),
+)
+
+SonicObservationLayout = namedtuple(
+    "SonicObservationLayout",
+    "policy_spans encoder_spans encoder_modes token_dim "
+    "action_dim mode_observation_name",
+    defaults=(29, "encoder_mode_4"),
+)
+
+
+def compute_mode_input_dim(mode):
+    return sum(span.dim for span in mode.feature_spans)
+
+
+def compute_policy_input_dim(layout):
+    if not layout.policy_spans:
+        return 0
+    return layout.policy_spans[-1].end
+
+
+def compute_encoder_input_dim(layout):
+    if not layout.encoder_spans:
+        return 0
+    return layout.encoder_spans[-1].end
+
+
+def compute_decoder_input_dim(layout):
+    return compute_policy_input_dim(layout)
+
+
+def compute_policy_tail_dim(layout):
+    return compute_policy_input_dim(layout) - layout.token_dim
+
+
+def compute_mode_scalar_index(layout):
+    mode_span = find_encoder_span(layout, layout.mode_observation_name)
+    return mode_span.start
+
+
+def find_policy_span(layout, name):
+    return find_span(layout.policy_spans, name)
+
+
+def find_encoder_span(layout, name):
+    return find_span(layout.encoder_spans, name)
+
+
+def find_span(spans, name):
+    for span in spans:
+        if span.name == name:
+            return span
+    raise KeyError(f"Unknown observation: {name}")
+
+
+def load_release_observation_layout(obs_config_path):
+    config = load_yaml(obs_config_path)
+    encoder_config = config.get("encoder", {})
+    token_dim = int(encoder_config["dimension"])
+    policy_spans = load_enabled_spans(config.get("observations", []), token_dim)
+    encoder_spans = load_enabled_spans(
+        encoder_config.get("encoder_observations", []), 0)
+    check_policy_spans(policy_spans, token_dim)
+    check_encoder_spans(encoder_spans)
+    encoder_span_map = {span.name: span for span in encoder_spans}
+    mode_configs = encoder_config.get("encoder_modes", [])
+    encoder_modes = [
+        load_encoder_mode(mode_config, encoder_span_map)
+        for mode_config in mode_configs
+    ]
+    if not encoder_modes:
+        raise ValueError("No encoder_modes found in observation config")
+    args = (
+        policy_spans,
+        encoder_spans,
+        tuple(sorted(encoder_modes, key=lambda mode: mode.mode_id)),
+        token_dim,
+    )
+    return SonicObservationLayout(*args)
+
+
+def load_yaml(obs_config_path):
+    obs_config_path = Path(obs_config_path)
+    with obs_config_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def check_policy_spans(policy_spans, token_dim):
+    if not policy_spans:
+        raise ValueError("No enabled policy observations found")
+    if policy_spans[0].name != "token_state":
+        name = policy_spans[0].name
+        raise ValueError(f"Expected 'token_state' first, got {name}")
+    if policy_spans[0].dim != token_dim:
+        dim = policy_spans[0].dim
+        raise ValueError(
+            f"token_state dimension mismatch: expected {token_dim}, got {dim}")
+
+
+def check_encoder_spans(encoder_spans):
+    if not encoder_spans:
+        raise ValueError("No enabled encoder observations found")
+    if encoder_spans[0].name != "encoder_mode_4":
+        name = encoder_spans[0].name
+        raise ValueError(f"Expected 'encoder_mode_4' first, got {name}")
+
+
+def load_encoder_mode(mode_config, encoder_span_map):
+    required_observations = tuple(mode_config.get("required_observations", []))
+    feature_spans = tuple(
+        encoder_span_map[name]
+        for name in required_observations
+        if name != "encoder_mode_4"
+    )
+    temporal_frames = compute_temporal_frames(required_observations)
+    feature_groups = compute_feature_groups(
+        mode_config["name"], feature_spans, encoder_span_map)
+    args = (
+        mode_config["name"],
+        int(mode_config["mode_id"]),
+        required_observations,
+        feature_spans,
+        temporal_frames,
+        feature_groups,
+    )
+    return EncoderModeLayout(*args)
+
+
+def compute_temporal_frames(required_observations):
+    frame_counts = []
+    for name in required_observations:
+        if name == "encoder_mode_4":
+            continue
+        match = _MULTI_FRAME_PATTERN.match(name)
+        if match is None:
+            return None
+        frame_counts.append(int(match.group("frames")))
+    if frame_counts and len(set(frame_counts)) == 1:
+        return frame_counts[0]
+    return None
+
+
+def compute_feature_groups(mode_name, feature_spans, encoder_span_map):
+    if mode_name not in _RELEASE_ENCODER_GROUPS:
+        return tuple((span,) for span in feature_spans)
+    return tuple(
+        tuple(encoder_span_map[name] for name in group)
+        for group in _RELEASE_ENCODER_GROUPS[mode_name]
+    )
+
+
+def resolve_observation_dim(name, token_dim):
+    if name == "token_state":
+        return token_dim
+    if name in _BASE_OBSERVATION_DIMS:
+        return _BASE_OBSERVATION_DIMS[name]
+    match = _MULTI_FRAME_PATTERN.match(name)
+    if match is None:
+        raise ValueError(f"Unsupported observation name: {name}")
+    base_name = match.group("base")
+    if base_name not in _BASE_OBSERVATION_DIMS:
+        raise ValueError(f"Unsupported base observation name: {base_name}")
+    return _BASE_OBSERVATION_DIMS[base_name] * int(match.group("frames"))
+
+
+def load_enabled_spans(observation_entries, token_dim):
+    spans = []
+    offset = 0
+    for entry in observation_entries:
+        if not entry.get("enabled", False):
+            continue
+        dim = resolve_observation_dim(entry["name"], token_dim)
+        span = ObservationSpan(entry["name"], offset, offset + dim, dim)
+        spans.append(span)
+        offset += dim
+    return tuple(spans)

--- a/paz/models/foundation/sonic/layout.py
+++ b/paz/models/foundation/sonic/layout.py
@@ -66,15 +66,19 @@ def compute_mode_input_dim(mode):
 
 
 def compute_policy_input_dim(layout):
-    if not layout.policy_spans:
-        return 0
-    return layout.policy_spans[-1].end
+    if layout.policy_spans:
+        dim = layout.policy_spans[-1].end
+    else:
+        dim = 0
+    return dim
 
 
 def compute_encoder_input_dim(layout):
-    if not layout.encoder_spans:
-        return 0
-    return layout.encoder_spans[-1].end
+    if layout.encoder_spans:
+        dim = layout.encoder_spans[-1].end
+    else:
+        dim = 0
+    return dim
 
 
 def compute_decoder_input_dim(layout):
@@ -107,6 +111,10 @@ def find_span(spans, name):
 
 def load_release_observation_layout(obs_config_path):
     config = load_yaml(obs_config_path)
+    return build_observation_layout(config)
+
+
+def build_observation_layout(config):
     encoder_config = config.get("encoder", {})
     token_dim = int(encoder_config["dimension"])
     policy_spans = load_enabled_spans(config.get("observations", []), token_dim)
@@ -175,40 +183,48 @@ def load_encoder_mode(mode_config, encoder_span_map):
 
 def compute_temporal_frames(required_observations):
     frame_counts = []
+    consistent = True
     for name in required_observations:
         if name == "encoder_mode_4":
             continue
         match = _MULTI_FRAME_PATTERN.match(name)
         if match is None:
-            return None
+            consistent = False
+            break
         frame_counts.append(int(match.group("frames")))
-    if frame_counts and len(set(frame_counts)) == 1:
-        return frame_counts[0]
-    return None
+    if consistent and frame_counts and len(set(frame_counts)) == 1:
+        temporal_frames = frame_counts[0]
+    else:
+        temporal_frames = None
+    return temporal_frames
 
 
 def compute_feature_groups(mode_name, feature_spans, encoder_span_map):
     if mode_name not in _RELEASE_ENCODER_GROUPS:
-        return tuple((span,) for span in feature_spans)
-    feature_groups = []
-    for group in _RELEASE_ENCODER_GROUPS[mode_name]:
-        spans = tuple(encoder_span_map[name] for name in group)
-        feature_groups.append(spans)
-    return tuple(feature_groups)
+        feature_groups = tuple((span,) for span in feature_spans)
+    else:
+        groups = []
+        for group in _RELEASE_ENCODER_GROUPS[mode_name]:
+            spans = tuple(encoder_span_map[name] for name in group)
+            groups.append(spans)
+        feature_groups = tuple(groups)
+    return feature_groups
 
 
 def resolve_observation_dim(name, token_dim):
     if name == "token_state":
-        return token_dim
-    if name in _BASE_OBSERVATION_DIMS:
-        return _BASE_OBSERVATION_DIMS[name]
-    match = _MULTI_FRAME_PATTERN.match(name)
-    if match is None:
-        raise ValueError(f"Unsupported observation name: {name}")
-    base_name = match.group("base")
-    if base_name not in _BASE_OBSERVATION_DIMS:
-        raise ValueError(f"Unsupported base observation name: {base_name}")
-    return _BASE_OBSERVATION_DIMS[base_name] * int(match.group("frames"))
+        dim = token_dim
+    elif name in _BASE_OBSERVATION_DIMS:
+        dim = _BASE_OBSERVATION_DIMS[name]
+    else:
+        match = _MULTI_FRAME_PATTERN.match(name)
+        if match is None:
+            raise ValueError(f"Unsupported observation name: {name}")
+        base_name = match.group("base")
+        if base_name not in _BASE_OBSERVATION_DIMS:
+            raise ValueError(f"Unsupported base observation name: {base_name}")
+        dim = _BASE_OBSERVATION_DIMS[base_name] * int(match.group("frames"))
+    return dim
 
 
 def load_enabled_spans(observation_entries, token_dim):

--- a/paz/models/foundation/sonic/layout_test.py
+++ b/paz/models/foundation/sonic/layout_test.py
@@ -1,0 +1,132 @@
+import pytest
+
+from paz.models.foundation.sonic.layout import compute_decoder_input_dim
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.layout import compute_mode_scalar_index
+from paz.models.foundation.sonic.layout import compute_policy_tail_dim
+from paz.models.foundation.sonic.layout import find_encoder_span
+from paz.models.foundation.sonic.layout import load_release_observation_layout
+
+_SYNTHETIC_YAML = """
+observations:
+  - name: "token_state"
+    enabled: true
+  - name: "his_last_actions_10frame_step1"
+    enabled: true
+  - name: "his_gravity_dir"
+    enabled: false
+
+encoder:
+  dimension: 8
+  encoder_observations:
+    - name: "encoder_mode_4"
+      enabled: true
+    - name: "motion_root_z_position"
+      enabled: true
+    - name: "motion_anchor_orientation_10frame_step5"
+      enabled: true
+  encoder_modes:
+    - name: "beta"
+      mode_id: 1
+      required_observations:
+        - encoder_mode_4
+        - motion_root_z_position
+    - name: "alpha"
+      mode_id: 0
+      required_observations:
+        - encoder_mode_4
+        - motion_anchor_orientation_10frame_step5
+"""
+
+
+def write_synthetic_config(tmp_path, text=_SYNTHETIC_YAML):
+    config_path = tmp_path / "observation_config.yaml"
+    config_path.write_text(text)
+    return config_path
+
+
+def test_layout_dims_match_release_semantics(tmp_path):
+    layout = load_release_observation_layout(write_synthetic_config(tmp_path))
+    assert layout.token_dim == 8
+    assert compute_policy_tail_dim(layout) == 290
+    assert compute_decoder_input_dim(layout) == 298
+    assert compute_encoder_input_dim(layout) == 65
+    assert compute_mode_scalar_index(layout) == 0
+
+
+def test_encoder_modes_are_sorted_by_mode_id(tmp_path):
+    layout = load_release_observation_layout(write_synthetic_config(tmp_path))
+    assert [mode.name for mode in layout.encoder_modes] == ["alpha", "beta"]
+
+
+def test_temporal_frames_resolved_per_mode(tmp_path):
+    layout = load_release_observation_layout(write_synthetic_config(tmp_path))
+    alpha, beta = layout.encoder_modes
+    assert alpha.temporal_frames == 10
+    assert beta.temporal_frames is None
+
+
+def test_find_encoder_span_raises_on_unknown_name(tmp_path):
+    layout = load_release_observation_layout(write_synthetic_config(tmp_path))
+    with pytest.raises(KeyError):
+        find_encoder_span(layout, "not_a_real_observation")
+
+
+def test_disabled_observations_are_skipped(tmp_path):
+    layout = load_release_observation_layout(write_synthetic_config(tmp_path))
+    names = [span.name for span in layout.policy_spans]
+    assert "his_gravity_dir" not in names
+
+
+def test_missing_token_state_first_raises(tmp_path):
+    text = _SYNTHETIC_YAML.replace(
+        '  - name: "token_state"\n    enabled: true\n', "")
+    with pytest.raises(ValueError):
+        load_release_observation_layout(write_synthetic_config(tmp_path, text))
+
+
+def test_missing_encoder_mode_4_first_raises(tmp_path):
+    text = _SYNTHETIC_YAML.replace(
+        '    - name: "encoder_mode_4"\n      enabled: true\n', "")
+    with pytest.raises(ValueError):
+        load_release_observation_layout(write_synthetic_config(tmp_path, text))
+
+
+def test_no_encoder_modes_raises(tmp_path):
+    text = _SYNTHETIC_YAML.split("  encoder_modes:")[0]
+    with pytest.raises(ValueError):
+        load_release_observation_layout(write_synthetic_config(tmp_path, text))
+
+
+def test_release_encoder_groups_override_g1_grouping(tmp_path):
+    text = """
+observations:
+  - name: "token_state"
+    enabled: true
+
+encoder:
+  dimension: 4
+  encoder_observations:
+    - name: "encoder_mode_4"
+      enabled: true
+    - name: "motion_joint_positions_10frame_step5"
+      enabled: true
+    - name: "motion_joint_velocities_10frame_step5"
+      enabled: true
+    - name: "motion_anchor_orientation_10frame_step5"
+      enabled: true
+  encoder_modes:
+    - name: "g1"
+      mode_id: 0
+      required_observations:
+        - encoder_mode_4
+        - motion_joint_positions_10frame_step5
+        - motion_joint_velocities_10frame_step5
+        - motion_anchor_orientation_10frame_step5
+"""
+    layout = load_release_observation_layout(
+        write_synthetic_config(tmp_path, text))
+    g1 = layout.encoder_modes[0]
+    assert len(g1.feature_groups) == 2
+    assert len(g1.feature_groups[0]) == 2
+    assert len(g1.feature_groups[1]) == 1

--- a/paz/models/foundation/sonic/model.py
+++ b/paz/models/foundation/sonic/model.py
@@ -1,0 +1,191 @@
+"""Keras architecture for the ported SONIC deploy actor."""
+
+from collections import namedtuple
+
+import keras
+from keras import layers
+
+from paz.models.foundation.sonic.layout import EncoderModeLayout
+from paz.models.foundation.sonic.layout import ObservationSpan
+from paz.models.foundation.sonic.layout import SonicObservationLayout
+from paz.models.foundation.sonic.layout import compute_decoder_input_dim
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.layout import compute_mode_scalar_index
+from paz.models.foundation.sonic.layout import compute_policy_tail_dim
+
+_ENCODER_HIDDEN_DIMS = (2048, 1024, 512, 512)
+_DECODER_HIDDEN_DIMS = (2048, 2048, 1024, 1024, 512, 512)
+
+FSQArgs = namedtuple(
+    "FSQArgs", "num_tokens token_dim offset scale rounding_shift divisor")
+_RELEASE_FSQ_ARGS = FSQArgs(2, 32, 0.032237, 15.515501, 0.5, 16.0)
+
+
+def build_sonic_actor(layout, encoder, decoder):
+    encoder_obs = build_input("encoder_obs", compute_encoder_input_dim(layout))
+    policy_obs = build_input(
+        "policy_obs_tail", compute_policy_tail_dim(layout))
+    encoded_tokens = encoder(encoder_obs)
+    decoder_input = compute_cat(encoded_tokens, policy_obs)
+    action = decoder(decoder_input)
+    inputs = {"encoder_obs": encoder_obs, "policy_obs_tail": policy_obs}
+    return keras.Model(inputs, action, name="sonic_actor")
+
+
+def build_sonic_encoder(layout):
+    encoder_input = build_input("obs_dict", compute_encoder_input_dim(layout))
+    mode_id = compute_mode_id(encoder_input, compute_mode_scalar_index(layout))
+    branch_tokens = compute_branch_tokens_list(encoder_input, layout)
+    selected_tokens = compute_selected_tokens(
+        branch_tokens, mode_id, len(layout.encoder_modes))
+    return keras.Model(encoder_input, selected_tokens, name="sonic_encoder")
+
+
+def build_sonic_decoder(layout):
+    decoder_input = build_input("obs_dict", compute_decoder_input_dim(layout))
+    decoder_features = compute_decoder_features(
+        decoder_input, layout.token_dim, compute_policy_tail_dim(layout))
+    args = (decoder_features, _DECODER_HIDDEN_DIMS, layout.action_dim,
+            "g1_dyn")
+    action = compute_dense_stack(*args)
+    return keras.Model(decoder_input, action, name="sonic_decoder")
+
+
+def build_input(name, dim):
+    return keras.Input(shape=(dim,), dtype="float32", name=name)
+
+
+def compute_mode_id(encoder_input, mode_index):
+    mode_id = encoder_input[:, mode_index]
+    return keras.ops.cast(mode_id, "int32")
+
+
+def compute_branch_tokens_list(encoder_input, layout):
+    branch_tokens = []
+    for mode_layout in layout.encoder_modes:
+        args = encoder_input, mode_layout, layout.token_dim
+        branch_tokens.append(compute_branch_tokens(*args))
+    return branch_tokens
+
+
+def compute_branch_tokens(encoder_input, mode_layout, token_dim):
+    mode_input = compute_mode_input(encoder_input, mode_layout)
+    args = mode_input, _ENCODER_HIDDEN_DIMS, token_dim, mode_layout.name
+    branch_latent = compute_dense_stack(*args)
+    return compute_release_fsq(branch_latent, _RELEASE_FSQ_ARGS)
+
+
+def compute_selected_tokens(branch_tokens, mode_id, num_modes):
+    stacked_tokens = keras.ops.stack(branch_tokens, axis=1)
+    mode_weights = keras.ops.one_hot(mode_id, num_modes)
+    mode_weights = keras.ops.cast(mode_weights, "float32")
+    mode_weights = keras.ops.expand_dims(mode_weights, axis=-1)
+    return keras.ops.sum(stacked_tokens * mode_weights, axis=1)
+
+
+def compute_decoder_features(decoder_input, token_dim, tail_dim):
+    token_state = decoder_input[:, :token_dim]
+    policy_tail = decoder_input[:, -tail_dim:]
+    return compute_cat(token_state, policy_tail)
+
+
+def compute_dense_stack(inputs, hidden_dims, output_dim, prefix):
+    x = inputs
+    layer_id = 0
+    for units in hidden_dims:
+        x = layers.Dense(units, name=f"{prefix}_module_{layer_id}")(x)
+        x = layers.Activation("swish", name=f"{prefix}_silu_{layer_id}")(x)
+        layer_id += 2
+    return layers.Dense(output_dim, name=f"{prefix}_module_{layer_id}")(x)
+
+
+def compute_mode_input(encoder_input, mode_layout):
+    if not mode_layout.feature_spans:
+        raise ValueError(f"Encoder mode {mode_layout.name} has no spans")
+    if mode_layout.temporal_frames is None:
+        return compute_flat_mode_input(encoder_input, mode_layout.feature_spans)
+    return compute_temporal_mode_input(encoder_input, mode_layout)
+
+
+def compute_flat_mode_input(encoder_input, spans):
+    parts = compute_parts(encoder_input, spans)
+    if len(parts) == 1:
+        return parts[0]
+    return keras.ops.concatenate(parts, axis=-1)
+
+
+def compute_temporal_mode_input(encoder_input, mode_layout):
+    temporal_parts = []
+    num_frames = mode_layout.temporal_frames
+    for group in compute_feature_groups(mode_layout):
+        args = encoder_input, group, num_frames
+        temporal_parts.append(compute_temporal_part(*args))
+    merged = keras.ops.concatenate(temporal_parts, axis=-1)
+    total_dim = compute_total_dim(mode_layout.feature_spans)
+    return keras.ops.reshape(merged, (-1, total_dim))
+
+
+def compute_feature_groups(mode_layout):
+    if mode_layout.feature_groups:
+        return mode_layout.feature_groups
+    return tuple((span,) for span in mode_layout.feature_spans)
+
+
+def compute_temporal_part(encoder_input, group, num_frames):
+    # Concatenates each span in the group before reshaping into frames, so a
+    # multi-span group (e.g. position+velocity) does not interleave per
+    # timestep. This matches the released model's own training-time layout
+    # exactly (verified against the release ONNX in sonic_test.py) even
+    # though it looks unintuitive; do not "fix" the ordering here.
+    merged_group = compute_flat_mode_input(encoder_input, group)
+    group_dim = compute_total_dim(group)
+    part_dim = group_dim // num_frames
+    return keras.ops.reshape(merged_group, (-1, num_frames, part_dim))
+
+
+def compute_parts(encoder_input, spans):
+    return [encoder_input[:, span.start:span.end] for span in spans]
+
+
+def compute_total_dim(spans):
+    return sum(span.dim for span in spans)
+
+
+def compute_cat(left, right):
+    return keras.ops.concatenate([left, right], axis=-1)
+
+
+def compute_release_fsq(inputs, fsq_args):
+    inputs = keras.ops.cast(inputs, "float32")
+    inputs = keras.ops.reshape(
+        inputs, (-1, fsq_args.num_tokens, fsq_args.token_dim))
+    inputs = keras.ops.tanh(inputs + fsq_args.offset) * fsq_args.scale
+    inputs = keras.ops.round(inputs - fsq_args.rounding_shift)
+    inputs = inputs / fsq_args.divisor
+    return keras.ops.reshape(
+        inputs, (-1, fsq_args.num_tokens * fsq_args.token_dim))
+
+
+def build_toy_layout():
+    # A small layout for tests: one flat mode, one temporal mode. token_dim
+    # must stay 64 (2 * 32) to satisfy _RELEASE_FSQ_ARGS' fixed reshape.
+    token_dim = 64
+    mode_span = ObservationSpan("encoder_mode_4", 0, 4, 4)
+    flat_span = ObservationSpan("motion_root_z_position", 4, 5, 1)
+    temporal_span = ObservationSpan(
+        "motion_anchor_orientation_10frame_step5", 5, 65, 60)
+    flat_mode = EncoderModeLayout(
+        "flat", 0, ("encoder_mode_4", "motion_root_z_position"),
+        (flat_span,))
+    temporal_mode = EncoderModeLayout(
+        "temporal", 1,
+        ("encoder_mode_4", "motion_anchor_orientation_10frame_step5"),
+        (temporal_span,), temporal_frames=10)
+    policy_spans = (
+        ObservationSpan("token_state", 0, token_dim, token_dim),
+        ObservationSpan("policy_tail", token_dim, token_dim + 6, 6),
+    )
+    encoder_spans = (mode_span, flat_span, temporal_span)
+    modes = (flat_mode, temporal_mode)
+    return SonicObservationLayout(policy_spans, encoder_spans, modes,
+                                   token_dim)

--- a/paz/models/foundation/sonic/model.py
+++ b/paz/models/foundation/sonic/model.py
@@ -13,15 +13,11 @@ from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import compute_mode_scalar_index
 from paz.models.foundation.sonic.layout import compute_policy_tail_dim
 
-_ENCODER_HIDDEN_DIMS = (2048, 1024, 512, 512)
-_DECODER_HIDDEN_DIMS = (2048, 2048, 1024, 1024, 512, 512)
-
 FSQArgs = namedtuple(
     "FSQArgs", "num_tokens token_dim offset scale rounding_shift divisor")
-_RELEASE_FSQ_ARGS = FSQArgs(2, 32, 0.032237, 15.515501, 0.5, 16.0)
 
 
-def build_sonic_actor(layout, encoder, decoder):
+def build_actor(layout, encoder, decoder):
     encoder_obs = build_input("encoder_obs", compute_encoder_input_dim(layout))
     policy_obs = build_input(
         "policy_obs_tail", compute_policy_tail_dim(layout))
@@ -32,7 +28,7 @@ def build_sonic_actor(layout, encoder, decoder):
     return keras.Model(inputs, action, name="sonic_actor")
 
 
-def build_sonic_encoder(layout):
+def build_encoder(layout):
     encoder_input = build_input("obs_dict", compute_encoder_input_dim(layout))
     mode_id = compute_mode_id(encoder_input, compute_mode_scalar_index(layout))
     branch_tokens = compute_branch_tokens_list(encoder_input, layout)
@@ -41,12 +37,12 @@ def build_sonic_encoder(layout):
     return keras.Model(encoder_input, selected_tokens, name="sonic_encoder")
 
 
-def build_sonic_decoder(layout):
+def build_decoder(layout):
     decoder_input = build_input("obs_dict", compute_decoder_input_dim(layout))
     decoder_features = compute_decoder_features(
         decoder_input, layout.token_dim, compute_policy_tail_dim(layout))
-    args = (decoder_features, _DECODER_HIDDEN_DIMS, layout.action_dim,
-            "g1_dyn")
+    hidden_dims = (2048, 2048, 1024, 1024, 512, 512)
+    args = (decoder_features, hidden_dims, layout.action_dim, "g1_dyn")
     action = compute_dense_stack(*args)
     return keras.Model(decoder_input, action, name="sonic_decoder")
 
@@ -70,9 +66,11 @@ def compute_branch_tokens_list(encoder_input, layout):
 
 def compute_branch_tokens(encoder_input, mode_layout, token_dim):
     mode_input = compute_mode_input(encoder_input, mode_layout)
-    args = mode_input, _ENCODER_HIDDEN_DIMS, token_dim, mode_layout.name
+    hidden_dims = (2048, 1024, 512, 512)
+    args = mode_input, hidden_dims, token_dim, mode_layout.name
     branch_latent = compute_dense_stack(*args)
-    return compute_release_fsq(branch_latent, _RELEASE_FSQ_ARGS)
+    fsq_args = FSQArgs(2, 32, 0.032237, 15.515501, 0.5, 16.0)
+    return compute_release_fsq(branch_latent, fsq_args)
 
 
 def compute_selected_tokens(branch_tokens, mode_id, num_modes):
@@ -91,12 +89,13 @@ def compute_decoder_features(decoder_input, token_dim, tail_dim):
 
 def compute_dense_stack(inputs, hidden_dims, output_dim, prefix):
     x = inputs
-    layer_id = 0
+    layer_index = 0
     for units in hidden_dims:
-        x = layers.Dense(units, name=f"{prefix}_module_{layer_id}")(x)
-        x = layers.Activation("swish", name=f"{prefix}_silu_{layer_id}")(x)
-        layer_id += 2
-    return layers.Dense(output_dim, name=f"{prefix}_module_{layer_id}")(x)
+        x = layers.Dense(units, name=f"{prefix}_module_{layer_index}")(x)
+        x = layers.Activation(
+            "swish", name=f"{prefix}_silu_{layer_index}")(x)
+        layer_index = layer_index + 2
+    return layers.Dense(output_dim, name=f"{prefix}_module_{layer_index}")(x)
 
 
 def compute_mode_input(encoder_input, mode_layout):
@@ -168,7 +167,7 @@ def compute_release_fsq(inputs, fsq_args):
 
 def build_toy_layout():
     # A small layout for tests: one flat mode, one temporal mode. token_dim
-    # must stay 64 (2 * 32) to satisfy _RELEASE_FSQ_ARGS' fixed reshape.
+    # must stay 64 (2 * 32) to satisfy compute_release_fsq's fixed reshape.
     token_dim = 64
     mode_span = ObservationSpan("encoder_mode_4", 0, 4, 4)
     flat_span = ObservationSpan("motion_root_z_position", 4, 5, 1)

--- a/paz/models/foundation/sonic/model.py
+++ b/paz/models/foundation/sonic/model.py
@@ -1,7 +1,5 @@
 """Keras architecture for the ported SONIC deploy actor."""
 
-from collections import namedtuple
-
 import keras
 from keras import layers
 
@@ -10,14 +8,14 @@ from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import compute_mode_scalar_index
 from paz.models.foundation.sonic.layout import compute_policy_tail_dim
 
-FSQArgs = namedtuple(
-    "FSQArgs", "num_tokens token_dim offset scale rounding_shift divisor")
-
 
 def build_actor(layout, encoder, decoder):
-    encoder_obs = build_input("encoder_obs", compute_encoder_input_dim(layout))
-    policy_obs = build_input(
-        "policy_obs_tail", compute_policy_tail_dim(layout))
+    encoder_dim = compute_encoder_input_dim(layout)
+    encoder_obs = keras.Input(
+        shape=(encoder_dim,), dtype="float32", name="encoder_obs")
+    tail_dim = compute_policy_tail_dim(layout)
+    policy_obs = keras.Input(
+        shape=(tail_dim,), dtype="float32", name="policy_obs_tail")
     encoded_tokens = encoder(encoder_obs)
     decoder_input = compute_cat(encoded_tokens, policy_obs)
     action = decoder(decoder_input)
@@ -26,7 +24,9 @@ def build_actor(layout, encoder, decoder):
 
 
 def build_encoder(layout):
-    encoder_input = build_input("obs_dict", compute_encoder_input_dim(layout))
+    encoder_dim = compute_encoder_input_dim(layout)
+    encoder_input = keras.Input(
+        shape=(encoder_dim,), dtype="float32", name="obs_dict")
     mode_id = compute_mode_id(encoder_input, compute_mode_scalar_index(layout))
     branch_tokens = compute_branch_tokens_list(encoder_input, layout)
     selected_tokens = compute_selected_tokens(
@@ -35,17 +35,15 @@ def build_encoder(layout):
 
 
 def build_decoder(layout):
-    decoder_input = build_input("obs_dict", compute_decoder_input_dim(layout))
+    decoder_dim = compute_decoder_input_dim(layout)
+    decoder_input = keras.Input(
+        shape=(decoder_dim,), dtype="float32", name="obs_dict")
     decoder_features = compute_decoder_features(
         decoder_input, layout.token_dim, compute_policy_tail_dim(layout))
     hidden_dims = (2048, 2048, 1024, 1024, 512, 512)
     args = (decoder_features, hidden_dims, layout.action_dim, "g1_dyn")
     action = compute_dense_stack(*args)
     return keras.Model(decoder_input, action, name="sonic_decoder")
-
-
-def build_input(name, dim):
-    return keras.Input(shape=(dim,), dtype="float32", name=name)
 
 
 def compute_mode_id(encoder_input, mode_index):
@@ -66,8 +64,8 @@ def compute_branch_tokens(encoder_input, mode_layout, token_dim):
     hidden_dims = (2048, 1024, 512, 512)
     args = mode_input, hidden_dims, token_dim, mode_layout.name
     branch_latent = compute_dense_stack(*args)
-    fsq_args = FSQArgs(2, 32, 0.032237, 15.515501, 0.5, 16.0)
-    return compute_release_fsq(branch_latent, fsq_args)
+    return compute_release_fsq(
+        branch_latent, 2, 32, 0.032237, 15.515501, 0.5, 16.0)
 
 
 def compute_selected_tokens(branch_tokens, mode_id, num_modes):
@@ -99,15 +97,20 @@ def compute_mode_input(encoder_input, mode_layout):
     if not mode_layout.feature_spans:
         raise ValueError(f"Encoder mode {mode_layout.name} has no spans")
     if mode_layout.temporal_frames is None:
-        return compute_flat_mode_input(encoder_input, mode_layout.feature_spans)
-    return compute_temporal_mode_input(encoder_input, mode_layout)
+        mode_input = compute_flat_mode_input(
+            encoder_input, mode_layout.feature_spans)
+    else:
+        mode_input = compute_temporal_mode_input(encoder_input, mode_layout)
+    return mode_input
 
 
 def compute_flat_mode_input(encoder_input, spans):
     parts = compute_parts(encoder_input, spans)
     if len(parts) == 1:
-        return parts[0]
-    return keras.ops.concatenate(parts, axis=-1)
+        flat_input = parts[0]
+    else:
+        flat_input = keras.ops.concatenate(parts, axis=-1)
+    return flat_input
 
 
 def compute_temporal_mode_input(encoder_input, mode_layout):
@@ -123,8 +126,10 @@ def compute_temporal_mode_input(encoder_input, mode_layout):
 
 def compute_feature_groups(mode_layout):
     if mode_layout.feature_groups:
-        return mode_layout.feature_groups
-    return tuple((span,) for span in mode_layout.feature_spans)
+        feature_groups = mode_layout.feature_groups
+    else:
+        feature_groups = tuple((span,) for span in mode_layout.feature_spans)
+    return feature_groups
 
 
 def compute_temporal_part(encoder_input, group, num_frames):
@@ -151,12 +156,14 @@ def compute_cat(left, right):
     return keras.ops.concatenate([left, right], axis=-1)
 
 
-def compute_release_fsq(inputs, fsq_args):
+def compute_release_fsq(
+        inputs, num_tokens, token_dim, offset, scale, rounding_shift,
+        divisor):
     inputs = keras.ops.cast(inputs, "float32")
-    token_shape = (-1, fsq_args.num_tokens, fsq_args.token_dim)
+    token_shape = (-1, num_tokens, token_dim)
     inputs = keras.ops.reshape(inputs, token_shape)
-    inputs = keras.ops.tanh(inputs + fsq_args.offset) * fsq_args.scale
-    inputs = keras.ops.round(inputs - fsq_args.rounding_shift)
-    inputs = inputs / fsq_args.divisor
-    flat_shape = (-1, fsq_args.num_tokens * fsq_args.token_dim)
+    inputs = keras.ops.tanh(inputs + offset) * scale
+    inputs = keras.ops.round(inputs - rounding_shift)
+    inputs = inputs / divisor
+    flat_shape = (-1, num_tokens * token_dim)
     return keras.ops.reshape(inputs, flat_shape)

--- a/paz/models/foundation/sonic/model.py
+++ b/paz/models/foundation/sonic/model.py
@@ -5,9 +5,6 @@ from collections import namedtuple
 import keras
 from keras import layers
 
-from paz.models.foundation.sonic.layout import EncoderModeLayout
-from paz.models.foundation.sonic.layout import ObservationSpan
-from paz.models.foundation.sonic.layout import SonicObservationLayout
 from paz.models.foundation.sonic.layout import compute_decoder_input_dim
 from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import compute_mode_scalar_index
@@ -156,35 +153,10 @@ def compute_cat(left, right):
 
 def compute_release_fsq(inputs, fsq_args):
     inputs = keras.ops.cast(inputs, "float32")
-    inputs = keras.ops.reshape(
-        inputs, (-1, fsq_args.num_tokens, fsq_args.token_dim))
+    token_shape = (-1, fsq_args.num_tokens, fsq_args.token_dim)
+    inputs = keras.ops.reshape(inputs, token_shape)
     inputs = keras.ops.tanh(inputs + fsq_args.offset) * fsq_args.scale
     inputs = keras.ops.round(inputs - fsq_args.rounding_shift)
     inputs = inputs / fsq_args.divisor
-    return keras.ops.reshape(
-        inputs, (-1, fsq_args.num_tokens * fsq_args.token_dim))
-
-
-def build_toy_layout():
-    # A small layout for tests: one flat mode, one temporal mode. token_dim
-    # must stay 64 (2 * 32) to satisfy compute_release_fsq's fixed reshape.
-    token_dim = 64
-    mode_span = ObservationSpan("encoder_mode_4", 0, 4, 4)
-    flat_span = ObservationSpan("motion_root_z_position", 4, 5, 1)
-    temporal_span = ObservationSpan(
-        "motion_anchor_orientation_10frame_step5", 5, 65, 60)
-    flat_mode = EncoderModeLayout(
-        "flat", 0, ("encoder_mode_4", "motion_root_z_position"),
-        (flat_span,))
-    temporal_mode = EncoderModeLayout(
-        "temporal", 1,
-        ("encoder_mode_4", "motion_anchor_orientation_10frame_step5"),
-        (temporal_span,), temporal_frames=10)
-    policy_spans = (
-        ObservationSpan("token_state", 0, token_dim, token_dim),
-        ObservationSpan("policy_tail", token_dim, token_dim + 6, 6),
-    )
-    encoder_spans = (mode_span, flat_span, temporal_span)
-    modes = (flat_mode, temporal_mode)
-    return SonicObservationLayout(policy_spans, encoder_spans, modes,
-                                   token_dim)
+    flat_shape = (-1, fsq_args.num_tokens * fsq_args.token_dim)
+    return keras.ops.reshape(inputs, flat_shape)

--- a/paz/models/foundation/sonic/model.py
+++ b/paz/models/foundation/sonic/model.py
@@ -11,11 +11,9 @@ from paz.models.foundation.sonic.layout import compute_policy_tail_dim
 
 def build_actor(layout, encoder, decoder):
     encoder_dim = compute_encoder_input_dim(layout)
-    encoder_obs = keras.Input(
-        shape=(encoder_dim,), dtype="float32", name="encoder_obs")
+    encoder_obs = keras.Input((encoder_dim,), name="encoder_obs")
     tail_dim = compute_policy_tail_dim(layout)
-    policy_obs = keras.Input(
-        shape=(tail_dim,), dtype="float32", name="policy_obs_tail")
+    policy_obs = keras.Input((tail_dim,), name="policy_obs_tail")
     encoded_tokens = encoder(encoder_obs)
     decoder_input = compute_cat(encoded_tokens, policy_obs)
     action = decoder(decoder_input)
@@ -25,23 +23,23 @@ def build_actor(layout, encoder, decoder):
 
 def build_encoder(layout):
     encoder_dim = compute_encoder_input_dim(layout)
-    encoder_input = keras.Input(
-        shape=(encoder_dim,), dtype="float32", name="obs_dict")
-    mode_id = compute_mode_id(encoder_input, compute_mode_scalar_index(layout))
+    encoder_input = keras.Input((encoder_dim,), name="obs_dict")
+    mode_index = compute_mode_scalar_index(layout)
+    mode_id = compute_mode_id(encoder_input, mode_index)
     branch_tokens = compute_branch_tokens_list(encoder_input, layout)
-    selected_tokens = compute_selected_tokens(
-        branch_tokens, mode_id, len(layout.encoder_modes))
+    args = branch_tokens, mode_id, len(layout.encoder_modes)
+    selected_tokens = compute_selected_tokens(*args)
     return keras.Model(encoder_input, selected_tokens, name="sonic_encoder")
 
 
 def build_decoder(layout):
     decoder_dim = compute_decoder_input_dim(layout)
-    decoder_input = keras.Input(
-        shape=(decoder_dim,), dtype="float32", name="obs_dict")
-    decoder_features = compute_decoder_features(
-        decoder_input, layout.token_dim, compute_policy_tail_dim(layout))
+    decoder_input = keras.Input((decoder_dim,), name="obs_dict")
+    tail_dim = compute_policy_tail_dim(layout)
+    token_dim = layout.token_dim
+    features = compute_decoder_features(decoder_input, token_dim, tail_dim)
     hidden_dims = (2048, 2048, 1024, 1024, 512, 512)
-    args = (decoder_features, hidden_dims, layout.action_dim, "g1_dyn")
+    args = (features, hidden_dims, layout.action_dim, "g1_dyn")
     action = compute_dense_stack(*args)
     return keras.Model(decoder_input, action, name="sonic_decoder")
 
@@ -64,8 +62,8 @@ def compute_branch_tokens(encoder_input, mode_layout, token_dim):
     hidden_dims = (2048, 1024, 512, 512)
     args = mode_input, hidden_dims, token_dim, mode_layout.name
     branch_latent = compute_dense_stack(*args)
-    return compute_release_fsq(
-        branch_latent, 2, 32, 0.032237, 15.515501, 0.5, 16.0)
+    fsq_args = branch_latent, 2, 32, 0.032237, 15.515501, 0.5, 16.0
+    return compute_release_fsq(*fsq_args)
 
 
 def compute_selected_tokens(branch_tokens, mode_id, num_modes):
@@ -83,12 +81,10 @@ def compute_decoder_features(decoder_input, token_dim, tail_dim):
 
 
 def compute_dense_stack(inputs, hidden_dims, output_dim, prefix):
-    x = inputs
-    layer_index = 0
+    x, layer_index = inputs, 0
     for units in hidden_dims:
         x = layers.Dense(units, name=f"{prefix}_module_{layer_index}")(x)
-        x = layers.Activation(
-            "swish", name=f"{prefix}_silu_{layer_index}")(x)
+        x = layers.Activation("swish", name=f"{prefix}_silu_{layer_index}")(x)
         layer_index = layer_index + 2
     return layers.Dense(output_dim, name=f"{prefix}_module_{layer_index}")(x)
 
@@ -97,8 +93,8 @@ def compute_mode_input(encoder_input, mode_layout):
     if not mode_layout.feature_spans:
         raise ValueError(f"Encoder mode {mode_layout.name} has no spans")
     if mode_layout.temporal_frames is None:
-        mode_input = compute_flat_mode_input(
-            encoder_input, mode_layout.feature_spans)
+        spans = mode_layout.feature_spans
+        mode_input = compute_flat_mode_input(encoder_input, spans)
     else:
         mode_input = compute_temporal_mode_input(encoder_input, mode_layout)
     return mode_input

--- a/paz/models/foundation/sonic/model_test.py
+++ b/paz/models/foundation/sonic/model_test.py
@@ -5,9 +5,9 @@ from paz.models.foundation.sonic.layout import compute_decoder_input_dim
 from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import compute_policy_tail_dim
 from paz.models.foundation.sonic.model import FSQArgs
-from paz.models.foundation.sonic.model import build_sonic_actor
-from paz.models.foundation.sonic.model import build_sonic_decoder
-from paz.models.foundation.sonic.model import build_sonic_encoder
+from paz.models.foundation.sonic.model import build_actor
+from paz.models.foundation.sonic.model import build_decoder
+from paz.models.foundation.sonic.model import build_encoder
 from paz.models.foundation.sonic.model import build_toy_layout
 from paz.models.foundation.sonic.model import compute_release_fsq
 from paz.models.foundation.sonic.model import compute_temporal_part
@@ -15,7 +15,7 @@ from paz.models.foundation.sonic.model import compute_temporal_part
 
 def test_encoder_output_shape_matches_token_dim():
     layout = build_toy_layout()
-    encoder = build_sonic_encoder(layout)
+    encoder = build_encoder(layout)
     x = np.zeros((1, compute_encoder_input_dim(layout)), dtype="float32")
     tokens = np.array(encoder(x, training=False))
     assert tokens.shape == (1, layout.token_dim)
@@ -23,7 +23,7 @@ def test_encoder_output_shape_matches_token_dim():
 
 def test_decoder_output_shape_matches_action_dim():
     layout = build_toy_layout()
-    decoder = build_sonic_decoder(layout)
+    decoder = build_decoder(layout)
     x = np.zeros((1, compute_decoder_input_dim(layout)), dtype="float32")
     action = np.array(decoder(x, training=False))
     assert action.shape == (1, layout.action_dim)
@@ -31,9 +31,9 @@ def test_decoder_output_shape_matches_action_dim():
 
 def test_actor_composes_encoder_and_decoder():
     layout = build_toy_layout()
-    encoder = build_sonic_encoder(layout)
-    decoder = build_sonic_decoder(layout)
-    actor = build_sonic_actor(layout, encoder, decoder)
+    encoder = build_encoder(layout)
+    decoder = build_decoder(layout)
+    actor = build_actor(layout, encoder, decoder)
     inputs = {
         "encoder_obs": np.zeros(
             (1, compute_encoder_input_dim(layout)), dtype="float32"),
@@ -46,7 +46,7 @@ def test_actor_composes_encoder_and_decoder():
 
 def test_mode_routing_selects_matching_branch():
     layout = build_toy_layout()
-    encoder = build_sonic_encoder(layout)
+    encoder = build_encoder(layout)
     x_flat = np.random.default_rng(0).normal(
         size=(1, compute_encoder_input_dim(layout))).astype("float32")
     x_temporal = x_flat.copy()

--- a/paz/models/foundation/sonic/model_test.py
+++ b/paz/models/foundation/sonic/model_test.py
@@ -4,7 +4,6 @@ from paz.models.foundation.sonic.layout import ObservationSpan
 from paz.models.foundation.sonic.layout import compute_decoder_input_dim
 from paz.models.foundation.sonic.layout import compute_encoder_input_dim
 from paz.models.foundation.sonic.layout import compute_policy_tail_dim
-from paz.models.foundation.sonic.model import FSQArgs
 from paz.models.foundation.sonic.model import build_actor
 from paz.models.foundation.sonic.model import build_decoder
 from paz.models.foundation.sonic.model import build_encoder
@@ -54,8 +53,8 @@ def test_mode_routing_selects_matching_branch(toy_layout):
 
 def test_fsq_output_lies_on_quantization_grid():
     inputs = np.random.default_rng(1).normal(size=(2, 8)).astype("float32")
-    fsq_args = FSQArgs(2, 4, 0.032237, 15.515501, 0.5, 16.0)
-    output = np.array(compute_release_fsq(inputs, fsq_args))
+    output = np.array(
+        compute_release_fsq(inputs, 2, 4, 0.032237, 15.515501, 0.5, 16.0))
     scaled = output * 16.0
     assert np.allclose(scaled, np.round(scaled))
 

--- a/paz/models/foundation/sonic/model_test.py
+++ b/paz/models/foundation/sonic/model_test.py
@@ -8,47 +8,42 @@ from paz.models.foundation.sonic.model import FSQArgs
 from paz.models.foundation.sonic.model import build_actor
 from paz.models.foundation.sonic.model import build_decoder
 from paz.models.foundation.sonic.model import build_encoder
-from paz.models.foundation.sonic.model import build_toy_layout
 from paz.models.foundation.sonic.model import compute_release_fsq
 from paz.models.foundation.sonic.model import compute_temporal_part
 
 
-def test_encoder_output_shape_matches_token_dim():
-    layout = build_toy_layout()
-    encoder = build_encoder(layout)
-    x = np.zeros((1, compute_encoder_input_dim(layout)), dtype="float32")
+def test_encoder_output_shape_matches_token_dim(toy_layout):
+    encoder = build_encoder(toy_layout)
+    x = np.zeros((1, compute_encoder_input_dim(toy_layout)), dtype="float32")
     tokens = np.array(encoder(x, training=False))
-    assert tokens.shape == (1, layout.token_dim)
+    assert tokens.shape == (1, toy_layout.token_dim)
 
 
-def test_decoder_output_shape_matches_action_dim():
-    layout = build_toy_layout()
-    decoder = build_decoder(layout)
-    x = np.zeros((1, compute_decoder_input_dim(layout)), dtype="float32")
+def test_decoder_output_shape_matches_action_dim(toy_layout):
+    decoder = build_decoder(toy_layout)
+    x = np.zeros((1, compute_decoder_input_dim(toy_layout)), dtype="float32")
     action = np.array(decoder(x, training=False))
-    assert action.shape == (1, layout.action_dim)
+    assert action.shape == (1, toy_layout.action_dim)
 
 
-def test_actor_composes_encoder_and_decoder():
-    layout = build_toy_layout()
-    encoder = build_encoder(layout)
-    decoder = build_decoder(layout)
-    actor = build_actor(layout, encoder, decoder)
+def test_actor_composes_encoder_and_decoder(toy_layout):
+    encoder = build_encoder(toy_layout)
+    decoder = build_decoder(toy_layout)
+    actor = build_actor(toy_layout, encoder, decoder)
     inputs = {
         "encoder_obs": np.zeros(
-            (1, compute_encoder_input_dim(layout)), dtype="float32"),
+            (1, compute_encoder_input_dim(toy_layout)), dtype="float32"),
         "policy_obs_tail": np.zeros(
-            (1, compute_policy_tail_dim(layout)), dtype="float32"),
+            (1, compute_policy_tail_dim(toy_layout)), dtype="float32"),
     }
     action = np.array(actor(inputs, training=False))
-    assert action.shape == (1, layout.action_dim)
+    assert action.shape == (1, toy_layout.action_dim)
 
 
-def test_mode_routing_selects_matching_branch():
-    layout = build_toy_layout()
-    encoder = build_encoder(layout)
+def test_mode_routing_selects_matching_branch(toy_layout):
+    encoder = build_encoder(toy_layout)
     x_flat = np.random.default_rng(0).normal(
-        size=(1, compute_encoder_input_dim(layout))).astype("float32")
+        size=(1, compute_encoder_input_dim(toy_layout))).astype("float32")
     x_temporal = x_flat.copy()
     x_flat[0, 0] = 0
     x_temporal[0, 0] = 1
@@ -73,6 +68,7 @@ def test_temporal_part_concatenates_before_reshaping():
     span_a = ObservationSpan("a", 0, 4, 4)
     span_b = ObservationSpan("b", 4, 8, 4)
     encoder_input = np.array([[1, 2, 3, 4, 10, 20, 30, 40]], dtype="float32")
-    output = np.array(compute_temporal_part(encoder_input, (span_a, span_b), 2))
+    output = np.array(
+        compute_temporal_part(encoder_input, (span_a, span_b), 2))
     expected = np.array([[[1, 2, 3, 4], [10, 20, 30, 40]]], dtype="float32")
     assert np.array_equal(output, expected)

--- a/paz/models/foundation/sonic/model_test.py
+++ b/paz/models/foundation/sonic/model_test.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+from paz.models.foundation.sonic.layout import ObservationSpan
+from paz.models.foundation.sonic.layout import compute_decoder_input_dim
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.layout import compute_policy_tail_dim
+from paz.models.foundation.sonic.model import FSQArgs
+from paz.models.foundation.sonic.model import build_sonic_actor
+from paz.models.foundation.sonic.model import build_sonic_decoder
+from paz.models.foundation.sonic.model import build_sonic_encoder
+from paz.models.foundation.sonic.model import build_toy_layout
+from paz.models.foundation.sonic.model import compute_release_fsq
+from paz.models.foundation.sonic.model import compute_temporal_part
+
+
+def test_encoder_output_shape_matches_token_dim():
+    layout = build_toy_layout()
+    encoder = build_sonic_encoder(layout)
+    x = np.zeros((1, compute_encoder_input_dim(layout)), dtype="float32")
+    tokens = np.array(encoder(x, training=False))
+    assert tokens.shape == (1, layout.token_dim)
+
+
+def test_decoder_output_shape_matches_action_dim():
+    layout = build_toy_layout()
+    decoder = build_sonic_decoder(layout)
+    x = np.zeros((1, compute_decoder_input_dim(layout)), dtype="float32")
+    action = np.array(decoder(x, training=False))
+    assert action.shape == (1, layout.action_dim)
+
+
+def test_actor_composes_encoder_and_decoder():
+    layout = build_toy_layout()
+    encoder = build_sonic_encoder(layout)
+    decoder = build_sonic_decoder(layout)
+    actor = build_sonic_actor(layout, encoder, decoder)
+    inputs = {
+        "encoder_obs": np.zeros(
+            (1, compute_encoder_input_dim(layout)), dtype="float32"),
+        "policy_obs_tail": np.zeros(
+            (1, compute_policy_tail_dim(layout)), dtype="float32"),
+    }
+    action = np.array(actor(inputs, training=False))
+    assert action.shape == (1, layout.action_dim)
+
+
+def test_mode_routing_selects_matching_branch():
+    layout = build_toy_layout()
+    encoder = build_sonic_encoder(layout)
+    x_flat = np.random.default_rng(0).normal(
+        size=(1, compute_encoder_input_dim(layout))).astype("float32")
+    x_temporal = x_flat.copy()
+    x_flat[0, 0] = 0
+    x_temporal[0, 0] = 1
+    tokens_flat = np.array(encoder(x_flat, training=False))
+    tokens_temporal = np.array(encoder(x_temporal, training=False))
+    assert not np.allclose(tokens_flat, tokens_temporal)
+
+
+def test_fsq_output_lies_on_quantization_grid():
+    inputs = np.random.default_rng(1).normal(size=(2, 8)).astype("float32")
+    fsq_args = FSQArgs(2, 4, 0.032237, 15.515501, 0.5, 16.0)
+    output = np.array(compute_release_fsq(inputs, fsq_args))
+    scaled = output * 16.0
+    assert np.allclose(scaled, np.round(scaled))
+
+
+def test_temporal_part_concatenates_before_reshaping():
+    # Pins compute_temporal_part's concatenate-then-reshape order for a
+    # multi-span group: each span's values stay contiguous across frames
+    # rather than interleaving per timestep. Matches the released model's
+    # training-time layout (e.g. the real "g1" position+velocity group).
+    span_a = ObservationSpan("a", 0, 4, 4)
+    span_b = ObservationSpan("b", 4, 8, 4)
+    encoder_input = np.array([[1, 2, 3, 4, 10, 20, 30, 40]], dtype="float32")
+    output = np.array(compute_temporal_part(encoder_input, (span_a, span_b), 2))
+    expected = np.array([[[1, 2, 3, 4], [10, 20, 30, 40]]], dtype="float32")
+    assert np.array_equal(output, expected)

--- a/paz/models/foundation/sonic/pretrained.py
+++ b/paz/models/foundation/sonic/pretrained.py
@@ -1,0 +1,47 @@
+"""Download and build the pretrained SONIC deploy actor.
+
+The v0.27 release assets are not uploaded yet: run
+paz.models.foundation.sonic.conversion against a real release directory
+(see conversion.py's main()) to produce them, then publish that output
+directory's contents to SONIC_ASSETS_URL before Sonic(weights="pretrained")
+can succeed.
+"""
+
+from collections import namedtuple
+
+from keras.utils import get_file
+
+from paz.models.foundation.sonic.layout import load_release_observation_layout
+from paz.models.foundation.sonic.model import build_sonic_actor
+from paz.models.foundation.sonic.model import build_sonic_decoder
+from paz.models.foundation.sonic.model import build_sonic_encoder
+
+SONIC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.27/"  # fmt: skip
+SONIC_CACHE_SUBDIR = "paz/models/sonic"
+
+SonicModels = namedtuple("Sonic", "layout encoder decoder actor")
+
+
+def Sonic(weights="pretrained"):
+    layout = build_layout()
+    encoder = build_sonic_encoder(layout)
+    decoder = build_sonic_decoder(layout)
+    actor = build_sonic_actor(layout, encoder, decoder)
+    if weights == "pretrained":
+        load_pretrained_weights(encoder, decoder)
+    return SonicModels(layout, encoder, decoder, actor)
+
+
+def build_layout():
+    obs_config = fetch_sonic_asset("observation_config.yaml")
+    return load_release_observation_layout(obs_config)
+
+
+def load_pretrained_weights(encoder, decoder):
+    encoder.load_weights(fetch_sonic_asset("sonic_encoder.weights.h5"))
+    decoder.load_weights(fetch_sonic_asset("sonic_decoder.weights.h5"))
+
+
+def fetch_sonic_asset(filename):
+    return get_file(filename, SONIC_ASSETS_URL + filename,
+                     cache_subdir=SONIC_CACHE_SUBDIR)

--- a/paz/models/foundation/sonic/pretrained.py
+++ b/paz/models/foundation/sonic/pretrained.py
@@ -1,6 +1,6 @@
 """Download and build the pretrained SONIC deploy actor.
 
-The v0.27 release assets are not uploaded yet: run
+The v0.27 weight assets are not uploaded yet: run
 paz.models.foundation.sonic.conversion against a real release directory
 (see conversion.py's main()) to produce them, then publish that output
 directory's contents to SONIC_ASSETS_URL before SONIC(weights="pretrained")
@@ -11,7 +11,7 @@ from collections import namedtuple
 
 from keras.utils import get_file
 
-from paz.models.foundation.sonic.layout import load_release_observation_layout
+from paz.models.foundation.sonic.layout import build_observation_layout
 from paz.models.foundation.sonic.model import build_actor
 from paz.models.foundation.sonic.model import build_decoder
 from paz.models.foundation.sonic.model import build_encoder
@@ -21,20 +21,90 @@ SONIC_CACHE_SUBDIR = "paz/models/sonic"
 
 SonicModels = namedtuple("SonicModels", "layout encoder decoder actor")
 
+# The released observation contract (encoder branches, history spans, and
+# their fixed dimensions). Small and release-specific, so it ships as a
+# literal here instead of a separately downloaded/parsed YAML file.
+RELEASE_OBSERVATION_CONFIG = {
+    "observations": (
+        {"name": "token_state", "enabled": True},
+        {"name": "his_base_angular_velocity_10frame_step1", "enabled": True},
+        {"name": "his_body_joint_positions_10frame_step1", "enabled": True},
+        {"name": "his_body_joint_velocities_10frame_step1", "enabled": True},
+        {"name": "his_last_actions_10frame_step1", "enabled": True},
+        {"name": "his_gravity_dir_10frame_step1", "enabled": True},
+    ),
+    "encoder": {
+        "dimension": 64,
+        "encoder_observations": (
+            {"name": "encoder_mode_4", "enabled": True},
+            {"name": "motion_joint_positions_10frame_step5",
+             "enabled": True},
+            {"name": "motion_joint_velocities_10frame_step5",
+             "enabled": True},
+            {"name": "motion_root_z_position_10frame_step5",
+             "enabled": True},
+            {"name": "motion_root_z_position", "enabled": True},
+            {"name": "motion_anchor_orientation", "enabled": True},
+            {"name": "motion_anchor_orientation_10frame_step5",
+             "enabled": True},
+            {"name": "motion_joint_positions_lowerbody_10frame_step5",
+             "enabled": True},
+            {"name": "motion_joint_velocities_lowerbody_10frame_step5",
+             "enabled": True},
+            {"name": "vr_3point_local_target", "enabled": True},
+            {"name": "vr_3point_local_orn_target", "enabled": True},
+            {"name": "smpl_joints_10frame_step1", "enabled": True},
+            {"name": "smpl_anchor_orientation_10frame_step1",
+             "enabled": True},
+            {"name": "motion_joint_positions_wrists_10frame_step1",
+             "enabled": True},
+        ),
+        "encoder_modes": (
+            {
+                "name": "g1",
+                "mode_id": 0,
+                "required_observations": (
+                    "encoder_mode_4",
+                    "motion_joint_positions_10frame_step5",
+                    "motion_joint_velocities_10frame_step5",
+                    "motion_anchor_orientation_10frame_step5",
+                ),
+            },
+            {
+                "name": "teleop",
+                "mode_id": 1,
+                "required_observations": (
+                    "encoder_mode_4",
+                    "motion_joint_positions_lowerbody_10frame_step5",
+                    "motion_joint_velocities_lowerbody_10frame_step5",
+                    "vr_3point_local_target",
+                    "vr_3point_local_orn_target",
+                    "motion_anchor_orientation",
+                ),
+            },
+            {
+                "name": "smpl",
+                "mode_id": 2,
+                "required_observations": (
+                    "encoder_mode_4",
+                    "smpl_joints_10frame_step1",
+                    "smpl_anchor_orientation_10frame_step1",
+                    "motion_joint_positions_wrists_10frame_step1",
+                ),
+            },
+        ),
+    },
+}
+
 
 def SONIC(weights="pretrained"):
-    layout = build_layout()
+    layout = build_observation_layout(RELEASE_OBSERVATION_CONFIG)
     encoder = build_encoder(layout)
     decoder = build_decoder(layout)
     actor = build_actor(layout, encoder, decoder)
     if weights == "pretrained":
         load_pretrained_weights(encoder, decoder)
     return SonicModels(layout, encoder, decoder, actor)
-
-
-def build_layout():
-    obs_config = fetch_asset("observation_config.yaml")
-    return load_release_observation_layout(obs_config)
 
 
 def load_pretrained_weights(encoder, decoder):

--- a/paz/models/foundation/sonic/pretrained.py
+++ b/paz/models/foundation/sonic/pretrained.py
@@ -3,7 +3,7 @@
 The v0.27 release assets are not uploaded yet: run
 paz.models.foundation.sonic.conversion against a real release directory
 (see conversion.py's main()) to produce them, then publish that output
-directory's contents to SONIC_ASSETS_URL before Sonic(weights="pretrained")
+directory's contents to SONIC_ASSETS_URL before SONIC(weights="pretrained")
 can succeed.
 """
 
@@ -12,36 +12,36 @@ from collections import namedtuple
 from keras.utils import get_file
 
 from paz.models.foundation.sonic.layout import load_release_observation_layout
-from paz.models.foundation.sonic.model import build_sonic_actor
-from paz.models.foundation.sonic.model import build_sonic_decoder
-from paz.models.foundation.sonic.model import build_sonic_encoder
+from paz.models.foundation.sonic.model import build_actor
+from paz.models.foundation.sonic.model import build_decoder
+from paz.models.foundation.sonic.model import build_encoder
 
 SONIC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.27/"  # fmt: skip
 SONIC_CACHE_SUBDIR = "paz/models/sonic"
 
-SonicModels = namedtuple("Sonic", "layout encoder decoder actor")
+SonicModels = namedtuple("SonicModels", "layout encoder decoder actor")
 
 
-def Sonic(weights="pretrained"):
+def SONIC(weights="pretrained"):
     layout = build_layout()
-    encoder = build_sonic_encoder(layout)
-    decoder = build_sonic_decoder(layout)
-    actor = build_sonic_actor(layout, encoder, decoder)
+    encoder = build_encoder(layout)
+    decoder = build_decoder(layout)
+    actor = build_actor(layout, encoder, decoder)
     if weights == "pretrained":
         load_pretrained_weights(encoder, decoder)
     return SonicModels(layout, encoder, decoder, actor)
 
 
 def build_layout():
-    obs_config = fetch_sonic_asset("observation_config.yaml")
+    obs_config = fetch_asset("observation_config.yaml")
     return load_release_observation_layout(obs_config)
 
 
 def load_pretrained_weights(encoder, decoder):
-    encoder.load_weights(fetch_sonic_asset("sonic_encoder.weights.h5"))
-    decoder.load_weights(fetch_sonic_asset("sonic_decoder.weights.h5"))
+    encoder.load_weights(fetch_asset("sonic_encoder.weights.h5"))
+    decoder.load_weights(fetch_asset("sonic_decoder.weights.h5"))
 
 
-def fetch_sonic_asset(filename):
+def fetch_asset(filename):
     return get_file(filename, SONIC_ASSETS_URL + filename,
                      cache_subdir=SONIC_CACHE_SUBDIR)

--- a/paz/models/foundation/sonic/pretrained.py
+++ b/paz/models/foundation/sonic/pretrained.py
@@ -1,10 +1,10 @@
 """Download and build the pretrained SONIC deploy actor.
 
-The v0.27 weight assets are not uploaded yet: run
-paz.models.foundation.sonic.conversion against a real release directory
-(see conversion.py's main()) to produce them, then publish that output
-directory's contents to SONIC_ASSETS_URL before SONIC(weights="pretrained")
-can succeed.
+Weights are Model Derivatives licensed by NVIDIA Corporation under the
+NVIDIA Open Model License (see the release's sonic_LICENSE.txt /
+sonic_NOTICE.txt at SONIC_ASSETS_URL). By calling SONIC(weights=
+"pretrained") you agree to that Agreement and to NVIDIA's Trustworthy AI
+terms (https://www.nvidia.com/en-us/agreements/trustworthy-ai/terms/).
 """
 
 from collections import namedtuple
@@ -16,7 +16,7 @@ from paz.models.foundation.sonic.model import build_actor
 from paz.models.foundation.sonic.model import build_decoder
 from paz.models.foundation.sonic.model import build_encoder
 
-SONIC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.27/"  # fmt: skip
+SONIC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.28/"  # fmt: skip
 SONIC_CACHE_SUBDIR = "paz/models/sonic"
 
 SonicModels = namedtuple("SonicModels", "layout encoder decoder actor")

--- a/paz/models/foundation/sonic/pretrained.py
+++ b/paz/models/foundation/sonic/pretrained.py
@@ -113,5 +113,5 @@ def load_pretrained_weights(encoder, decoder):
 
 
 def fetch_asset(filename):
-    return get_file(filename, SONIC_ASSETS_URL + filename,
-                     cache_subdir=SONIC_CACHE_SUBDIR)
+    url = SONIC_ASSETS_URL + filename
+    return get_file(filename, url, cache_subdir=SONIC_CACHE_SUBDIR)

--- a/paz/models/foundation/sonic/pretrained_test.py
+++ b/paz/models/foundation/sonic/pretrained_test.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from paz.models.foundation.sonic.layout import compute_encoder_input_dim
+from paz.models.foundation.sonic.pretrained import SONIC
+
+
+def test_pretrained_sonic_downloads_and_runs():
+    sonic = SONIC(weights="pretrained")
+    layout = sonic.layout
+    x = np.zeros((1, compute_encoder_input_dim(layout)), dtype="float32")
+    tokens = np.array(sonic.encoder(x, training=False))
+    assert tokens.shape == (1, layout.token_dim)
+    assert np.isfinite(tokens).all()

--- a/paz/models/foundation/sonic/sonic_test.py
+++ b/paz/models/foundation/sonic/sonic_test.py
@@ -1,0 +1,68 @@
+"""Opt-in numeric parity check against the real released SONIC weights.
+
+Skipped unless SONIC_RELEASE_DIR points at a gear_sonic_deploy release
+directory containing observation_config.yaml, model_encoder.onnx and
+model_decoder.onnx (see the SONIC Keras port handoff for that layout).
+"""
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ort = pytest.importorskip("onnxruntime")
+
+from paz.models.foundation.sonic.conversion import port_sonic_weights
+from paz.models.foundation.sonic.layout import compute_mode_scalar_index
+from paz.models.foundation.sonic.layout import load_release_observation_layout
+
+RELEASE_DIR = os.environ.get("SONIC_RELEASE_DIR")
+
+
+def release_files_exist():
+    if not RELEASE_DIR:
+        return False
+    release_dir = Path(RELEASE_DIR)
+    names = ("observation_config.yaml", "model_encoder.onnx",
+             "model_decoder.onnx")
+    return all((release_dir / name).exists() for name in names)
+
+
+pytestmark = pytest.mark.skipif(
+    not release_files_exist(),
+    reason="SONIC_RELEASE_DIR not set to a real release directory")
+
+
+def build_release_runtime():
+    release_dir = Path(RELEASE_DIR)
+    obs_config = release_dir / "observation_config.yaml"
+    encoder_onnx = release_dir / "model_encoder.onnx"
+    decoder_onnx = release_dir / "model_decoder.onnx"
+    layout = load_release_observation_layout(obs_config)
+    encoder, decoder, actor = port_sonic_weights(
+        layout, encoder_onnx, decoder_onnx)
+    encoder_session = ort.InferenceSession(str(encoder_onnx))
+    decoder_session = ort.InferenceSession(str(decoder_onnx))
+    return layout, encoder, decoder, encoder_session, decoder_session
+
+
+def test_encoder_matches_onnx_runtime_per_mode():
+    layout, encoder, _, encoder_session, _ = build_release_runtime()
+    mode_index = compute_mode_scalar_index(layout)
+    rng = np.random.default_rng(0)
+    for mode in layout.encoder_modes:
+        x = rng.normal(size=(1, layout.encoder_spans[-1].end))
+        x = x.astype("float32")
+        x[0, mode_index] = float(mode.mode_id)
+        onnx_out = encoder_session.run(None, {"obs_dict": x})[0]
+        paz_out = np.array(encoder(x, training=False))
+        assert np.abs(onnx_out - paz_out).max() < 1e-4
+
+
+def test_decoder_matches_onnx_runtime():
+    layout, _, decoder, _, decoder_session = build_release_runtime()
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=(1, layout.policy_spans[-1].end)).astype("float32")
+    onnx_out = decoder_session.run(None, {"obs_dict": x})[0]
+    paz_out = np.array(decoder(x, training=False))
+    assert np.abs(onnx_out - paz_out).max() < 1e-4

--- a/paz/models/foundation/sonic/sonic_test.py
+++ b/paz/models/foundation/sonic/sonic_test.py
@@ -12,7 +12,7 @@ import pytest
 
 ort = pytest.importorskip("onnxruntime")
 
-from paz.models.foundation.sonic.conversion import port_sonic_weights
+from paz.models.foundation.sonic.conversion import port_weights
 from paz.models.foundation.sonic.layout import compute_mode_scalar_index
 from paz.models.foundation.sonic.layout import load_release_observation_layout
 
@@ -39,7 +39,7 @@ def build_release_runtime():
     encoder_onnx = release_dir / "model_encoder.onnx"
     decoder_onnx = release_dir / "model_decoder.onnx"
     layout = load_release_observation_layout(obs_config)
-    encoder, decoder, actor = port_sonic_weights(
+    encoder, decoder, actor = port_weights(
         layout, encoder_onnx, decoder_onnx)
     encoder_session = ort.InferenceSession(str(encoder_onnx))
     decoder_session = ort.InferenceSession(str(decoder_onnx))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ dependencies = [
     "scipy"
 ]
 
+[project.optional-dependencies]
+sonic = [
+    "mujoco>=3.3",
+    "onnx>=1.16",
+]
+
 [project.urls]
 Homepage = "https://github.com/oarriaga/paz"
 Repository = "https://github.com/oarriaga/paz"


### PR DESCRIPTION
## Why

The SONIC humanoid whole-body-control actor (three encoder branches with an
FSQ-quantizer bottleneck, feeding a decoder MLP) was implemented as a Keras
port in `gear_sonic/keras` (GR00T-WholeBodyControl), independent of paz's
conventions. This brings that architecture and its ONNX weight-import
tooling into paz as `paz/models/foundation/sonic`.

## What changed

- `layout.py`: `SonicObservationLayout` / `EncoderModeLayout` /
  `ObservationSpan` as namedtuples with `compute_*`/`find_*` helper
  functions, replacing the original's dataclass properties/methods.
  `load_release_observation_layout` parses the release YAML unchanged.
- `model.py`: `build_sonic_encoder` / `build_sonic_decoder` /
  `build_sonic_actor` plus the FSQ/dense-stack/mode-routing helpers,
  restyled but behaviorally identical to the original. FSQ hyperparameters
  are now a named `FSQArgs` tuple instead of an anonymous 6-tuple.
- `conversion.py`: imports the released ONNX weights into the ported Keras
  models via the same regex-based layer-name matching as the original
  (encoder kernels transposed, decoder kernels not - that asymmetry is
  intentional and preserved). Includes a CLI (`main()`) that writes a
  complete asset bundle (both weight files plus `observation_config.yaml`).
- `pretrained.py`: `Sonic(weights="pretrained")` follows the same
  `keras.utils.get_file` download pattern as `Gemma4`/`Whisper`. The
  converted weights are not uploaded to `altamira-data` yet - see the
  module docstring; publishing them is a follow-up decision, not part of
  this PR.
- Registered `Sonic` in `paz/models/__init__.py`.

## Verification

- `pytest paz/models/foundation/sonic/` -> 17 passed, 2 skipped.
- The 2 skipped tests are an opt-in numeric-parity check (gated by
  `SONIC_RELEASE_DIR`) against the real released ONNX files. Run locally
  against those assets: encoder output matches ONNX Runtime exactly (max
  abs diff 0.0) across all three modes (g1/teleop/smpl); decoder matches
  within 1e-5, consistent with the tolerances already validated in the
  source repo.
- `pyflakes` clean on all new files.
- `/code-review` at medium effort found and fixed 4 issues: the conversion
  CLI's output bundle was missing `observation_config.yaml`, a
  hanging-parenthesis FSQ signature/anonymous tuple, duplicated test
  fixtures across two test files, and a `conftest.py` convention drift
  from the sibling `gemma4` package.