### PR TITLE
Make Depth Anything 3 examples run out of the box

### DIFF
--- a/examples/depth_anything3/demo.py
+++ b/examples/depth_anything3/demo.py
@@ -1,0 +1,21 @@
+"""Demo images for the Depth Anything 3 examples, fetched on first use.
+
+The multi-view pair are the Sydney Opera House frames shipped with the
+official Depth Anything 3 repository; the indoor image is a COCO sample.
+"""
+from keras.utils import get_file
+
+import paz
+
+SOH = "https://raw.githubusercontent.com/ByteDance-Seed/Depth-Anything-3/main/assets/examples/SOH/"  # fmt: skip
+URLS = {
+    "opera_house_0": SOH + "000.png",
+    "opera_house_1": SOH + "010.png",
+    "indoor": "http://images.cocodataset.org/val2017/000000039769.jpg",
+}
+
+
+def fetch_image(name):
+    url = URLS[name]
+    path = get_file(name + url[-4:], url, cache_subdir="paz/examples/da3")
+    return paz.image.load(path)

--- a/examples/depth_anything3/estimate_metric.py
+++ b/examples/depth_anything3/estimate_metric.py
@@ -1,11 +1,10 @@
 """Metric monocular depth in meters with Depth Anything 3.
 
-Convert the DA3METRIC-LARGE checkpoint first:
+Runs out of the box: with no arguments it downloads the pretrained
+DA3METRIC-LARGE weights and an indoor demo image, then prints depth in meters.
 
-    DA3_MODEL=metric python -m paz.models.foundation.depth_anything3.convert
-
-Focal length is in pixels at the processed resolution and must be given
-explicitly; it is never inferred.
+Focal length is in pixels at the processed resolution; the model never infers
+it. The default suits the demo image; pass --focal_length for your own camera.
 """
 import argparse
 
@@ -14,17 +13,23 @@ import numpy as np
 import paz
 from paz.applications import EstimateDepthAnything3MetricLarge
 
+import demo
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--weights", default="pretrained")
-    parser.add_argument("--image", required=True)
-    parser.add_argument("--focal_length", type=float, required=True)
+    parser.add_argument("--image", default=None)
+    parser.add_argument("--focal_length", type=float, default=470.0)
     parser.add_argument("--image_size", type=int, default=518)
     args = parser.parse_args()
 
     settings = args.focal_length, args.weights, args.image_size
     estimate = EstimateDepthAnything3MetricLarge(*settings)
-    depth_meters, sky = estimate(paz.image.load(args.image))
+    if args.image is None:
+        image = demo.fetch_image("indoor")
+    else:
+        image = paz.image.load(args.image)
+    depth_meters, sky = estimate(image)
 
     depth_meters = np.array(depth_meters)[0]
     lowest = round(float(depth_meters.min()), 3)

--- a/examples/depth_anything3/estimate_multi_view.py
+++ b/examples/depth_anything3/estimate_multi_view.py
@@ -1,8 +1,8 @@
 """Any-view depth, rays, and recovered cameras with Depth Anything 3.
 
-Convert the DA3-SMALL checkpoint first:
-
-    python -m paz.models.foundation.depth_anything3.convert
+Runs out of the box: with no arguments it downloads the pretrained DA3-SMALL
+weights and two Opera House views, then prints per-view depth shapes and the
+camera pose recovered jointly from the unposed images.
 """
 import argparse
 
@@ -11,15 +11,21 @@ import numpy as np
 import paz
 from paz.applications import EstimateDepthAnything3Small
 
+import demo
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--weights", default="pretrained")
-    parser.add_argument("--images", nargs="+", required=True)
+    parser.add_argument("--images", nargs="+", default=None)
     parser.add_argument("--image_size", type=int, default=518)
     args = parser.parse_args()
 
     estimate = EstimateDepthAnything3Small(args.weights, args.image_size)
-    images = [paz.image.load(path) for path in args.images]
+    if args.images is None:
+        names = "opera_house_0", "opera_house_1"
+        images = [demo.fetch_image(name) for name in names]
+    else:
+        images = [paz.image.load(path) for path in args.images]
     outputs = estimate(images)
     depth, confidence, extrinsics, intrinsics, rays, ray_confidence = outputs
 

--- a/examples/depth_anything3/estimate_single_view.py
+++ b/examples/depth_anything3/estimate_single_view.py
@@ -1,8 +1,8 @@
 """Monocular relative depth with Depth Anything 3.
 
-Convert the DA3MONO-LARGE checkpoint first:
-
-    DA3_MODEL=mono python -m paz.models.foundation.depth_anything3.convert
+Runs out of the box: with no arguments it downloads the pretrained
+DA3MONO-LARGE weights and a demo image, then writes a depth map. The Opera
+House scene shows the sharp near/far separation the monocular model recovers.
 """
 import argparse
 
@@ -11,16 +11,22 @@ import numpy as np
 import paz
 from paz.applications import EstimateDepthAnything3MonoLarge
 
+import demo
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--weights", default="pretrained")
-    parser.add_argument("--image", required=True)
+    parser.add_argument("--image", default=None)
     parser.add_argument("--image_size", type=int, default=518)
     parser.add_argument("--output", default="depth.png")
     args = parser.parse_args()
 
     estimate = EstimateDepthAnything3MonoLarge(args.weights, args.image_size)
-    depth, sky = estimate(paz.image.load(args.image))
+    if args.image is None:
+        image = demo.fetch_image("opera_house_0")
+    else:
+        image = paz.image.load(args.image)
+    depth, sky = estimate(image)
 
     depth = np.array(depth)[0]
     scaled = (depth - depth.min()) / (depth.max() - depth.min() + 1e-8)


### PR DESCRIPTION
The three `examples/depth_anything3` scripts now run with zero arguments.
Weights already default to `pretrained`; this adds a demo-image fallback when
no `--image` is passed, so each example downloads its inputs and produces
output out of the box.

- `demo.py` fetches images via `keras.utils.get_file`: the official Depth
  Anything 3 Opera House pair (any-view + monocular) and a COCO indoor scene
  (metric). Passing `--image(s)` still overrides.
- Images are chosen to show each model's strength: multi-view recovers
  per-view cameras from two unposed views; monocular gives a sharp near/far
  depth map; metric returns depth in meters (default focal for the demo).

## Verification (`KERAS_BACKEND=jax`, CPU, no arguments)
- single-view: downloads MONO-LARGE weights + demo image, writes a depth map
  (near/far correct).
- multi-view: downloads SMALL weights + both views, prints recovered cameras
  (view 0 at origin, view 1 translated).
- metric: downloads METRIC-LARGE weights + indoor image, prints depth ~0.8-1.7 m.
- 80-column and pyflakes clean (the demo URL uses `# fmt: skip`).
