### PR TITLE
Add SAM 2 image models

### DIFF
--- a/examples/sam2/demo.py
+++ b/examples/sam2/demo.py
@@ -1,0 +1,11 @@
+"""Demo image for the SAM 2 example, fetched on first use."""
+from keras.utils import get_file
+
+import paz
+
+URL = "http://images.cocodataset.org/val2017/000000039769.jpg"
+
+
+def fetch_image():
+    path = get_file("sam2_cats.jpg", URL, cache_subdir="paz/examples/sam2")
+    return paz.image.load(path)

--- a/examples/sam2/segment_image.py
+++ b/examples/sam2/segment_image.py
@@ -19,6 +19,11 @@ import demo
 BACKGROUND = (0, 0, 0)
 FOREGROUND = (30, 144, 255)
 
+
+def load_image(path):
+    return demo.fetch_image() if path is None else paz.image.load(path)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--weights", required=True)
@@ -29,18 +34,16 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     model = SAM21HieraSmall(weights=args.weights)
-    image = demo.fetch_image() if args.image is None else \
-        paz.image.load(args.image)
-
-    features = predict.encode_image(model, image)
-    points = [args.positive, args.negative]
-    masks, scores, low_res = predict.predict(
-        model, features, points=points, labels=[1, 0], multimask=True)
+    image = load_image(args.image)
+    state = predict.encode_image(model, image)
+    prompt = dict(points=[args.positive, args.negative], labels=[1, 0])
+    masks, scores, _ = predict.predict(state, **prompt)
+    masks, scores = predict.select(masks, scores, multimask=True)
 
     best = int(np.argmax(np.array(scores)[0]))
     mask = np.array(masks)[0, best] > 0
-    overlaid = overlay_masks(image, mask.astype("int32"),
-                             [BACKGROUND, FOREGROUND])
+    colors = [BACKGROUND, FOREGROUND]
+    overlaid = overlay_masks(image, mask.astype("int32"), colors)
     paz.image.write(args.output, overlaid)
     print("best mask", best, "score", float(np.array(scores)[0, best]))
     print("saved", args.output)

--- a/examples/sam2/segment_image.py
+++ b/examples/sam2/segment_image.py
@@ -1,0 +1,46 @@
+"""Segment an object with SAM 2.1 from one positive and one negative point.
+
+Converted weights come from a directory produced by
+``paz.models.foundation.sam2.pretrained.convert_checkpoint``; pass it with
+``--weights``. The positive point marks the object, the negative point marks
+background; the mask with the highest predicted quality is overlaid.
+"""
+import argparse
+
+import numpy as np
+
+import paz
+from paz.models import SAM21HieraSmall
+from paz.models.foundation.sam2 import predict
+from paz.backend.draw import overlay_masks
+
+import demo
+
+BACKGROUND = (0, 0, 0)
+FOREGROUND = (30, 144, 255)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", required=True)
+    parser.add_argument("--image", default=None)
+    parser.add_argument("--positive", type=int, nargs=2, default=(340, 260))
+    parser.add_argument("--negative", type=int, nargs=2, default=(50, 40))
+    parser.add_argument("--output", default="sam2_mask.png")
+    args = parser.parse_args()
+
+    model = SAM21HieraSmall(weights=args.weights)
+    image = demo.fetch_image() if args.image is None else \
+        paz.image.load(args.image)
+
+    features = predict.encode_image(model, image)
+    points = [args.positive, args.negative]
+    masks, scores, low_res = predict.predict(
+        model, features, points=points, labels=[1, 0], multimask=True)
+
+    best = int(np.argmax(np.array(scores)[0]))
+    mask = np.array(masks)[0, best] > 0
+    overlaid = overlay_masks(image, mask.astype("int32"),
+                             [BACKGROUND, FOREGROUND])
+    paz.image.write(args.output, overlaid)
+    print("best mask", best, "score", float(np.array(scores)[0, best]))
+    print("saved", args.output)

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -50,3 +50,11 @@ from .foundation.gemma4.causal_lm import Gemma4CausalLM
 from .feature.xfeat.model import XFeatModel
 from .feature.xfeat.model import XFeat
 from .feature.lightglue.model import LighterGlue
+from .foundation.sam2 import SAM2HieraTiny
+from .foundation.sam2 import SAM2HieraSmall
+from .foundation.sam2 import SAM2HieraBasePlus
+from .foundation.sam2 import SAM2HieraLarge
+from .foundation.sam2 import SAM21HieraTiny
+from .foundation.sam2 import SAM21HieraSmall
+from .foundation.sam2 import SAM21HieraBasePlus
+from .foundation.sam2 import SAM21HieraLarge

--- a/paz/models/foundation/sam2/__init__.py
+++ b/paz/models/foundation/sam2/__init__.py
@@ -1,0 +1,7 @@
+"""SAM 2 / SAM 2.1 static-image models built from PAZ transformer parts.
+
+One shared architecture (Hiera trunk, FPN neck, prompt encoder, two-way mask
+decoder) drives the eight official factories, which differ only by immutable
+configuration and checkpoint weights. Video memory is intentionally out of
+scope for this module.
+"""

--- a/paz/models/foundation/sam2/__init__.py
+++ b/paz/models/foundation/sam2/__init__.py
@@ -5,3 +5,11 @@ decoder) drives the eight official factories, which differ only by immutable
 configuration and checkpoint weights. Video memory is intentionally out of
 scope for this module.
 """
+from paz.models.foundation.sam2.pretrained import SAM2HieraTiny
+from paz.models.foundation.sam2.pretrained import SAM2HieraSmall
+from paz.models.foundation.sam2.pretrained import SAM2HieraBasePlus
+from paz.models.foundation.sam2.pretrained import SAM2HieraLarge
+from paz.models.foundation.sam2.pretrained import SAM21HieraTiny
+from paz.models.foundation.sam2.pretrained import SAM21HieraSmall
+from paz.models.foundation.sam2.pretrained import SAM21HieraBasePlus
+from paz.models.foundation.sam2.pretrained import SAM21HieraLarge

--- a/paz/models/foundation/sam2/configuration.py
+++ b/paz/models/foundation/sam2/configuration.py
@@ -1,0 +1,40 @@
+"""Immutable Hiera trunk configuration for the four SAM 2 architectures.
+
+SAM 2 and SAM 2.1 share these architectures and differ only in checkpoint
+weights, so the eight public factories reuse these four configs. The SAM
+prompt encoder and mask decoder are identical across every variant and are
+therefore fixed as module constants instead of configuration fields.
+"""
+from collections import namedtuple
+
+IMAGE_SIZE = 1024
+PATCH_STRIDE = 4
+BACKBONE_STRIDE = 16
+PROMPT_EMBED_DIM = 256
+DIM_MUL = 2
+HEAD_MUL = 2
+QUERY_STRIDE = (2, 2)
+QUERY_POOL_STAGES = 3
+MLP_RATIO = 4.0
+
+fields = ("name embed_dim num_heads stages global_attention_blocks "
+          "window_spec background_size")
+SAM2Config = namedtuple("SAM2Config", fields)
+
+TINY = SAM2Config("hiera_tiny", 96, 1, (1, 2, 7, 2), (5, 7, 9),
+                  (8, 4, 14, 7), (7, 7))
+SMALL = SAM2Config("hiera_small", 96, 1, (1, 2, 11, 2), (7, 10, 13),
+                   (8, 4, 14, 7), (7, 7))
+BASE_PLUS = SAM2Config("hiera_base_plus", 112, 2, (2, 3, 16, 3),
+                       (12, 16, 20), (8, 4, 14, 7), (14, 14))
+LARGE = SAM2Config("hiera_large", 144, 2, (2, 6, 36, 4), (23, 33, 43),
+                   (8, 4, 16, 8), (7, 7))
+
+
+def stage_dimensions(embed_dim, num_stages):
+    return [embed_dim * DIM_MUL ** stage for stage in range(num_stages)]
+
+
+def backbone_channels(config):
+    dimensions = stage_dimensions(config.embed_dim, len(config.stages))
+    return list(reversed(dimensions))

--- a/paz/models/foundation/sam2/configuration.py
+++ b/paz/models/foundation/sam2/configuration.py
@@ -29,12 +29,3 @@ BASE_PLUS = SAM2Config("hiera_base_plus", 112, 2, (2, 3, 16, 3),
                        (12, 16, 20), (8, 4, 14, 7), (14, 14))
 LARGE = SAM2Config("hiera_large", 144, 2, (2, 6, 36, 4), (23, 33, 43),
                    (8, 4, 16, 8), (7, 7))
-
-
-def stage_dimensions(embed_dim, num_stages):
-    return [embed_dim * DIM_MUL ** stage for stage in range(num_stages)]
-
-
-def backbone_channels(config):
-    dimensions = stage_dimensions(config.embed_dim, len(config.stages))
-    return list(reversed(dimensions))

--- a/paz/models/foundation/sam2/configuration.py
+++ b/paz/models/foundation/sam2/configuration.py
@@ -8,7 +8,6 @@ therefore fixed as module constants instead of configuration fields.
 from collections import namedtuple
 
 IMAGE_SIZE = 1024
-PATCH_STRIDE = 4
 BACKBONE_STRIDE = 16
 PROMPT_EMBED_DIM = 256
 DIM_MUL = 2
@@ -17,15 +16,15 @@ QUERY_STRIDE = (2, 2)
 QUERY_POOL_STAGES = 3
 MLP_RATIO = 4.0
 
-fields = ("name embed_dim num_heads stages global_attention_blocks "
-          "window_spec background_size")
-SAM2Config = namedtuple("SAM2Config", fields)
+FIELDS = "embed_dim num_heads stages global_blocks window_spec background"
+SAM2Config = namedtuple("SAM2Config", FIELDS)
 
-TINY = SAM2Config("hiera_tiny", 96, 1, (1, 2, 7, 2), (5, 7, 9),
-                  (8, 4, 14, 7), (7, 7))
-SMALL = SAM2Config("hiera_small", 96, 1, (1, 2, 11, 2), (7, 10, 13),
-                   (8, 4, 14, 7), (7, 7))
-BASE_PLUS = SAM2Config("hiera_base_plus", 112, 2, (2, 3, 16, 3),
-                       (12, 16, 20), (8, 4, 14, 7), (14, 14))
-LARGE = SAM2Config("hiera_large", 144, 2, (2, 6, 36, 4), (23, 33, 43),
-                   (8, 4, 16, 8), (7, 7))
+tiny = 96, 1, (1, 2, 7, 2), (5, 7, 9), (8, 4, 14, 7), (7, 7)
+small = 96, 1, (1, 2, 11, 2), (7, 10, 13), (8, 4, 14, 7), (7, 7)
+base = 112, 2, (2, 3, 16, 3), (12, 16, 20), (8, 4, 14, 7), (14, 14)
+large = 144, 2, (2, 6, 36, 4), (23, 33, 43), (8, 4, 16, 8), (7, 7)
+
+TINY = SAM2Config(*tiny)
+SMALL = SAM2Config(*small)
+BASE_PLUS = SAM2Config(*base)
+LARGE = SAM2Config(*large)

--- a/paz/models/foundation/sam2/convert.py
+++ b/paz/models/foundation/sam2/convert.py
@@ -1,10 +1,10 @@
 """Convert an official SAM 2 checkpoint into the PAZ image-inference models.
 
 Maps every image-required parameter explicitly, transposes convolution and
-dense kernels, and fails on missing, mismatched, or unexpected image keys.
-Video-memory parameters are listed as deferred and reported, never silently
-ignored. Takes a plain ``{key: ndarray}`` state dict so the runtime env needs
-no torch, mirroring the dinov2 converter.
+dense kernels, and fails on any unmapped image-prefix key. Video-memory
+parameters (memory_attention/memory_encoder, maskmem*, obj_ptr*, no_mem_pos*,
+no_obj*, mask_downsample) are deferred and tolerated, never silently mapped.
+Takes a plain ``{key: ndarray}`` state dict so the runtime needs no torch.
 """
 import numpy as np
 
@@ -16,9 +16,8 @@ PROMPT = "sam_prompt_encoder."
 DECODER = "sam_mask_decoder."
 TRANSFORMER = "sam_mask_decoder.transformer."
 
-DEFERRED = ("memory_attention", "memory_encoder", "maskmem_tpos_enc",
-            "no_mem_pos_enc", "no_obj_ptr", "no_obj_embed_spatial",
-            "mask_downsample", "obj_ptr_proj", "obj_ptr_tpos_proj")
+# Only keys under these prefixes must be mapped; everything else is deferred.
+IMAGE = "image_encoder sam_prompt_encoder sam_mask_decoder no_mem_embed".split()
 
 
 def convert(models, state_dict, used=None):
@@ -27,122 +26,122 @@ def convert(models, state_dict, used=None):
     convert_point_encoder(models.point_encoder, state_dict, used)
     convert_mask_downscaling(models.mask_downscaling, state_dict, used)
     convert_mask_decoder(models.mask_decoder, state_dict, used)
-    reject_unused_image_keys(state_dict, used)
+    reject_unmapped_image_keys(state_dict, used)
     return models
 
 
 def convert_image_encoder(model, state_dict, config, used):
-    set_conv(model, "patch_embed_proj", TRUNK + "patch_embed.proj",
-             state_dict, used)
+    def dense(name, source):
+        set_dense(model, name, source, state_dict, used)
+
+    def conv(name, source):
+        set_conv(model, name, source, state_dict, used)
+
+    def norm(name, source):
+        set_norm(model, name, source, state_dict, used)
+
+    conv("patch_embed_proj", TRUNK + "patch_embed.proj")
     background = take(state_dict, TRUNK + "pos_embed", used)
     window = take(state_dict, TRUNK + "pos_embed_window", used)
     set_layer(model, "trunk_pos_embed", [to_last(background), to_last(window)])
     specifications, _ = hiera.build_block_specifications(config)
     for index, dim, dim_out, _, _, _, name in specifications:
         block = f"{TRUNK}blocks.{index}"
-        set_norm(model, f"{name}_norm1", f"{block}.norm1", state_dict, used)
-        set_norm(model, f"{name}_norm2", f"{block}.norm2", state_dict, used)
-        set_dense(model, f"{name}_attn_qkv", f"{block}.attn.qkv", state_dict,
-                  used)
-        set_dense(model, f"{name}_attn_proj", f"{block}.attn.proj", state_dict,
-                  used)
-        set_dense(model, f"{name}_mlp_fc1", f"{block}.mlp.layers.0",
-                  state_dict, used)
-        set_dense(model, f"{name}_mlp_fc2", f"{block}.mlp.layers.1",
-                  state_dict, used)
+        norm(f"{name}_norm1", f"{block}.norm1")
+        norm(f"{name}_norm2", f"{block}.norm2")
+        dense(f"{name}_attn_qkv", f"{block}.attn.qkv")
+        dense(f"{name}_attn_proj", f"{block}.attn.proj")
+        dense(f"{name}_mlp_fc1", f"{block}.mlp.layers.0")
+        dense(f"{name}_mlp_fc2", f"{block}.mlp.layers.1")
         if dim != dim_out:
-            set_dense(model, f"{name}_proj", f"{block}.proj", state_dict, used)
+            dense(f"{name}_proj", f"{block}.proj")
     for index in range(4):
-        set_conv(model, f"neck_conv_{index}",
-                 f"{NECK}convs.{index}.conv", state_dict, used)
-    set_conv(model, "sam_mask_decoder_conv_s0", DECODER + "conv_s0",
-             state_dict, used)
-    set_conv(model, "sam_mask_decoder_conv_s1", DECODER + "conv_s1",
-             state_dict, used)
+        conv(f"neck_conv_{index}", f"{NECK}convs.{index}.conv")
+    conv("sam_mask_decoder_conv_s0", DECODER + "conv_s0")
+    conv("sam_mask_decoder_conv_s1", DECODER + "conv_s1")
     vector = take(state_dict, "no_mem_embed", used).reshape(-1)
     set_layer(model, "no_mem_embed", [vector])
 
 
 def convert_point_encoder(model, state_dict, used):
-    matrix = take(state_dict, PROMPT + "pe_layer."
-                  "positional_encoding_gaussian_matrix", used)
-    set_layer(model, "prompt_pe", [matrix])
-    corners = [take(state_dict, f"{PROMPT}point_embeddings.{index}.weight",
-                    used)[0] for index in range(4)]
+    key = PROMPT + "pe_layer.positional_encoding_gaussian_matrix"
+    set_layer(model, "prompt_pe", [take(state_dict, key, used)])
+    corners = []
+    for index in range(4):
+        source = f"{PROMPT}point_embeddings.{index}.weight"
+        corners.append(take(state_dict, source, used)[0])
     not_a_point = take(state_dict, PROMPT + "not_a_point_embed.weight", used)
     set_layer(model, "point_label_embed", [np.stack(corners), not_a_point])
 
 
 def convert_mask_downscaling(model, state_dict, used):
-    set_conv(model, "mask_down_0", PROMPT + "mask_downscaling.0", state_dict,
-             used)
-    set_norm(model, "mask_down_ln0", PROMPT + "mask_downscaling.1", state_dict,
-             used)
-    set_conv(model, "mask_down_3", PROMPT + "mask_downscaling.3", state_dict,
-             used)
-    set_norm(model, "mask_down_ln3", PROMPT + "mask_downscaling.4", state_dict,
-             used)
-    set_conv(model, "mask_down_6", PROMPT + "mask_downscaling.6", state_dict,
-             used)
+    def conv(name, source):
+        set_conv(model, name, source, state_dict, used)
+
+    def norm(name, source):
+        set_norm(model, name, source, state_dict, used)
+
+    conv("mask_down_0", PROMPT + "mask_downscaling.0")
+    norm("mask_down_ln0", PROMPT + "mask_downscaling.1")
+    conv("mask_down_3", PROMPT + "mask_downscaling.3")
+    norm("mask_down_ln3", PROMPT + "mask_downscaling.4")
+    conv("mask_down_6", PROMPT + "mask_downscaling.6")
     no_mask = take(state_dict, PROMPT + "no_mask_embed.weight", used)
     set_layer(model, "no_mask_embed", [no_mask.reshape(-1)])
 
 
 def convert_mask_decoder(model, state_dict, used):
-    set_layer(model, "obj_score_token",
-              [take(state_dict, DECODER + "obj_score_token.weight", used)])
-    set_layer(model, "iou_token",
-              [take(state_dict, DECODER + "iou_token.weight", used)])
-    set_layer(model, "mask_tokens",
-              [take(state_dict, DECODER + "mask_tokens.weight", used)])
+    def dense(name, source):
+        set_dense(model, name, source, state_dict, used)
+
+    def norm(name, source):
+        set_norm(model, name, source, state_dict, used)
+
+    def conv_t(name, source):
+        set_conv_transpose(model, name, source, state_dict, used)
+
+    for token in ("obj_score_token", "iou_token", "mask_tokens"):
+        weight = take(state_dict, f"{DECODER}{token}.weight", used)
+        set_layer(model, token, [weight])
     for index in range(2):
-        convert_two_way_block(model, state_dict, index, used)
-    convert_attention(model, "twoway_final_attn",
-                      TRANSFORMER + "final_attn_token_to_image", state_dict,
-                      used)
-    set_norm(model, "twoway_norm_final", TRANSFORMER + "norm_final_attn",
-             state_dict, used)
-    set_conv_transpose(model, "output_upscaling_0",
-                       DECODER + "output_upscaling.0", state_dict, used)
-    set_norm(model, "output_upscaling_1", DECODER + "output_upscaling.1",
-             state_dict, used)
-    set_conv_transpose(model, "output_upscaling_3",
-                       DECODER + "output_upscaling.3", state_dict, used)
+        convert_two_way_block(dense, norm, index)
+    final = TRANSFORMER + "final_attn_token_to_image"
+    convert_attention(dense, "twoway_final_attn", final)
+    norm("twoway_norm_final", TRANSFORMER + "norm_final_attn")
+    conv_t("output_upscaling_0", DECODER + "output_upscaling.0")
+    norm("output_upscaling_1", DECODER + "output_upscaling.1")
+    conv_t("output_upscaling_3", DECODER + "output_upscaling.3")
     for index in range(4):
-        convert_mlp(model, f"output_hypernetworks_mlps_{index}",
-                    f"{DECODER}output_hypernetworks_mlps.{index}", 3,
-                    state_dict, used)
-    convert_mlp(model, "iou_prediction_head",
-                DECODER + "iou_prediction_head", 3, state_dict, used)
-    convert_mlp(model, "pred_obj_score_head",
-                DECODER + "pred_obj_score_head", 3, state_dict, used)
+        name = f"output_hypernetworks_mlps_{index}"
+        source = f"{DECODER}output_hypernetworks_mlps.{index}"
+        convert_mlp(dense, name, source, 3)
+    iou_head = DECODER + "iou_prediction_head"
+    obj_head = DECODER + "pred_obj_score_head"
+    convert_mlp(dense, "iou_prediction_head", iou_head, 3)
+    convert_mlp(dense, "pred_obj_score_head", obj_head, 3)
 
 
-def convert_two_way_block(model, state_dict, index, used):
+def convert_two_way_block(dense, norm, index):
     block = f"{TRANSFORMER}layers.{index}"
     name = f"twoway_{index}"
-    convert_attention(model, f"{name}_self", f"{block}.self_attn", state_dict,
-                      used)
-    convert_attention(model, f"{name}_cross_t2i",
-                      f"{block}.cross_attn_token_to_image", state_dict, used)
-    convert_attention(model, f"{name}_cross_i2t",
-                      f"{block}.cross_attn_image_to_token", state_dict, used)
-    convert_mlp(model, f"{name}_mlp", f"{block}.mlp", 2, state_dict, used)
-    for norm in range(1, 5):
-        set_norm(model, f"{name}_norm{norm}", f"{block}.norm{norm}",
-                 state_dict, used)
+    convert_attention(dense, f"{name}_self", f"{block}.self_attn")
+    t2i = f"{block}.cross_attn_token_to_image"
+    i2t = f"{block}.cross_attn_image_to_token"
+    convert_attention(dense, f"{name}_cross_t2i", t2i)
+    convert_attention(dense, f"{name}_cross_i2t", i2t)
+    convert_mlp(dense, f"{name}_mlp", f"{block}.mlp", 2)
+    for number in range(1, 5):
+        norm(f"{name}_norm{number}", f"{block}.norm{number}")
 
 
-def convert_attention(model, name, source, state_dict, used):
+def convert_attention(dense, name, source):
     for part in ("q", "k", "v", "out"):
-        target = f"{name}_{part}"
-        set_dense(model, target, f"{source}.{part}_proj", state_dict, used)
+        dense(f"{name}_{part}", f"{source}.{part}_proj")
 
 
-def convert_mlp(model, name, source, layers, state_dict, used):
+def convert_mlp(dense, name, source, layers):
     for index in range(layers):
-        set_dense(model, f"{name}_layers_{index}", f"{source}.layers.{index}",
-                  state_dict, used)
+        dense(f"{name}_layers_{index}", f"{source}.layers.{index}")
 
 
 def set_dense(model, name, source, state_dict, used):
@@ -189,8 +188,8 @@ def take(state_dict, key, used):
     return np.asarray(state_dict[key])
 
 
-def reject_unused_image_keys(state_dict, used):
+def reject_unmapped_image_keys(state_dict, used):
     unused = [key for key in state_dict if key not in used]
-    unexpected = [key for key in unused if not key.startswith(DEFERRED)]
-    if unexpected:
-        raise KeyError(f"unexpected image keys: {sorted(unexpected)}")
+    missed = [k for k in unused if any(k.startswith(p) for p in IMAGE)]
+    if missed:
+        raise KeyError(f"unmapped image keys: {sorted(missed)}")

--- a/paz/models/foundation/sam2/convert.py
+++ b/paz/models/foundation/sam2/convert.py
@@ -1,0 +1,196 @@
+"""Convert an official SAM 2 checkpoint into the PAZ image-inference models.
+
+Maps every image-required parameter explicitly, transposes convolution and
+dense kernels, and fails on missing, mismatched, or unexpected image keys.
+Video-memory parameters are listed as deferred and reported, never silently
+ignored. Takes a plain ``{key: ndarray}`` state dict so the runtime env needs
+no torch, mirroring the dinov2 converter.
+"""
+import numpy as np
+
+from paz.models.foundation.sam2 import hiera
+
+TRUNK = "image_encoder.trunk."
+NECK = "image_encoder.neck."
+PROMPT = "sam_prompt_encoder."
+DECODER = "sam_mask_decoder."
+TRANSFORMER = "sam_mask_decoder.transformer."
+
+DEFERRED = ("memory_attention", "memory_encoder", "maskmem_tpos_enc",
+            "no_mem_pos_enc", "no_obj_ptr", "no_obj_embed_spatial",
+            "mask_downsample", "obj_ptr_proj", "obj_ptr_tpos_proj")
+
+
+def convert(models, state_dict, used=None):
+    used = set() if used is None else used
+    convert_image_encoder(models.image_encoder, state_dict, models.config, used)
+    convert_point_encoder(models.point_encoder, state_dict, used)
+    convert_mask_downscaling(models.mask_downscaling, state_dict, used)
+    convert_mask_decoder(models.mask_decoder, state_dict, used)
+    reject_unused_image_keys(state_dict, used)
+    return models
+
+
+def convert_image_encoder(model, state_dict, config, used):
+    set_conv(model, "patch_embed_proj", TRUNK + "patch_embed.proj",
+             state_dict, used)
+    background = take(state_dict, TRUNK + "pos_embed", used)
+    window = take(state_dict, TRUNK + "pos_embed_window", used)
+    set_layer(model, "trunk_pos_embed", [to_last(background), to_last(window)])
+    specifications, _ = hiera.build_block_specifications(config)
+    for index, dim, dim_out, _, _, _, name in specifications:
+        block = f"{TRUNK}blocks.{index}"
+        set_norm(model, f"{name}_norm1", f"{block}.norm1", state_dict, used)
+        set_norm(model, f"{name}_norm2", f"{block}.norm2", state_dict, used)
+        set_dense(model, f"{name}_attn_qkv", f"{block}.attn.qkv", state_dict,
+                  used)
+        set_dense(model, f"{name}_attn_proj", f"{block}.attn.proj", state_dict,
+                  used)
+        set_dense(model, f"{name}_mlp_fc1", f"{block}.mlp.layers.0",
+                  state_dict, used)
+        set_dense(model, f"{name}_mlp_fc2", f"{block}.mlp.layers.1",
+                  state_dict, used)
+        if dim != dim_out:
+            set_dense(model, f"{name}_proj", f"{block}.proj", state_dict, used)
+    for index in range(4):
+        set_conv(model, f"neck_conv_{index}",
+                 f"{NECK}convs.{index}.conv", state_dict, used)
+    set_conv(model, "sam_mask_decoder_conv_s0", DECODER + "conv_s0",
+             state_dict, used)
+    set_conv(model, "sam_mask_decoder_conv_s1", DECODER + "conv_s1",
+             state_dict, used)
+    vector = take(state_dict, "no_mem_embed", used).reshape(-1)
+    set_layer(model, "no_mem_embed", [vector])
+
+
+def convert_point_encoder(model, state_dict, used):
+    matrix = take(state_dict, PROMPT + "pe_layer."
+                  "positional_encoding_gaussian_matrix", used)
+    set_layer(model, "prompt_pe", [matrix])
+    corners = [take(state_dict, f"{PROMPT}point_embeddings.{index}.weight",
+                    used)[0] for index in range(4)]
+    not_a_point = take(state_dict, PROMPT + "not_a_point_embed.weight", used)
+    set_layer(model, "point_label_embed", [np.stack(corners), not_a_point])
+
+
+def convert_mask_downscaling(model, state_dict, used):
+    set_conv(model, "mask_down_0", PROMPT + "mask_downscaling.0", state_dict,
+             used)
+    set_norm(model, "mask_down_ln0", PROMPT + "mask_downscaling.1", state_dict,
+             used)
+    set_conv(model, "mask_down_3", PROMPT + "mask_downscaling.3", state_dict,
+             used)
+    set_norm(model, "mask_down_ln3", PROMPT + "mask_downscaling.4", state_dict,
+             used)
+    set_conv(model, "mask_down_6", PROMPT + "mask_downscaling.6", state_dict,
+             used)
+    no_mask = take(state_dict, PROMPT + "no_mask_embed.weight", used)
+    set_layer(model, "no_mask_embed", [no_mask.reshape(-1)])
+
+
+def convert_mask_decoder(model, state_dict, used):
+    set_layer(model, "obj_score_token",
+              [take(state_dict, DECODER + "obj_score_token.weight", used)])
+    set_layer(model, "iou_token",
+              [take(state_dict, DECODER + "iou_token.weight", used)])
+    set_layer(model, "mask_tokens",
+              [take(state_dict, DECODER + "mask_tokens.weight", used)])
+    for index in range(2):
+        convert_two_way_block(model, state_dict, index, used)
+    convert_attention(model, "twoway_final_attn",
+                      TRANSFORMER + "final_attn_token_to_image", state_dict,
+                      used)
+    set_norm(model, "twoway_norm_final", TRANSFORMER + "norm_final_attn",
+             state_dict, used)
+    set_conv_transpose(model, "output_upscaling_0",
+                       DECODER + "output_upscaling.0", state_dict, used)
+    set_norm(model, "output_upscaling_1", DECODER + "output_upscaling.1",
+             state_dict, used)
+    set_conv_transpose(model, "output_upscaling_3",
+                       DECODER + "output_upscaling.3", state_dict, used)
+    for index in range(4):
+        convert_mlp(model, f"output_hypernetworks_mlps_{index}",
+                    f"{DECODER}output_hypernetworks_mlps.{index}", 3,
+                    state_dict, used)
+    convert_mlp(model, "iou_prediction_head",
+                DECODER + "iou_prediction_head", 3, state_dict, used)
+    convert_mlp(model, "pred_obj_score_head",
+                DECODER + "pred_obj_score_head", 3, state_dict, used)
+
+
+def convert_two_way_block(model, state_dict, index, used):
+    block = f"{TRANSFORMER}layers.{index}"
+    name = f"twoway_{index}"
+    convert_attention(model, f"{name}_self", f"{block}.self_attn", state_dict,
+                      used)
+    convert_attention(model, f"{name}_cross_t2i",
+                      f"{block}.cross_attn_token_to_image", state_dict, used)
+    convert_attention(model, f"{name}_cross_i2t",
+                      f"{block}.cross_attn_image_to_token", state_dict, used)
+    convert_mlp(model, f"{name}_mlp", f"{block}.mlp", 2, state_dict, used)
+    for norm in range(1, 5):
+        set_norm(model, f"{name}_norm{norm}", f"{block}.norm{norm}",
+                 state_dict, used)
+
+
+def convert_attention(model, name, source, state_dict, used):
+    for part in ("q", "k", "v", "out"):
+        target = f"{name}_{part}"
+        set_dense(model, target, f"{source}.{part}_proj", state_dict, used)
+
+
+def convert_mlp(model, name, source, layers, state_dict, used):
+    for index in range(layers):
+        set_dense(model, f"{name}_layers_{index}", f"{source}.layers.{index}",
+                  state_dict, used)
+
+
+def set_dense(model, name, source, state_dict, used):
+    kernel = take(state_dict, f"{source}.weight", used).T
+    bias = take(state_dict, f"{source}.bias", used)
+    set_layer(model, name, [kernel, bias])
+
+
+def set_conv(model, name, source, state_dict, used):
+    kernel = take(state_dict, f"{source}.weight", used)
+    bias = take(state_dict, f"{source}.bias", used)
+    set_layer(model, name, [np.transpose(kernel, (2, 3, 1, 0)), bias])
+
+
+def set_conv_transpose(model, name, source, state_dict, used):
+    kernel = take(state_dict, f"{source}.weight", used)
+    bias = take(state_dict, f"{source}.bias", used)
+    set_layer(model, name, [np.transpose(kernel, (2, 3, 1, 0)), bias])
+
+
+def set_norm(model, name, source, state_dict, used):
+    gamma = take(state_dict, f"{source}.weight", used)
+    beta = take(state_dict, f"{source}.bias", used)
+    set_layer(model, name, [gamma, beta])
+
+
+def to_last(parameter):
+    return parameter[0].transpose(1, 2, 0)
+
+
+def set_layer(model, name, arrays):
+    layer = model.get_layer(name)
+    current = [tuple(weight.shape) for weight in layer.get_weights()]
+    target = [tuple(array.shape) for array in arrays]
+    if current != target:
+        raise ValueError(f"{name} shapes {target} do not fit {current}")
+    layer.set_weights(arrays)
+
+
+def take(state_dict, key, used):
+    if key not in state_dict:
+        raise KeyError(f"missing source key: {key}")
+    used.add(key)
+    return np.asarray(state_dict[key])
+
+
+def reject_unused_image_keys(state_dict, used):
+    unused = [key for key in state_dict if key not in used]
+    unexpected = [key for key in unused if not key.startswith(DEFERRED)]
+    if unexpected:
+        raise KeyError(f"unexpected image keys: {sorted(unexpected)}")

--- a/paz/models/foundation/sam2/convert_test.py
+++ b/paz/models/foundation/sam2/convert_test.py
@@ -1,0 +1,193 @@
+"""Converter coverage and strictness without torch.
+
+Builds a torch-style state dict from a constructed bundle (the inverse of the
+converter), converts it into a fresh bundle, and checks the mapping is
+complete and reproduces the outputs. Also checks missing and unexpected keys
+are rejected and deferred video keys are tolerated.
+"""
+import numpy as np
+import pytest
+
+from paz.models.foundation.sam2 import model as sam2_model, convert, hiera
+from paz.models.foundation.sam2.configuration import TINY
+
+TRUNK = convert.TRUNK
+NECK = convert.NECK
+PROMPT = convert.PROMPT
+DECODER = convert.DECODER
+TRANSFORMER = convert.TRANSFORMER
+
+
+def dense(model, name, source, state):
+    kernel, bias = model.get_layer(name).get_weights()
+    state[f"{source}.weight"] = kernel.T
+    state[f"{source}.bias"] = bias
+
+
+def conv(model, name, source, state):
+    kernel, bias = model.get_layer(name).get_weights()
+    state[f"{source}.weight"] = np.transpose(kernel, (3, 2, 0, 1))
+    state[f"{source}.bias"] = bias
+
+
+def norm(model, name, source, state):
+    gamma, beta = model.get_layer(name).get_weights()
+    state[f"{source}.weight"] = gamma
+    state[f"{source}.bias"] = beta
+
+
+def to_torch_state_dict(bundle):
+    state = {}
+    encode_image_encoder(bundle.image_encoder, state)
+    encode_point_encoder(bundle.point_encoder, state)
+    encode_mask_downscaling(bundle.mask_downscaling, state)
+    encode_mask_decoder(bundle.mask_decoder, state)
+    return state
+
+
+def encode_image_encoder(model, state):
+    conv(model, "patch_embed_proj", TRUNK + "patch_embed.proj", state)
+    background, window = model.get_layer("trunk_pos_embed").get_weights()
+    state[TRUNK + "pos_embed"] = background.transpose(2, 0, 1)[None]
+    state[TRUNK + "pos_embed_window"] = window.transpose(2, 0, 1)[None]
+    specifications, _ = hiera.build_block_specifications(TINY)
+    for index, dim, dim_out, _, _, _, name in specifications:
+        block = f"{TRUNK}blocks.{index}"
+        norm(model, f"{name}_norm1", f"{block}.norm1", state)
+        norm(model, f"{name}_norm2", f"{block}.norm2", state)
+        dense(model, f"{name}_attn_qkv", f"{block}.attn.qkv", state)
+        dense(model, f"{name}_attn_proj", f"{block}.attn.proj", state)
+        dense(model, f"{name}_mlp_fc1", f"{block}.mlp.layers.0", state)
+        dense(model, f"{name}_mlp_fc2", f"{block}.mlp.layers.1", state)
+        if dim != dim_out:
+            dense(model, f"{name}_proj", f"{block}.proj", state)
+    for index in range(4):
+        conv(model, f"neck_conv_{index}", f"{NECK}convs.{index}.conv", state)
+    conv(model, "sam_mask_decoder_conv_s0", DECODER + "conv_s0", state)
+    conv(model, "sam_mask_decoder_conv_s1", DECODER + "conv_s1", state)
+    vector = model.get_layer("no_mem_embed").get_weights()[0]
+    state["no_mem_embed"] = vector.reshape(1, 1, -1)
+
+
+def encode_point_encoder(model, state):
+    matrix = model.get_layer("prompt_pe").get_weights()[0]
+    state[PROMPT + "pe_layer.positional_encoding_gaussian_matrix"] = matrix
+    corners, not_a_point = model.get_layer("point_label_embed").get_weights()
+    for index in range(4):
+        state[f"{PROMPT}point_embeddings.{index}.weight"] = corners[index:
+                                                                     index + 1]
+    state[PROMPT + "not_a_point_embed.weight"] = not_a_point
+
+
+def encode_mask_downscaling(model, state):
+    conv(model, "mask_down_0", PROMPT + "mask_downscaling.0", state)
+    norm(model, "mask_down_ln0", PROMPT + "mask_downscaling.1", state)
+    conv(model, "mask_down_3", PROMPT + "mask_downscaling.3", state)
+    norm(model, "mask_down_ln3", PROMPT + "mask_downscaling.4", state)
+    conv(model, "mask_down_6", PROMPT + "mask_downscaling.6", state)
+    no_mask = model.get_layer("no_mask_embed").get_weights()[0]
+    state[PROMPT + "no_mask_embed.weight"] = no_mask.reshape(1, -1)
+
+
+def encode_mask_decoder(model, state):
+    for name, source in (("obj_score_token", "obj_score_token"),
+                         ("iou_token", "iou_token"),
+                         ("mask_tokens", "mask_tokens")):
+        state[DECODER + f"{source}.weight"] = \
+            model.get_layer(name).get_weights()[0]
+    for index in range(2):
+        encode_two_way_block(model, index, state)
+    encode_attention(model, "twoway_final_attn",
+                     TRANSFORMER + "final_attn_token_to_image", state)
+    norm(model, "twoway_norm_final", TRANSFORMER + "norm_final_attn", state)
+    encode_conv_transpose(model, "output_upscaling_0",
+                          DECODER + "output_upscaling.0", state)
+    norm(model, "output_upscaling_1", DECODER + "output_upscaling.1", state)
+    encode_conv_transpose(model, "output_upscaling_3",
+                          DECODER + "output_upscaling.3", state)
+    for index in range(4):
+        encode_mlp(model, f"output_hypernetworks_mlps_{index}",
+                   f"{DECODER}output_hypernetworks_mlps.{index}", 3, state)
+    encode_mlp(model, "iou_prediction_head",
+               DECODER + "iou_prediction_head", 3, state)
+    encode_mlp(model, "pred_obj_score_head",
+               DECODER + "pred_obj_score_head", 3, state)
+
+
+def encode_two_way_block(model, index, state):
+    block = f"{TRANSFORMER}layers.{index}"
+    name = f"twoway_{index}"
+    encode_attention(model, f"{name}_self", f"{block}.self_attn", state)
+    encode_attention(model, f"{name}_cross_t2i",
+                     f"{block}.cross_attn_token_to_image", state)
+    encode_attention(model, f"{name}_cross_i2t",
+                     f"{block}.cross_attn_image_to_token", state)
+    encode_mlp(model, f"{name}_mlp", f"{block}.mlp", 2, state)
+    for number in range(1, 5):
+        norm(model, f"{name}_norm{number}", f"{block}.norm{number}", state)
+
+
+def encode_attention(model, name, source, state):
+    for part in ("q", "k", "v", "out"):
+        dense(model, f"{name}_{part}", f"{source}.{part}_proj", state)
+
+
+def encode_mlp(model, name, source, layers, state):
+    for index in range(layers):
+        dense(model, f"{name}_layers_{index}", f"{source}.layers.{index}",
+              state)
+
+
+def encode_conv_transpose(model, name, source, state):
+    kernel, bias = model.get_layer(name).get_weights()
+    state[f"{source}.weight"] = np.transpose(kernel, (3, 2, 0, 1))
+    state[f"{source}.bias"] = bias
+
+
+def randomize(bundle):
+    generator = np.random.RandomState(1)
+    for model in bundle[:4]:
+        model.set_weights([generator.randn(*w.shape).astype("float32") * 0.05
+                           for w in model.get_weights()])
+
+
+def test_converter_reproduces_source():
+    source = sam2_model.build(TINY)
+    randomize(source)
+    state = to_torch_state_dict(source)
+    target = sam2_model.build(TINY)
+    used = set()
+    convert.convert(target, state, used)
+    assert used == set(state)
+    inputs = [np.zeros((1, 64, 64, 256), np.float32),
+              np.zeros((1, 256, 256, 32), np.float32),
+              np.zeros((1, 128, 128, 64), np.float32),
+              np.zeros((1, 2, 256), np.float32),
+              np.zeros((1, 64, 64, 256), np.float32),
+              np.zeros((1, 64, 64, 256), np.float32)]
+    expected = np.array(source.mask_decoder(inputs)[0])
+    result = np.array(target.mask_decoder(inputs)[0])
+    assert np.allclose(expected, result, atol=1e-5)
+
+
+def test_converter_rejects_missing_key():
+    bundle = sam2_model.build(TINY)
+    state = to_torch_state_dict(bundle)
+    del state[DECODER + "iou_token.weight"]
+    with pytest.raises(KeyError):
+        convert.convert(sam2_model.build(TINY), state)
+
+
+def test_converter_rejects_unexpected_key():
+    bundle = sam2_model.build(TINY)
+    state = to_torch_state_dict(bundle)
+    state["sam_mask_decoder.surprise"] = np.zeros((2,), np.float32)
+    with pytest.raises(KeyError):
+        convert.convert(sam2_model.build(TINY), state)
+
+
+def test_converter_tolerates_deferred_keys():
+    bundle = sam2_model.build(TINY)
+    state = to_torch_state_dict(bundle)
+    state["memory_encoder.deferred"] = np.zeros((2,), np.float32)
+    convert.convert(sam2_model.build(TINY), state)

--- a/paz/models/foundation/sam2/convert_test.py
+++ b/paz/models/foundation/sam2/convert_test.py
@@ -2,8 +2,8 @@
 
 Builds a torch-style state dict from a constructed bundle (the inverse of the
 converter), converts it into a fresh bundle, and checks the mapping is
-complete and reproduces the outputs. Also checks missing and unexpected keys
-are rejected and deferred video keys are tolerated.
+complete and reproduces the outputs. Also checks unmapped image keys are
+rejected and deferred video keys are tolerated.
 """
 import numpy as np
 import pytest
@@ -18,22 +18,23 @@ DECODER = convert.DECODER
 TRANSFORMER = convert.TRANSFORMER
 
 
-def dense(model, name, source, state):
-    kernel, bias = model.get_layer(name).get_weights()
-    state[f"{source}.weight"] = kernel.T
-    state[f"{source}.bias"] = bias
+def setters(model, state):
+    def dense(name, source):
+        kernel, bias = model.get_layer(name).get_weights()
+        state[f"{source}.weight"] = kernel.T
+        state[f"{source}.bias"] = bias
 
+    def conv(name, source):
+        kernel, bias = model.get_layer(name).get_weights()
+        state[f"{source}.weight"] = np.transpose(kernel, (3, 2, 0, 1))
+        state[f"{source}.bias"] = bias
 
-def conv(model, name, source, state):
-    kernel, bias = model.get_layer(name).get_weights()
-    state[f"{source}.weight"] = np.transpose(kernel, (3, 2, 0, 1))
-    state[f"{source}.bias"] = bias
+    def norm(name, source):
+        gamma, beta = model.get_layer(name).get_weights()
+        state[f"{source}.weight"] = gamma
+        state[f"{source}.bias"] = beta
 
-
-def norm(model, name, source, state):
-    gamma, beta = model.get_layer(name).get_weights()
-    state[f"{source}.weight"] = gamma
-    state[f"{source}.bias"] = beta
+    return dense, conv, norm
 
 
 def to_torch_state_dict(bundle):
@@ -46,25 +47,26 @@ def to_torch_state_dict(bundle):
 
 
 def encode_image_encoder(model, state):
-    conv(model, "patch_embed_proj", TRUNK + "patch_embed.proj", state)
+    dense, conv, norm = setters(model, state)
+    conv("patch_embed_proj", TRUNK + "patch_embed.proj")
     background, window = model.get_layer("trunk_pos_embed").get_weights()
     state[TRUNK + "pos_embed"] = background.transpose(2, 0, 1)[None]
     state[TRUNK + "pos_embed_window"] = window.transpose(2, 0, 1)[None]
     specifications, _ = hiera.build_block_specifications(TINY)
     for index, dim, dim_out, _, _, _, name in specifications:
         block = f"{TRUNK}blocks.{index}"
-        norm(model, f"{name}_norm1", f"{block}.norm1", state)
-        norm(model, f"{name}_norm2", f"{block}.norm2", state)
-        dense(model, f"{name}_attn_qkv", f"{block}.attn.qkv", state)
-        dense(model, f"{name}_attn_proj", f"{block}.attn.proj", state)
-        dense(model, f"{name}_mlp_fc1", f"{block}.mlp.layers.0", state)
-        dense(model, f"{name}_mlp_fc2", f"{block}.mlp.layers.1", state)
+        norm(f"{name}_norm1", f"{block}.norm1")
+        norm(f"{name}_norm2", f"{block}.norm2")
+        dense(f"{name}_attn_qkv", f"{block}.attn.qkv")
+        dense(f"{name}_attn_proj", f"{block}.attn.proj")
+        dense(f"{name}_mlp_fc1", f"{block}.mlp.layers.0")
+        dense(f"{name}_mlp_fc2", f"{block}.mlp.layers.1")
         if dim != dim_out:
-            dense(model, f"{name}_proj", f"{block}.proj", state)
+            dense(f"{name}_proj", f"{block}.proj")
     for index in range(4):
-        conv(model, f"neck_conv_{index}", f"{NECK}convs.{index}.conv", state)
-    conv(model, "sam_mask_decoder_conv_s0", DECODER + "conv_s0", state)
-    conv(model, "sam_mask_decoder_conv_s1", DECODER + "conv_s1", state)
+        conv(f"neck_conv_{index}", f"{NECK}convs.{index}.conv")
+    conv("sam_mask_decoder_conv_s0", DECODER + "conv_s0")
+    conv("sam_mask_decoder_conv_s1", DECODER + "conv_s1")
     vector = model.get_layer("no_mem_embed").get_weights()[0]
     state["no_mem_embed"] = vector.reshape(1, 1, -1)
 
@@ -74,81 +76,86 @@ def encode_point_encoder(model, state):
     state[PROMPT + "pe_layer.positional_encoding_gaussian_matrix"] = matrix
     corners, not_a_point = model.get_layer("point_label_embed").get_weights()
     for index in range(4):
-        state[f"{PROMPT}point_embeddings.{index}.weight"] = corners[index:
-                                                                     index + 1]
+        source = f"{PROMPT}point_embeddings.{index}.weight"
+        state[source] = corners[index:index + 1]
     state[PROMPT + "not_a_point_embed.weight"] = not_a_point
 
 
 def encode_mask_downscaling(model, state):
-    conv(model, "mask_down_0", PROMPT + "mask_downscaling.0", state)
-    norm(model, "mask_down_ln0", PROMPT + "mask_downscaling.1", state)
-    conv(model, "mask_down_3", PROMPT + "mask_downscaling.3", state)
-    norm(model, "mask_down_ln3", PROMPT + "mask_downscaling.4", state)
-    conv(model, "mask_down_6", PROMPT + "mask_downscaling.6", state)
+    _, conv, norm = setters(model, state)
+    conv("mask_down_0", PROMPT + "mask_downscaling.0")
+    norm("mask_down_ln0", PROMPT + "mask_downscaling.1")
+    conv("mask_down_3", PROMPT + "mask_downscaling.3")
+    norm("mask_down_ln3", PROMPT + "mask_downscaling.4")
+    conv("mask_down_6", PROMPT + "mask_downscaling.6")
     no_mask = model.get_layer("no_mask_embed").get_weights()[0]
     state[PROMPT + "no_mask_embed.weight"] = no_mask.reshape(1, -1)
 
 
 def encode_mask_decoder(model, state):
-    for name, source in (("obj_score_token", "obj_score_token"),
-                         ("iou_token", "iou_token"),
-                         ("mask_tokens", "mask_tokens")):
-        state[DECODER + f"{source}.weight"] = \
-            model.get_layer(name).get_weights()[0]
+    dense, conv, norm = setters(model, state)
+    for token in ("obj_score_token", "iou_token", "mask_tokens"):
+        state[f"{DECODER}{token}.weight"] = layer_weight(model, token)
     for index in range(2):
-        encode_two_way_block(model, index, state)
-    encode_attention(model, "twoway_final_attn",
-                     TRANSFORMER + "final_attn_token_to_image", state)
-    norm(model, "twoway_norm_final", TRANSFORMER + "norm_final_attn", state)
-    encode_conv_transpose(model, "output_upscaling_0",
-                          DECODER + "output_upscaling.0", state)
-    norm(model, "output_upscaling_1", DECODER + "output_upscaling.1", state)
-    encode_conv_transpose(model, "output_upscaling_3",
-                          DECODER + "output_upscaling.3", state)
+        encode_two_way_block(dense, norm, index, state)
+    encode_attention(dense, "twoway_final_attn", final_source())
+    norm("twoway_norm_final", TRANSFORMER + "norm_final_attn")
+    conv("output_upscaling_0", DECODER + "output_upscaling.0")
+    norm("output_upscaling_1", DECODER + "output_upscaling.1")
+    conv("output_upscaling_3", DECODER + "output_upscaling.3")
     for index in range(4):
-        encode_mlp(model, f"output_hypernetworks_mlps_{index}",
-                   f"{DECODER}output_hypernetworks_mlps.{index}", 3, state)
-    encode_mlp(model, "iou_prediction_head",
-               DECODER + "iou_prediction_head", 3, state)
-    encode_mlp(model, "pred_obj_score_head",
-               DECODER + "pred_obj_score_head", 3, state)
+        name = f"output_hypernetworks_mlps_{index}"
+        source = f"{DECODER}output_hypernetworks_mlps.{index}"
+        encode_mlp(dense, name, source, 3)
+    encode_mlp(dense, "iou_prediction_head", DECODER + "iou_prediction_head", 3)
+    encode_mlp(dense, "pred_obj_score_head", DECODER + "pred_obj_score_head", 3)
 
 
-def encode_two_way_block(model, index, state):
+def encode_two_way_block(dense, norm, index, state):
     block = f"{TRANSFORMER}layers.{index}"
     name = f"twoway_{index}"
-    encode_attention(model, f"{name}_self", f"{block}.self_attn", state)
-    encode_attention(model, f"{name}_cross_t2i",
-                     f"{block}.cross_attn_token_to_image", state)
-    encode_attention(model, f"{name}_cross_i2t",
-                     f"{block}.cross_attn_image_to_token", state)
-    encode_mlp(model, f"{name}_mlp", f"{block}.mlp", 2, state)
+    encode_attention(dense, f"{name}_self", f"{block}.self_attn")
+    t2i = f"{block}.cross_attn_token_to_image"
+    i2t = f"{block}.cross_attn_image_to_token"
+    encode_attention(dense, f"{name}_cross_t2i", t2i)
+    encode_attention(dense, f"{name}_cross_i2t", i2t)
+    encode_mlp(dense, f"{name}_mlp", f"{block}.mlp", 2)
     for number in range(1, 5):
-        norm(model, f"{name}_norm{number}", f"{block}.norm{number}", state)
+        norm(f"{name}_norm{number}", f"{block}.norm{number}")
 
 
-def encode_attention(model, name, source, state):
+def encode_attention(dense, name, source):
     for part in ("q", "k", "v", "out"):
-        dense(model, f"{name}_{part}", f"{source}.{part}_proj", state)
+        dense(f"{name}_{part}", f"{source}.{part}_proj")
 
 
-def encode_mlp(model, name, source, layers, state):
+def encode_mlp(dense, name, source, layers):
     for index in range(layers):
-        dense(model, f"{name}_layers_{index}", f"{source}.layers.{index}",
-              state)
+        dense(f"{name}_layers_{index}", f"{source}.layers.{index}")
 
 
-def encode_conv_transpose(model, name, source, state):
-    kernel, bias = model.get_layer(name).get_weights()
-    state[f"{source}.weight"] = np.transpose(kernel, (3, 2, 0, 1))
-    state[f"{source}.bias"] = bias
+def final_source():
+    return TRANSFORMER + "final_attn_token_to_image"
+
+
+def layer_weight(model, name):
+    return model.get_layer(name).get_weights()[0]
 
 
 def randomize(bundle):
     generator = np.random.RandomState(1)
     for model in bundle[:4]:
-        model.set_weights([generator.randn(*w.shape).astype("float32") * 0.05
-                           for w in model.get_weights()])
+        weights = [generator.randn(*w.shape) for w in model.get_weights()]
+        model.set_weights([w.astype("float32") * 0.05 for w in weights])
+
+
+def decoder_inputs():
+    embed = np.zeros((1, 64, 64, 256), np.float32)
+    high_res_0 = np.zeros((1, 256, 256, 32), np.float32)
+    high_res_1 = np.zeros((1, 128, 128, 64), np.float32)
+    sparse = np.zeros((1, 2, 256), np.float32)
+    dense = np.zeros((1, 64, 64, 256), np.float32)
+    return [embed, high_res_0, high_res_1, sparse, dense, embed]
 
 
 def test_converter_reproduces_source():
@@ -159,14 +166,8 @@ def test_converter_reproduces_source():
     used = set()
     convert.convert(target, state, used)
     assert used == set(state)
-    inputs = [np.zeros((1, 64, 64, 256), np.float32),
-              np.zeros((1, 256, 256, 32), np.float32),
-              np.zeros((1, 128, 128, 64), np.float32),
-              np.zeros((1, 2, 256), np.float32),
-              np.zeros((1, 64, 64, 256), np.float32),
-              np.zeros((1, 64, 64, 256), np.float32)]
-    expected = np.array(source.mask_decoder(inputs)[0])
-    result = np.array(target.mask_decoder(inputs)[0])
+    expected = np.array(source.mask_decoder(decoder_inputs())[0])
+    result = np.array(target.mask_decoder(decoder_inputs())[0])
     assert np.allclose(expected, result, atol=1e-5)
 
 
@@ -178,7 +179,7 @@ def test_converter_rejects_missing_key():
         convert.convert(sam2_model.build(TINY), state)
 
 
-def test_converter_rejects_unexpected_key():
+def test_converter_rejects_unmapped_image_key():
     bundle = sam2_model.build(TINY)
     state = to_torch_state_dict(bundle)
     state["sam_mask_decoder.surprise"] = np.zeros((2,), np.float32)

--- a/paz/models/foundation/sam2/hiera.py
+++ b/paz/models/foundation/sam2/hiera.py
@@ -10,43 +10,48 @@ from keras import ops
 from keras.layers import Conv2D, Dense, LayerNormalization
 from keras.layers import MaxPooling2D, ZeroPadding2D, Layer
 
-from paz.models.transformers.attention import compute_attention, kernel
+from paz.models.transformers.attention import compute_attention
 from paz.models.transformers import feedforward
-from paz.models.foundation.sam2 import configuration as config
+from paz.models.foundation.sam2 import configuration as cfg
 from paz.models.foundation.sam2.windows import window_partition
 from paz.models.foundation.sam2.windows import window_unpartition
 
 
 @keras.saving.register_keras_serializable(package="paz")
 class HieraPositionEmbedding(Layer):
-    def __init__(self, hidden_size, background_size, window, **kwargs):
+    def __init__(self, hidden_size, background, window, **kwargs):
         super().__init__(**kwargs)
         self.hidden_size = hidden_size
-        self.background_size = tuple(background_size)
+        self.background = tuple(background)
         self.window = window
 
     def build(self, input_shape):
-        background = (*self.background_size, self.hidden_size)
+        background = (*self.background, self.hidden_size)
         window = (self.window, self.window, self.hidden_size)
-        self.background = self.add_weight(
-            name="background", shape=background, initializer="zeros")
-        self.window_embed = self.add_weight(
-            name="window", shape=window, initializer="zeros")
+        self.background_table = self.zeros("background", background)
+        self.window_table = self.zeros("window", window)
+
+    def zeros(self, name, shape):
+        return self.add_weight(name=name, shape=shape, initializer="zeros")
 
     def call(self, x):
         height, width = x.shape[1], x.shape[2]
-        rows = bicubic_resize_matrix(self.background_size[0], height)
-        columns = bicubic_resize_matrix(self.background_size[1], width)
-        background = ops.einsum("hn,nmc->hmc", rows, self.background)
+        rows = bicubic_resize_matrix(self.background[0], height)
+        columns = bicubic_resize_matrix(self.background[1], width)
+        background = ops.einsum("hn,nmc->hmc", rows, self.background_table)
         background = ops.einsum("wm,hmc->hwc", columns, background)
-        tiles = (height // self.window, width // self.window, 1)
-        window = ops.tile(self.window_embed, tiles)
+        window = ops.tile(self.window_table, self.tiles(height, width))
         return x + background + window
 
+    def tiles(self, height, width):
+        return (height // self.window, width // self.window, 1)
+
     def get_config(self):
-        arguments = dict(hidden_size=self.hidden_size, window=self.window,
-                         background_size=self.background_size)
-        return {**super().get_config(), **arguments}
+        config = super().get_config()
+        config["hidden_size"] = self.hidden_size
+        config["background"] = self.background
+        config["window"] = self.window
+        return config
 
 
 def bicubic_resize_matrix(source, target, coefficient=-0.75):
@@ -65,19 +70,25 @@ def bicubic_resize_matrix(source, target, coefficient=-0.75):
 def cubic_weight(distance, coefficient):
     distance = abs(distance)
     if distance <= 1:
-        return ((coefficient + 2) * distance - (coefficient + 3)) \
-            * distance * distance + 1
+        return near_cubic(distance, coefficient)
     if distance < 2:
-        return coefficient * (((distance - 5) * distance + 8) * distance - 4)
+        return far_cubic(distance, coefficient)
     return 0.0
 
 
-def build(images, model_config):
-    tokens = build_patch_embedding(images, model_config.embed_dim)
-    tokens = HieraPositionEmbedding(
-        model_config.embed_dim, model_config.background_size,
-        model_config.window_spec[0], name="trunk_pos_embed")(tokens)
-    specifications, stage_ends = build_block_specifications(model_config)
+def near_cubic(t, a):
+    return ((a + 2) * t - (a + 3)) * t * t + 1
+
+
+def far_cubic(t, a):
+    return a * (((t - 5) * t + 8) * t - 4)
+
+
+def build(images, config):
+    tokens = build_patch_embedding(images, config.embed_dim)
+    args = config.embed_dim, config.background, config.window_spec[0]
+    tokens = HieraPositionEmbedding(*args, name="trunk_pos_embed")(tokens)
+    specifications, stage_ends = build_block_specifications(config)
     outputs = []
     for specification in specifications:
         tokens = apply_block(tokens, *specification)
@@ -88,34 +99,33 @@ def build(images, model_config):
 
 def build_patch_embedding(images, hidden_size):
     padded = ZeroPadding2D(3, name="patch_embed_pad")(images)
-    kwargs = dict(strides=4, padding="valid", kernel_initializer=kernel(),
-                  name="patch_embed_proj")
+    kwargs = dict(strides=4, padding="valid", name="patch_embed_proj")
     return Conv2D(hidden_size, 7, **kwargs)(padded)
 
 
-def build_block_specifications(model_config):
-    stages = model_config.stages
-    global_blocks = set(model_config.global_attention_blocks)
+def build_block_specifications(config):
+    stages = config.stages
+    global_blocks = set(config.global_blocks)
     stage_ends = [sum(stages[:i]) - 1 for i in range(1, len(stages) + 1)]
     starts = [end + 1 for end in stage_ends[:-1]]
-    pool_blocks = starts[:config.QUERY_POOL_STAGES]
-    embed_dim = model_config.embed_dim
-    num_heads = model_config.num_heads
+    pool_blocks = starts[:cfg.QUERY_POOL_STAGES]
+    embed_dim = config.embed_dim
+    num_heads = config.num_heads
     current_stage = 1
     specifications = []
     for index in range(sum(stages)):
         dim, dim_out = embed_dim, embed_dim
-        window = model_config.window_spec[current_stage - 1]
+        window = config.window_spec[current_stage - 1]
         if index in global_blocks:
             window = 0
         if (index - 1) in stage_ends:
-            dim_out = embed_dim * config.DIM_MUL
-            num_heads = num_heads * config.HEAD_MUL
+            dim_out = embed_dim * cfg.DIM_MUL
+            num_heads = num_heads * cfg.HEAD_MUL
             current_stage = current_stage + 1
         pool = index in pool_blocks
         name = f"trunk_block_{index}"
-        specifications.append((index, dim, dim_out, num_heads, window, pool,
-                               name))
+        spec = index, dim, dim_out, num_heads, window, pool, name
+        specifications.append(spec)
         embed_dim = dim_out
     return specifications, stage_ends
 
@@ -124,8 +134,7 @@ def apply_block(x, index, dim, dim_out, num_heads, window, pool, name):
     shortcut = x
     normed = LayerNormalization(epsilon=1e-6, name=f"{name}_norm1")(x)
     if dim != dim_out:
-        projected = Dense(dim_out, kernel_initializer=kernel(),
-                          name=f"{name}_proj")(normed)
+        projected = Dense(dim_out, name=f"{name}_proj")(normed)
         shortcut = pool_spatial(projected) if pool else projected
     height, width = normed.shape[1], normed.shape[2]
     padded_size = (height, width)
@@ -133,12 +142,12 @@ def apply_block(x, index, dim, dim_out, num_heads, window, pool, name):
         normed, padded_size = window_partition(normed, window)
     attended = apply_attention(normed, dim_out, num_heads, pool, f"{name}_attn")
     if pool:
-        window = window // config.QUERY_STRIDE[0]
+        window = window // cfg.QUERY_STRIDE[0]
         height, width = shortcut.shape[1], shortcut.shape[2]
         padded_size = padded_after_pool(height, width, window)
     if window > 0:
-        attended = window_unpartition(attended, window, padded_size,
-                                      (height, width))
+        size = (height, width)
+        attended = window_unpartition(attended, window, padded_size, size)
     tokens = ops.add(shortcut, attended)
     return apply_feedforward(tokens, dim_out, name)
 
@@ -146,8 +155,7 @@ def apply_block(x, index, dim, dim_out, num_heads, window, pool, name):
 def apply_attention(x, dim_out, num_heads, pool, name):
     height, width = x.shape[1], x.shape[2]
     head_dim = dim_out // num_heads
-    fused = Dense(dim_out * 3, kernel_initializer=kernel(),
-                  name=f"{name}_qkv")(x)
+    fused = Dense(dim_out * 3, name=f"{name}_qkv")(x)
     fused = ops.reshape(fused, (-1, height * width, 3, num_heads, head_dim))
     query, key, value = fused[:, :, 0], fused[:, :, 1], fused[:, :, 2]
     if pool:
@@ -161,21 +169,20 @@ def apply_attention(x, dim_out, num_heads, pool, name):
     context = compute_attention(query, key, value)
     context = ops.transpose(context, (0, 2, 1, 3))
     context = ops.reshape(context, (-1, height, width, dim_out))
-    return Dense(dim_out, kernel_initializer=kernel(),
-                 name=f"{name}_proj")(context)
+    return Dense(dim_out, name=f"{name}_proj")(context)
 
 
 def apply_feedforward(tokens, dim_out, name):
     normed = LayerNormalization(epsilon=1e-6, name=f"{name}_norm2")(tokens)
-    inner = int(dim_out * config.MLP_RATIO)
+    inner = int(dim_out * cfg.MLP_RATIO)
     names = f"{name}_mlp_fc1", f"{name}_mlp_fc2"
     forwarded = feedforward.gelu(normed, inner, dim_out, *names)
     return ops.add(tokens, forwarded)
 
 
 def pool_spatial(x):
-    return MaxPooling2D(config.QUERY_STRIDE, config.QUERY_STRIDE,
-                        padding="valid")(x)
+    stride = cfg.QUERY_STRIDE
+    return MaxPooling2D(stride, stride, padding="valid")(x)
 
 
 def padded_after_pool(height, width, window):

--- a/paz/models/foundation/sam2/hiera.py
+++ b/paz/models/foundation/sam2/hiera.py
@@ -1,0 +1,184 @@
+"""Hiera multiscale image backbone for SAM 2 (channels-last, functional).
+
+Reuses the shared attention scaling from ``paz.models.transformers`` and the
+GELU feedforward. Query pooling, window attention, and the interpolated
+windowed positional embedding are SAM-specific and stay local.
+"""
+import keras
+import numpy as np
+from keras import ops
+from keras.layers import Conv2D, Dense, LayerNormalization
+from keras.layers import MaxPooling2D, ZeroPadding2D, Layer
+
+from paz.models.transformers.attention import compute_attention, kernel
+from paz.models.transformers import feedforward
+from paz.models.foundation.sam2 import configuration as config
+from paz.models.foundation.sam2.windows import window_partition
+from paz.models.foundation.sam2.windows import window_unpartition
+
+
+@keras.saving.register_keras_serializable(package="paz")
+class HieraPositionEmbedding(Layer):
+    def __init__(self, hidden_size, background_size, window, **kwargs):
+        super().__init__(**kwargs)
+        self.hidden_size = hidden_size
+        self.background_size = tuple(background_size)
+        self.window = window
+
+    def build(self, input_shape):
+        background = (*self.background_size, self.hidden_size)
+        window = (self.window, self.window, self.hidden_size)
+        self.background = self.add_weight(
+            name="background", shape=background, initializer="zeros")
+        self.window_embed = self.add_weight(
+            name="window", shape=window, initializer="zeros")
+
+    def call(self, x):
+        height, width = x.shape[1], x.shape[2]
+        rows = bicubic_resize_matrix(self.background_size[0], height)
+        columns = bicubic_resize_matrix(self.background_size[1], width)
+        background = ops.einsum("hn,nmc->hmc", rows, self.background)
+        background = ops.einsum("wm,hmc->hwc", columns, background)
+        tiles = (height // self.window, width // self.window, 1)
+        window = ops.tile(self.window_embed, tiles)
+        return x + background + window
+
+    def get_config(self):
+        arguments = dict(hidden_size=self.hidden_size, window=self.window,
+                         background_size=self.background_size)
+        return {**super().get_config(), **arguments}
+
+
+def bicubic_resize_matrix(source, target, coefficient=-0.75):
+    scale = source / target
+    matrix = np.zeros((target, source), np.float32)
+    for row in range(target):
+        center = (row + 0.5) * scale - 0.5
+        left = int(np.floor(center))
+        fraction = center - left
+        for offset in (-1, 0, 1, 2):
+            column = min(max(left + offset, 0), source - 1)
+            matrix[row, column] += cubic_weight(fraction - offset, coefficient)
+    return matrix
+
+
+def cubic_weight(distance, coefficient):
+    distance = abs(distance)
+    if distance <= 1:
+        return ((coefficient + 2) * distance - (coefficient + 3)) \
+            * distance * distance + 1
+    if distance < 2:
+        return coefficient * (((distance - 5) * distance + 8) * distance - 4)
+    return 0.0
+
+
+def build(images, model_config):
+    tokens = build_patch_embedding(images, model_config.embed_dim)
+    tokens = HieraPositionEmbedding(
+        model_config.embed_dim, model_config.background_size,
+        model_config.window_spec[0], name="trunk_pos_embed")(tokens)
+    specifications, stage_ends = build_block_specifications(model_config)
+    outputs = []
+    for specification in specifications:
+        tokens = apply_block(tokens, *specification)
+        if specification[0] in stage_ends:
+            outputs.append(tokens)
+    return outputs
+
+
+def build_patch_embedding(images, hidden_size):
+    padded = ZeroPadding2D(3, name="patch_embed_pad")(images)
+    kwargs = dict(strides=4, padding="valid", kernel_initializer=kernel(),
+                  name="patch_embed_proj")
+    return Conv2D(hidden_size, 7, **kwargs)(padded)
+
+
+def build_block_specifications(model_config):
+    stages = model_config.stages
+    global_blocks = set(model_config.global_attention_blocks)
+    stage_ends = [sum(stages[:i]) - 1 for i in range(1, len(stages) + 1)]
+    starts = [end + 1 for end in stage_ends[:-1]]
+    pool_blocks = starts[:config.QUERY_POOL_STAGES]
+    embed_dim = model_config.embed_dim
+    num_heads = model_config.num_heads
+    current_stage = 1
+    specifications = []
+    for index in range(sum(stages)):
+        dim, dim_out = embed_dim, embed_dim
+        window = model_config.window_spec[current_stage - 1]
+        if index in global_blocks:
+            window = 0
+        if (index - 1) in stage_ends:
+            dim_out = embed_dim * config.DIM_MUL
+            num_heads = num_heads * config.HEAD_MUL
+            current_stage = current_stage + 1
+        pool = index in pool_blocks
+        name = f"trunk_block_{index}"
+        specifications.append((index, dim, dim_out, num_heads, window, pool,
+                               name))
+        embed_dim = dim_out
+    return specifications, stage_ends
+
+
+def apply_block(x, index, dim, dim_out, num_heads, window, pool, name):
+    shortcut = x
+    normed = LayerNormalization(epsilon=1e-6, name=f"{name}_norm1")(x)
+    if dim != dim_out:
+        projected = Dense(dim_out, kernel_initializer=kernel(),
+                          name=f"{name}_proj")(normed)
+        shortcut = pool_spatial(projected) if pool else projected
+    height, width = normed.shape[1], normed.shape[2]
+    padded_size = (height, width)
+    if window > 0:
+        normed, padded_size = window_partition(normed, window)
+    attended = apply_attention(normed, dim_out, num_heads, pool, f"{name}_attn")
+    if pool:
+        window = window // config.QUERY_STRIDE[0]
+        height, width = shortcut.shape[1], shortcut.shape[2]
+        padded_size = padded_after_pool(height, width, window)
+    if window > 0:
+        attended = window_unpartition(attended, window, padded_size,
+                                      (height, width))
+    tokens = ops.add(shortcut, attended)
+    return apply_feedforward(tokens, dim_out, name)
+
+
+def apply_attention(x, dim_out, num_heads, pool, name):
+    height, width = x.shape[1], x.shape[2]
+    head_dim = dim_out // num_heads
+    fused = Dense(dim_out * 3, kernel_initializer=kernel(),
+                  name=f"{name}_qkv")(x)
+    fused = ops.reshape(fused, (-1, height * width, 3, num_heads, head_dim))
+    query, key, value = fused[:, :, 0], fused[:, :, 1], fused[:, :, 2]
+    if pool:
+        query = ops.reshape(query, (-1, height, width, dim_out))
+        query = pool_spatial(query)
+        height, width = height // 2, width // 2
+        query = ops.reshape(query, (-1, height * width, num_heads, head_dim))
+    query = ops.transpose(query, (0, 2, 1, 3))
+    key = ops.transpose(key, (0, 2, 1, 3))
+    value = ops.transpose(value, (0, 2, 1, 3))
+    context = compute_attention(query, key, value)
+    context = ops.transpose(context, (0, 2, 1, 3))
+    context = ops.reshape(context, (-1, height, width, dim_out))
+    return Dense(dim_out, kernel_initializer=kernel(),
+                 name=f"{name}_proj")(context)
+
+
+def apply_feedforward(tokens, dim_out, name):
+    normed = LayerNormalization(epsilon=1e-6, name=f"{name}_norm2")(tokens)
+    inner = int(dim_out * config.MLP_RATIO)
+    names = f"{name}_mlp_fc1", f"{name}_mlp_fc2"
+    forwarded = feedforward.gelu(normed, inner, dim_out, *names)
+    return ops.add(tokens, forwarded)
+
+
+def pool_spatial(x):
+    return MaxPooling2D(config.QUERY_STRIDE, config.QUERY_STRIDE,
+                        padding="valid")(x)
+
+
+def padded_after_pool(height, width, window):
+    pad_h = (window - height % window) % window
+    pad_w = (window - width % window) % window
+    return (height + pad_h, width + pad_w)

--- a/paz/models/foundation/sam2/image_encoder.py
+++ b/paz/models/foundation/sam2/image_encoder.py
@@ -1,0 +1,24 @@
+"""SAM 2 image encoder: Hiera trunk, FPN neck, and SAM decoder projections.
+
+Outputs the 64x64 image embedding (with ``no_mem_embed`` added, as the image
+predictor does) and the two high-resolution features that the mask decoder
+fuses. The 1x1 ``conv_s0``/``conv_s1`` projections belong to the mask decoder
+in the checkpoint but run here once per image, matching ``forward_image``.
+"""
+from keras import Input, Model
+from keras.layers import Conv2D
+
+from paz.models.foundation.sam2 import hiera, neck
+from paz.models.foundation.sam2.configuration import IMAGE_SIZE
+from paz.models.foundation.sam2.layers import ChannelBias
+
+
+def build(config, name="sam2_image_encoder"):
+    images = Input((IMAGE_SIZE, IMAGE_SIZE, 3), name="pixels")
+    trunk = hiera.build(images, config)
+    features = neck.build(trunk)[:3]
+    high_res_0 = Conv2D(32, 1, name="sam_mask_decoder_conv_s0")(features[0])
+    high_res_1 = Conv2D(64, 1, name="sam_mask_decoder_conv_s1")(features[1])
+    embedding = ChannelBias(256, name="no_mem_embed")(features[2])
+    outputs = (embedding, high_res_0, high_res_1)
+    return Model(images, outputs, name=name)

--- a/paz/models/foundation/sam2/layers.py
+++ b/paz/models/foundation/sam2/layers.py
@@ -1,7 +1,8 @@
 """Small serializable layers that own SAM 2 weights not covered by Keras.
 
 ``ChannelBias`` adds a learned per-channel vector, used for ``no_mem_embed``
-and for the mask decoder's dense no-mask embedding.
+and the dense no-mask embedding. ``BroadcastTokens`` broadcasts a learned
+token table across the batch of a reference tensor.
 """
 import keras
 from keras import ops
@@ -16,14 +17,14 @@ class BroadcastTokens(Layer):
         self.hidden_size = hidden_size
 
     def build(self, input_shape):
-        self.tokens = self.add_weight(
-            name="tokens", shape=(self.count, self.hidden_size),
-            initializer="zeros")
+        shape = (self.count, self.hidden_size)
+        kwargs = dict(name="tokens", shape=shape, initializer="zeros")
+        self.tokens = self.add_weight(**kwargs)
 
     def call(self, reference):
         batch = ops.shape(reference)[0]
-        return ops.broadcast_to(
-            self.tokens[None], (batch, self.count, self.hidden_size))
+        shape = (batch, self.count, self.hidden_size)
+        return ops.broadcast_to(self.tokens[None], shape)
 
     def compute_output_shape(self, input_shape):
         return (input_shape[0], self.count, self.hidden_size)
@@ -40,8 +41,9 @@ class ChannelBias(Layer):
         self.channels = channels
 
     def build(self, input_shape):
-        self.bias = self.add_weight(
-            name="bias", shape=(self.channels,), initializer="zeros")
+        shape = (self.channels,)
+        kwargs = dict(name="bias", shape=shape, initializer="zeros")
+        self.bias = self.add_weight(**kwargs)
 
     def call(self, x):
         return x + self.bias

--- a/paz/models/foundation/sam2/layers.py
+++ b/paz/models/foundation/sam2/layers.py
@@ -1,0 +1,50 @@
+"""Small serializable layers that own SAM 2 weights not covered by Keras.
+
+``ChannelBias`` adds a learned per-channel vector, used for ``no_mem_embed``
+and for the mask decoder's dense no-mask embedding.
+"""
+import keras
+from keras import ops
+from keras.layers import Layer
+
+
+@keras.saving.register_keras_serializable(package="paz")
+class BroadcastTokens(Layer):
+    def __init__(self, count, hidden_size, **kwargs):
+        super().__init__(**kwargs)
+        self.count = count
+        self.hidden_size = hidden_size
+
+    def build(self, input_shape):
+        self.tokens = self.add_weight(
+            name="tokens", shape=(self.count, self.hidden_size),
+            initializer="zeros")
+
+    def call(self, reference):
+        batch = ops.shape(reference)[0]
+        return ops.broadcast_to(
+            self.tokens[None], (batch, self.count, self.hidden_size))
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], self.count, self.hidden_size)
+
+    def get_config(self):
+        arguments = dict(count=self.count, hidden_size=self.hidden_size)
+        return {**super().get_config(), **arguments}
+
+
+@keras.saving.register_keras_serializable(package="paz")
+class ChannelBias(Layer):
+    def __init__(self, channels, **kwargs):
+        super().__init__(**kwargs)
+        self.channels = channels
+
+    def build(self, input_shape):
+        self.bias = self.add_weight(
+            name="bias", shape=(self.channels,), initializer="zeros")
+
+    def call(self, x):
+        return x + self.bias
+
+    def get_config(self):
+        return {**super().get_config(), "channels": self.channels}

--- a/paz/models/foundation/sam2/mask_decoder.py
+++ b/paz/models/foundation/sam2/mask_decoder.py
@@ -1,0 +1,144 @@
+"""SAM 2 mask decoder: two-way transformer, upscaling, and prediction heads.
+
+Reuses ``compute_attention`` from ``paz.models.transformers`` for scaled
+dot-product attention. Output tokens (object-score, IoU, and four mask
+tokens) attend to the image embedding and back; a hypernetwork projects the
+mask tokens onto the upscaled features to produce four low-resolution masks.
+"""
+from keras import Input, Model, ops
+from keras.layers import Conv2DTranspose, Dense, LayerNormalization, Reshape
+
+from paz.models.transformers.attention import compute_attention
+from paz.models.foundation.sam2.configuration import PROMPT_EMBED_DIM
+from paz.models.foundation.sam2.layers import BroadcastTokens
+from paz.models.foundation.sam2.prompt_encoder import GRID
+
+NUM_HEADS = 8
+NUM_MASK_TOKENS = 4
+TOKENS = 6
+
+
+def build(name="sam2_mask_decoder"):
+    embed = Input((GRID, GRID, PROMPT_EMBED_DIM), name="image_embed")
+    high_res_0 = Input((256, 256, 32), name="high_res_0")
+    high_res_1 = Input((128, 128, 64), name="high_res_1")
+    sparse = Input((None, PROMPT_EMBED_DIM), name="sparse")
+    dense = Input((GRID, GRID, PROMPT_EMBED_DIM), name="dense")
+    image_pe = Input((GRID, GRID, PROMPT_EMBED_DIM), name="image_pe")
+
+    tokens = build_output_tokens(sparse)
+    source = flatten(ops.add(embed, dense))
+    positions = flatten(image_pe)
+    queries, keys = two_way_transformer(source, positions, tokens)
+    upscaled = upscale(reshape_to_grid(keys), high_res_0, high_res_1)
+    masks = hypernetwork(queries[:, 2:TOKENS], upscaled)
+    iou = mlp(queries[:, 1], 256, NUM_MASK_TOKENS, 3, "iou_prediction_head",
+              sigmoid=True)
+    obj = mlp(queries[:, 0], 256, 1, 3, "pred_obj_score_head")
+    inputs = (embed, high_res_0, high_res_1, sparse, dense, image_pe)
+    return Model(inputs, (masks, iou, obj), name=name)
+
+
+def build_output_tokens(sparse):
+    obj = BroadcastTokens(1, PROMPT_EMBED_DIM, name="obj_score_token")(sparse)
+    iou = BroadcastTokens(1, PROMPT_EMBED_DIM, name="iou_token")(sparse)
+    mask = BroadcastTokens(NUM_MASK_TOKENS, PROMPT_EMBED_DIM,
+                           name="mask_tokens")(sparse)
+    return ops.concatenate([obj, iou, mask, sparse], axis=1)
+
+
+def two_way_transformer(source, positions, tokens):
+    queries, keys = tokens, source
+    for index in range(2):
+        queries, keys = two_way_block(queries, keys, tokens, positions, index)
+    query = ops.add(queries, tokens)
+    key = ops.add(keys, positions)
+    attended = attention(query, key, keys, 2, "twoway_final_attn")
+    queries = ops.add(queries, attended)
+    queries = normalize(queries, "twoway_norm_final")
+    return queries, keys
+
+
+def two_way_block(queries, keys, query_pe, key_pe, index):
+    name = f"twoway_{index}"
+    if index == 0:
+        queries = attention(queries, queries, queries, 1, f"{name}_self")
+    else:
+        query = ops.add(queries, query_pe)
+        attended = attention(query, query, queries, 1, f"{name}_self")
+        queries = ops.add(queries, attended)
+    queries = normalize(queries, f"{name}_norm1")
+    query = ops.add(queries, query_pe)
+    key = ops.add(keys, key_pe)
+    attended = attention(query, key, keys, 2, f"{name}_cross_t2i")
+    queries = normalize(ops.add(queries, attended), f"{name}_norm2")
+    forwarded = mlp(queries, 2048, PROMPT_EMBED_DIM, 2, f"{name}_mlp")
+    queries = normalize(ops.add(queries, forwarded), f"{name}_norm3")
+    query = ops.add(queries, query_pe)
+    key = ops.add(keys, key_pe)
+    attended = attention(key, query, queries, 2, f"{name}_cross_i2t")
+    keys = normalize(ops.add(keys, attended), f"{name}_norm4")
+    return queries, keys
+
+
+def attention(query, key, value, downsample, name):
+    internal = PROMPT_EMBED_DIM // downsample
+    head_dim = internal // NUM_HEADS
+    query = split_heads(Dense(internal, name=f"{name}_q")(query), head_dim)
+    key = split_heads(Dense(internal, name=f"{name}_k")(key), head_dim)
+    value = split_heads(Dense(internal, name=f"{name}_v")(value), head_dim)
+    context = compute_attention(query, key, value)
+    context = merge_heads(context, internal)
+    return Dense(PROMPT_EMBED_DIM, name=f"{name}_out")(context)
+
+
+def split_heads(x, head_dim):
+    x = Reshape((-1, NUM_HEADS, head_dim))(x)
+    return ops.transpose(x, (0, 2, 1, 3))
+
+
+def merge_heads(context, internal):
+    context = ops.transpose(context, (0, 2, 1, 3))
+    return Reshape((-1, internal))(context)
+
+
+def upscale(source, high_res_0, high_res_1):
+    x = Conv2DTranspose(64, 2, strides=2, name="output_upscaling_0")(source)
+    x = normalize_channels(ops.add(x, high_res_1), "output_upscaling_1")
+    x = ops.gelu(x, approximate=False)
+    x = Conv2DTranspose(32, 2, strides=2, name="output_upscaling_3")(x)
+    x = ops.gelu(ops.add(x, high_res_0), approximate=False)
+    return x
+
+
+def hypernetwork(mask_tokens, upscaled):
+    projections = []
+    for index in range(NUM_MASK_TOKENS):
+        token = mask_tokens[:, index]
+        name = f"output_hypernetworks_mlps_{index}"
+        projections.append(mlp(token, 256, 32, 3, name))
+    weights = ops.stack(projections, axis=1)
+    return ops.einsum("bkc,bhwc->bkhw", weights, upscaled)
+
+
+def mlp(x, hidden, output, layers, name, sigmoid=False):
+    for index in range(layers - 1):
+        x = Dense(hidden, activation="relu", name=f"{name}_layers_{index}")(x)
+    x = Dense(output, name=f"{name}_layers_{layers - 1}")(x)
+    return ops.sigmoid(x) if sigmoid else x
+
+
+def flatten(x):
+    return ops.reshape(x, (-1, GRID * GRID, PROMPT_EMBED_DIM))
+
+
+def reshape_to_grid(x):
+    return ops.reshape(x, (-1, GRID, GRID, PROMPT_EMBED_DIM))
+
+
+def normalize(x, name):
+    return LayerNormalization(epsilon=1e-5, name=name)(x)
+
+
+def normalize_channels(x, name):
+    return LayerNormalization(axis=-1, epsilon=1e-6, name=name)(x)

--- a/paz/models/foundation/sam2/mask_decoder.py
+++ b/paz/models/foundation/sam2/mask_decoder.py
@@ -32,19 +32,22 @@ def build(name="sam2_mask_decoder"):
     queries, keys = two_way_transformer(source, positions, tokens)
     upscaled = upscale(reshape_to_grid(keys), high_res_0, high_res_1)
     masks = hypernetwork(queries[:, 2:TOKENS], upscaled)
-    iou = mlp(queries[:, 1], 256, NUM_MASK_TOKENS, 3, "iou_prediction_head",
-              sigmoid=True)
+    iou_args = queries[:, 1], 256, NUM_MASK_TOKENS, 3, "iou_prediction_head"
+    iou = mlp(*iou_args, sigmoid=True)
     obj = mlp(queries[:, 0], 256, 1, 3, "pred_obj_score_head")
     inputs = (embed, high_res_0, high_res_1, sparse, dense, image_pe)
     return Model(inputs, (masks, iou, obj), name=name)
 
 
 def build_output_tokens(sparse):
-    obj = BroadcastTokens(1, PROMPT_EMBED_DIM, name="obj_score_token")(sparse)
-    iou = BroadcastTokens(1, PROMPT_EMBED_DIM, name="iou_token")(sparse)
-    mask = BroadcastTokens(NUM_MASK_TOKENS, PROMPT_EMBED_DIM,
-                           name="mask_tokens")(sparse)
+    obj = output_token(1, "obj_score_token", sparse)
+    iou = output_token(1, "iou_token", sparse)
+    mask = output_token(NUM_MASK_TOKENS, "mask_tokens", sparse)
     return ops.concatenate([obj, iou, mask, sparse], axis=1)
+
+
+def output_token(count, name, reference):
+    return BroadcastTokens(count, PROMPT_EMBED_DIM, name=name)(reference)
 
 
 def two_way_transformer(source, positions, tokens):

--- a/paz/models/foundation/sam2/model.py
+++ b/paz/models/foundation/sam2/model.py
@@ -1,0 +1,22 @@
+"""Assemble the four SAM 2 image-inference sub-models into one bundle.
+
+The image encoder runs once per image; the point encoder, mask downscaling,
+and mask decoder run per prompt. Keeping them separate mirrors the official
+predictor's set-image / predict split and keeps each weight set serializable.
+"""
+from collections import namedtuple
+
+from paz.models.foundation.sam2 import image_encoder, prompt_encoder
+from paz.models.foundation.sam2 import mask_decoder
+
+SAM2 = namedtuple(
+    "SAM2", "image_encoder point_encoder mask_downscaling mask_decoder config")
+
+
+def build(config):
+    return SAM2(
+        image_encoder.build(config),
+        prompt_encoder.build_points(),
+        prompt_encoder.build_mask_downscaling(),
+        mask_decoder.build(),
+        config)

--- a/paz/models/foundation/sam2/model.py
+++ b/paz/models/foundation/sam2/model.py
@@ -9,14 +9,13 @@ from collections import namedtuple
 from paz.models.foundation.sam2 import image_encoder, prompt_encoder
 from paz.models.foundation.sam2 import mask_decoder
 
-SAM2 = namedtuple(
-    "SAM2", "image_encoder point_encoder mask_downscaling mask_decoder config")
+FIELDS = "image_encoder point_encoder mask_downscaling mask_decoder config"
+SAM2 = namedtuple("SAM2", FIELDS)
 
 
 def build(config):
-    return SAM2(
-        image_encoder.build(config),
-        prompt_encoder.build_points(),
-        prompt_encoder.build_mask_downscaling(),
-        mask_decoder.build(),
-        config)
+    encoder = image_encoder.build(config)
+    points = prompt_encoder.build_points()
+    downscaling = prompt_encoder.build_mask_downscaling()
+    decoder = mask_decoder.build()
+    return SAM2(encoder, points, downscaling, decoder, config)

--- a/paz/models/foundation/sam2/neck.py
+++ b/paz/models/foundation/sam2/neck.py
@@ -1,0 +1,31 @@
+"""FPN neck for SAM 2 (channels-last, functional).
+
+Lateral 1x1 convolutions to ``d_model`` with top-down 2x nearest fusion on
+the two lowest-resolution levels, matching the official ``FpnNeck``. The
+sinusoidal position encoding it also produces is only consumed by the video
+memory path, so it is omitted from image inference.
+"""
+from keras.layers import Conv2D, UpSampling2D, Add
+
+from paz.models.foundation.sam2.configuration import PROMPT_EMBED_DIM
+
+TOP_DOWN_LEVELS = (2, 3)
+
+
+def build(features):
+    last = len(features) - 1
+    laterals = []
+    for level, feature in enumerate(features):
+        name = f"neck_conv_{last - level}"
+        laterals.append(Conv2D(PROMPT_EMBED_DIM, 1, name=name)(feature))
+    outputs = [None] * len(features)
+    previous = None
+    for level in range(last, -1, -1):
+        lateral = laterals[level]
+        if level in TOP_DOWN_LEVELS and previous is not None:
+            upsampled = UpSampling2D(2, interpolation="nearest")(previous)
+            previous = Add()([lateral, upsampled])
+        else:
+            previous = lateral
+        outputs[level] = previous
+    return outputs

--- a/paz/models/foundation/sam2/predict.py
+++ b/paz/models/foundation/sam2/predict.py
@@ -37,7 +37,8 @@ def predict(bundle, features, points=None, labels=None, box=None, mask=None,
               sparse, dense, features.image_pe)
     masks, scores, _ = bundle.mask_decoder(inputs)
     masks, scores = select(masks, scores, multimask)
-    return upscale_masks(masks, features.size), scores, masks
+    upscaled = upscale_masks(masks, features.size)
+    return upscaled, scores, jp.clip(masks, -32.0, 32.0)
 
 
 def build_prompt(points, labels, box, size):

--- a/paz/models/foundation/sam2/predict.py
+++ b/paz/models/foundation/sam2/predict.py
@@ -1,9 +1,11 @@
 """Static-image inference orchestration for SAM 2.
 
-Encodes an image once, then predicts masks for point, box, combined, and
-previous-mask prompts. Coordinates are ``(x, y)`` in the original image; boxes
-are ``XYXY``. Returns masks at the original resolution, predicted quality
-scores, and the low-resolution logits for a follow-up prompt.
+Encode an image once into a ``State`` (weights bundle plus per-image
+features), then predict masks for point, box, combined, and previous-mask
+prompts. Coordinates are ``(x, y)`` in the original image; boxes are ``XYXY``.
+``predict`` returns the four candidate masks at the original resolution, their
+predicted quality scores, and the low-resolution logits for a follow-up
+prompt. ``select`` keeps the multimask candidates or the single mask.
 """
 from collections import namedtuple
 
@@ -16,27 +18,28 @@ from paz.models.foundation.sam2.preprocessing import transform_boxes
 from paz.models.foundation.sam2.prompt_encoder import dense_positional_encoding
 from paz.models.foundation.sam2.prompt_encoder import MASK_INPUT
 
-Features = namedtuple(
-    "Features", "image_embed high_res_0 high_res_1 image_pe size")
+FEATURES = "image_embed high_res_0 high_res_1 image_pe size"
+Features = namedtuple("Features", FEATURES)
+State = namedtuple("State", "bundle features")
 
 
 def encode_image(bundle, image):
     pixels = preprocess_image(image)[None]
     embedding, high_res_0, high_res_1 = bundle.image_encoder(pixels)
     image_pe = dense_positional_encoding(bundle.point_encoder)[None]
-    return Features(embedding, high_res_0, high_res_1, image_pe,
-                    image.shape[:2])
+    size = image.shape[:2]
+    features = Features(embedding, high_res_0, high_res_1, image_pe, size)
+    return State(bundle, features)
 
 
-def predict(bundle, features, points=None, labels=None, box=None, mask=None,
-            multimask=True):
+def predict(state, points=None, labels=None, box=None, mask=None):
+    bundle, features = state
     coordinates, labels = build_prompt(points, labels, box, features.size)
     sparse = bundle.point_encoder((coordinates, labels))
     dense = build_dense(bundle, mask)
-    inputs = (features.image_embed, features.high_res_0, features.high_res_1,
-              sparse, dense, features.image_pe)
+    tensors = (features.image_embed, features.high_res_0, features.high_res_1)
+    inputs = (*tensors, sparse, dense, features.image_pe)
     masks, scores, _ = bundle.mask_decoder(inputs)
-    masks, scores = select(masks, scores, multimask)
     upscaled = upscale_masks(masks, features.size)
     return upscaled, scores, jp.clip(masks, -32.0, 32.0)
 
@@ -67,7 +70,7 @@ def build_dense(bundle, mask):
     return dense
 
 
-def select(masks, scores, multimask):
+def select(masks, scores, multimask=True):
     start = 1 if multimask else 0
     stop = masks.shape[1] if multimask else 1
     return masks[:, start:stop], scores[:, start:stop]

--- a/paz/models/foundation/sam2/predict.py
+++ b/paz/models/foundation/sam2/predict.py
@@ -1,0 +1,78 @@
+"""Static-image inference orchestration for SAM 2.
+
+Encodes an image once, then predicts masks for point, box, combined, and
+previous-mask prompts. Coordinates are ``(x, y)`` in the original image; boxes
+are ``XYXY``. Returns masks at the original resolution, predicted quality
+scores, and the low-resolution logits for a follow-up prompt.
+"""
+from collections import namedtuple
+
+import jax.numpy as jp
+
+import paz
+from paz.models.foundation.sam2.preprocessing import preprocess_image
+from paz.models.foundation.sam2.preprocessing import transform_coords
+from paz.models.foundation.sam2.preprocessing import transform_boxes
+from paz.models.foundation.sam2.prompt_encoder import dense_positional_encoding
+from paz.models.foundation.sam2.prompt_encoder import MASK_INPUT
+
+Features = namedtuple(
+    "Features", "image_embed high_res_0 high_res_1 image_pe size")
+
+
+def encode_image(bundle, image):
+    pixels = preprocess_image(image)[None]
+    embedding, high_res_0, high_res_1 = bundle.image_encoder(pixels)
+    image_pe = dense_positional_encoding(bundle.point_encoder)[None]
+    return Features(embedding, high_res_0, high_res_1, image_pe,
+                    image.shape[:2])
+
+
+def predict(bundle, features, points=None, labels=None, box=None, mask=None,
+            multimask=True):
+    coordinates, labels = build_prompt(points, labels, box, features.size)
+    sparse = bundle.point_encoder((coordinates, labels))
+    dense = build_dense(bundle, mask)
+    inputs = (features.image_embed, features.high_res_0, features.high_res_1,
+              sparse, dense, features.image_pe)
+    masks, scores, _ = bundle.mask_decoder(inputs)
+    masks, scores = select(masks, scores, multimask)
+    return upscale_masks(masks, features.size), scores, masks
+
+
+def build_prompt(points, labels, box, size):
+    coordinates, categories = [], []
+    if box is not None:
+        corners = transform_boxes(box, size).reshape(-1, 2)
+        coordinates.append(corners)
+        categories.append(jp.array([2.0, 3.0]))
+    if points is not None:
+        coordinates.append(transform_coords(points, size))
+        categories.append(jp.asarray(labels, jp.float32))
+    coordinates.append(jp.zeros((1, 2)))
+    categories.append(jp.array([-1.0]))
+    coordinates = jp.concatenate(coordinates, axis=0)
+    categories = jp.concatenate(categories, axis=0)
+    return coordinates[None], categories[None]
+
+
+def build_dense(bundle, mask):
+    if mask is None:
+        zeros = jp.zeros((1, MASK_INPUT, MASK_INPUT, 1), jp.float32)
+        _, dense = bundle.mask_downscaling(zeros)
+        return dense
+    mask = jp.asarray(mask, jp.float32).reshape(1, MASK_INPUT, MASK_INPUT, 1)
+    dense, _ = bundle.mask_downscaling(mask)
+    return dense
+
+
+def select(masks, scores, multimask):
+    start = 1 if multimask else 0
+    stop = masks.shape[1] if multimask else 1
+    return masks[:, start:stop], scores[:, start:stop]
+
+
+def upscale_masks(masks, size):
+    channels_last = jp.transpose(masks[0], (1, 2, 0))
+    resized = paz.image.resize(channels_last, size, "linear", False)
+    return jp.transpose(resized, (2, 0, 1))[None]

--- a/paz/models/foundation/sam2/preprocessing.py
+++ b/paz/models/foundation/sam2/preprocessing.py
@@ -1,0 +1,33 @@
+"""Image and prompt-coordinate preprocessing for SAM 2 image inference.
+
+Mirrors the official ``SAM2Transforms``: scale to ``[0, 1]``, antialiased
+bilinear resize to ``1024 x 1024``, then ImageNet normalization. Coordinates
+arrive as ``(x, y)`` in the original image and leave in the resized ``1024``
+space expected by the prompt encoder.
+"""
+import jax.numpy as jp
+
+import paz
+from paz.models.foundation.sam2.configuration import IMAGE_SIZE
+
+MEAN = (0.485, 0.456, 0.406)
+STDV = (0.229, 0.224, 0.225)
+
+
+def preprocess_image(image, size=IMAGE_SIZE):
+    image = jp.asarray(image, jp.float32) / 255.0
+    image = paz.image.resize(image, (size, size), "linear", True)
+    mean = jp.asarray(MEAN, jp.float32)
+    stdv = jp.asarray(STDV, jp.float32)
+    return (image - mean) / stdv
+
+
+def transform_coords(coords, original_size, size=IMAGE_SIZE):
+    height, width = original_size
+    scale = jp.asarray([width, height], jp.float32)
+    return jp.asarray(coords, jp.float32) / scale * size
+
+
+def transform_boxes(boxes, original_size, size=IMAGE_SIZE):
+    corners = jp.asarray(boxes, jp.float32).reshape(-1, 2, 2)
+    return transform_coords(corners, original_size, size)

--- a/paz/models/foundation/sam2/pretrained.py
+++ b/paz/models/foundation/sam2/pretrained.py
@@ -12,8 +12,7 @@ from paz.models.foundation.sam2 import model as sam2_model
 from paz.models.foundation.sam2 import convert
 from paz.models.foundation.sam2 import configuration as cfg
 
-WEIGHT_FILES = ("image_encoder", "point_encoder", "mask_downscaling",
-                "mask_decoder")
+NAMES = "image_encoder point_encoder mask_downscaling mask_decoder".split()
 
 
 def SAM2HieraTiny(weights=None):
@@ -58,21 +57,22 @@ def build(config, weights):
 def save_weights(bundle, directory):
     directory = Path(directory)
     directory.mkdir(parents=True, exist_ok=True)
-    for model, name in zip(bundle[:4], WEIGHT_FILES):
+    for model, name in zip(bundle[:4], NAMES):
         model.save_weights(str(directory / f"{name}.weights.h5"))
 
 
 def load_weights(bundle, directory):
     directory = Path(directory)
-    for model, name in zip(bundle[:4], WEIGHT_FILES):
+    for model, name in zip(bundle[:4], NAMES):
         model.load_weights(str(directory / f"{name}.weights.h5"))
 
 
 def convert_checkpoint(checkpoint, config, directory):
     import torch
     state_dict = torch.load(checkpoint, map_location="cpu")["model"]
-    arrays = {key: value.float().cpu().numpy()
-              for key, value in state_dict.items()}
+    arrays = {}
+    for key, value in state_dict.items():
+        arrays[key] = value.float().cpu().numpy()
     bundle = sam2_model.build(config)
     convert.convert(bundle, arrays)
     save_weights(bundle, directory)

--- a/paz/models/foundation/sam2/pretrained.py
+++ b/paz/models/foundation/sam2/pretrained.py
@@ -1,0 +1,79 @@
+"""Public SAM 2 and SAM 2.1 image-model factories and weight utilities.
+
+The eight factories share four architectures and differ only by checkpoint.
+``weights`` accepts a directory holding the four converted ``.weights.h5``
+files; pass ``None`` for an uninitialized architecture. ``convert_checkpoint``
+turns an official ``.pt`` into such a directory and lazily imports torch, so
+the runtime never depends on it.
+"""
+from pathlib import Path
+
+from paz.models.foundation.sam2 import model as sam2_model
+from paz.models.foundation.sam2 import convert
+from paz.models.foundation.sam2 import configuration as cfg
+
+WEIGHT_FILES = ("image_encoder", "point_encoder", "mask_downscaling",
+                "mask_decoder")
+
+
+def SAM2HieraTiny(weights=None):
+    return build(cfg.TINY, weights)
+
+
+def SAM2HieraSmall(weights=None):
+    return build(cfg.SMALL, weights)
+
+
+def SAM2HieraBasePlus(weights=None):
+    return build(cfg.BASE_PLUS, weights)
+
+
+def SAM2HieraLarge(weights=None):
+    return build(cfg.LARGE, weights)
+
+
+def SAM21HieraTiny(weights=None):
+    return build(cfg.TINY, weights)
+
+
+def SAM21HieraSmall(weights=None):
+    return build(cfg.SMALL, weights)
+
+
+def SAM21HieraBasePlus(weights=None):
+    return build(cfg.BASE_PLUS, weights)
+
+
+def SAM21HieraLarge(weights=None):
+    return build(cfg.LARGE, weights)
+
+
+def build(config, weights):
+    bundle = sam2_model.build(config)
+    if weights is not None:
+        load_weights(bundle, weights)
+    return bundle
+
+
+def save_weights(bundle, directory):
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    for model, name in zip(bundle[:4], WEIGHT_FILES):
+        model.save_weights(str(directory / f"{name}.weights.h5"))
+
+
+def load_weights(bundle, directory):
+    directory = Path(directory)
+    for model, name in zip(bundle[:4], WEIGHT_FILES):
+        model.load_weights(str(directory / f"{name}.weights.h5"))
+
+
+def convert_checkpoint(checkpoint, config, directory):
+    import torch
+    state_dict = torch.load(checkpoint, map_location="cpu")["model"]
+    arrays = {key: value.float().cpu().numpy()
+              for key, value in state_dict.items()}
+    bundle = sam2_model.build(config)
+    convert.convert(bundle, arrays)
+    save_weights(bundle, directory)
+    return bundle

--- a/paz/models/foundation/sam2/prompt_encoder.py
+++ b/paz/models/foundation/sam2/prompt_encoder.py
@@ -1,0 +1,99 @@
+"""SAM 2 prompt encoder: point, box, and mask embeddings.
+
+Points and box corners share a random-Fourier positional encoding and add a
+learned per-label embedding. Coordinates arrive in the resized 1024 space.
+The dense positional encoding and the no-mask embedding are computed eagerly
+from the loaded weights and fed to the mask decoder as constants.
+"""
+import math
+
+import keras
+from keras import Input, Model, ops
+from keras.layers import Conv2D, LayerNormalization, Layer
+
+from paz.models.foundation.sam2.configuration import IMAGE_SIZE
+from paz.models.foundation.sam2.configuration import PROMPT_EMBED_DIM
+from paz.models.foundation.sam2.configuration import BACKBONE_STRIDE
+from paz.models.foundation.sam2.layers import ChannelBias
+
+GRID = IMAGE_SIZE // BACKBONE_STRIDE
+MASK_INPUT = 4 * GRID
+
+
+@keras.saving.register_keras_serializable(package="paz")
+class RandomFourierEmbedding(Layer):
+    def __init__(self, num_features, **kwargs):
+        super().__init__(**kwargs)
+        self.num_features = num_features
+
+    def build(self, input_shape):
+        self.matrix = self.add_weight(
+            name="matrix", shape=(2, self.num_features), initializer="zeros",
+            trainable=False)
+
+    def call(self, coordinates):
+        coordinates = 2.0 * coordinates - 1.0
+        projected = ops.matmul(coordinates, self.matrix)
+        projected = 2.0 * math.pi * projected
+        return ops.concatenate([ops.sin(projected), ops.cos(projected)], -1)
+
+    def get_config(self):
+        arguments = {"num_features": self.num_features}
+        return {**super().get_config(), **arguments}
+
+
+@keras.saving.register_keras_serializable(package="paz")
+class PointLabelEmbedding(Layer):
+    def build(self, input_shape):
+        self.corners = self.add_weight(
+            name="corners", shape=(4, PROMPT_EMBED_DIM), initializer="zeros")
+        self.not_a_point = self.add_weight(
+            name="not_a_point", shape=(1, PROMPT_EMBED_DIM),
+            initializer="zeros")
+
+    def call(self, inputs):
+        encoding, labels = inputs
+        labels = labels[..., None]
+        vectors = self.corners[None, None]
+        encoding = ops.where(labels == -1, self.not_a_point[None], encoding)
+        encoding = ops.where(labels == 0, encoding + vectors[..., 0, :],
+                             encoding)
+        encoding = ops.where(labels == 1, encoding + vectors[..., 1, :],
+                             encoding)
+        encoding = ops.where(labels == 2, encoding + vectors[..., 2, :],
+                             encoding)
+        encoding = ops.where(labels == 3, encoding + vectors[..., 3, :],
+                             encoding)
+        return encoding
+
+
+def build_points(name="sam2_prompt_encoder"):
+    coordinates = Input((None, 2), name="point_coords")
+    labels = Input((None,), name="point_labels")
+    normalized = (coordinates + 0.5) / IMAGE_SIZE
+    encoding = RandomFourierEmbedding(
+        PROMPT_EMBED_DIM // 2, name="prompt_pe")(normalized)
+    sparse = PointLabelEmbedding(name="point_label_embed")([encoding, labels])
+    return Model((coordinates, labels), sparse, name=name)
+
+
+def build_mask_downscaling(name="sam2_mask_downscaling"):
+    masks = Input((MASK_INPUT, MASK_INPUT, 1), name="mask_input")
+    x = Conv2D(4, 2, strides=2, name="mask_down_0")(masks)
+    x = LayerNormalization(axis=-1, epsilon=1e-6, name="mask_down_ln0")(x)
+    x = ops.gelu(x, approximate=False)
+    x = Conv2D(16, 2, strides=2, name="mask_down_3")(x)
+    x = LayerNormalization(axis=-1, epsilon=1e-6, name="mask_down_ln3")(x)
+    x = ops.gelu(x, approximate=False)
+    dense = Conv2D(PROMPT_EMBED_DIM, 1, name="mask_down_6")(x)
+    no_mask = ChannelBias(PROMPT_EMBED_DIM,
+                          name="no_mask_embed")(ops.zeros_like(dense))
+    return Model(masks, (dense, no_mask), name=name)
+
+
+def dense_positional_encoding(point_model):
+    layer = point_model.get_layer("prompt_pe")
+    axis = (ops.arange(GRID, dtype="float32") + 0.5) / GRID
+    grid_y, grid_x = ops.meshgrid(axis, axis, indexing="ij")
+    coordinates = ops.stack([grid_x, grid_y], axis=-1)
+    return layer(coordinates)

--- a/paz/models/foundation/sam2/prompt_encoder.py
+++ b/paz/models/foundation/sam2/prompt_encoder.py
@@ -27,9 +27,9 @@ class RandomFourierEmbedding(Layer):
         self.num_features = num_features
 
     def build(self, input_shape):
-        self.matrix = self.add_weight(
-            name="matrix", shape=(2, self.num_features), initializer="zeros",
-            trainable=False)
+        shape = (2, self.num_features)
+        kwargs = dict(name="matrix", shape=shape, initializer="zeros")
+        self.matrix = self.add_weight(trainable=False, **kwargs)
 
     def call(self, coordinates):
         coordinates = 2.0 * coordinates - 1.0
@@ -45,25 +45,18 @@ class RandomFourierEmbedding(Layer):
 @keras.saving.register_keras_serializable(package="paz")
 class PointLabelEmbedding(Layer):
     def build(self, input_shape):
-        self.corners = self.add_weight(
-            name="corners", shape=(4, PROMPT_EMBED_DIM), initializer="zeros")
-        self.not_a_point = self.add_weight(
-            name="not_a_point", shape=(1, PROMPT_EMBED_DIM),
-            initializer="zeros")
+        corners = dict(name="corners", shape=(4, PROMPT_EMBED_DIM))
+        point = dict(name="not_a_point", shape=(1, PROMPT_EMBED_DIM))
+        self.corners = self.add_weight(initializer="zeros", **corners)
+        self.not_a_point = self.add_weight(initializer="zeros", **point)
 
     def call(self, inputs):
         encoding, labels = inputs
         labels = labels[..., None]
-        vectors = self.corners[None, None]
         encoding = ops.where(labels == -1, self.not_a_point[None], encoding)
-        encoding = ops.where(labels == 0, encoding + vectors[..., 0, :],
-                             encoding)
-        encoding = ops.where(labels == 1, encoding + vectors[..., 1, :],
-                             encoding)
-        encoding = ops.where(labels == 2, encoding + vectors[..., 2, :],
-                             encoding)
-        encoding = ops.where(labels == 3, encoding + vectors[..., 3, :],
-                             encoding)
+        for label in range(4):
+            corner = self.corners[label]
+            encoding = ops.where(labels == label, encoding + corner, encoding)
         return encoding
 
 
@@ -71,8 +64,8 @@ def build_points(name="sam2_prompt_encoder"):
     coordinates = Input((None, 2), name="point_coords")
     labels = Input((None,), name="point_labels")
     normalized = (coordinates + 0.5) / IMAGE_SIZE
-    encoding = RandomFourierEmbedding(
-        PROMPT_EMBED_DIM // 2, name="prompt_pe")(normalized)
+    layer = RandomFourierEmbedding(PROMPT_EMBED_DIM // 2, name="prompt_pe")
+    encoding = layer(normalized)
     sparse = PointLabelEmbedding(name="point_label_embed")([encoding, labels])
     return Model((coordinates, labels), sparse, name=name)
 
@@ -86,8 +79,8 @@ def build_mask_downscaling(name="sam2_mask_downscaling"):
     x = LayerNormalization(axis=-1, epsilon=1e-6, name="mask_down_ln3")(x)
     x = ops.gelu(x, approximate=False)
     dense = Conv2D(PROMPT_EMBED_DIM, 1, name="mask_down_6")(x)
-    no_mask = ChannelBias(PROMPT_EMBED_DIM,
-                          name="no_mask_embed")(ops.zeros_like(dense))
+    empty = ops.zeros_like(dense)
+    no_mask = ChannelBias(PROMPT_EMBED_DIM, name="no_mask_embed")(empty)
     return Model(masks, (dense, no_mask), name=name)
 
 

--- a/paz/models/foundation/sam2/sam2_test.py
+++ b/paz/models/foundation/sam2/sam2_test.py
@@ -9,7 +9,7 @@ from paz.models.foundation.sam2 import model as sam2_model, predict
 from paz.models.foundation.sam2 import preprocessing
 from paz.models.foundation.sam2.windows import window_partition
 from paz.models.foundation.sam2.windows import window_unpartition
-from paz.models.foundation.sam2.configuration import TINY, backbone_channels
+from paz.models.foundation.sam2.configuration import TINY
 
 
 def test_preprocess_shape_and_normalization():
@@ -59,10 +59,6 @@ def test_image_encoder_output_shapes():
     assert tuple(embedding.shape) == (None, 64, 64, 256)
     assert tuple(high_res_0.shape) == (None, 256, 256, 32)
     assert tuple(high_res_1.shape) == (None, 128, 128, 64)
-
-
-def test_backbone_channels_follow_embed_dim():
-    assert backbone_channels(TINY) == [768, 384, 192, 96]
 
 
 def test_point_encoder_sparse_shape():

--- a/paz/models/foundation/sam2/sam2_test.py
+++ b/paz/models/foundation/sam2/sam2_test.py
@@ -90,15 +90,17 @@ def test_mask_downscaling_shape():
     assert np.array(no_mask).shape == (1, 64, 64, 256)
 
 
+def decoder_inputs():
+    embed = np.zeros((1, 64, 64, 256), np.float32)
+    high_res_0 = np.zeros((1, 256, 256, 32), np.float32)
+    high_res_1 = np.zeros((1, 128, 128, 64), np.float32)
+    sparse = np.zeros((1, 2, 256), np.float32)
+    dense = np.zeros((1, 64, 64, 256), np.float32)
+    return [embed, high_res_0, high_res_1, sparse, dense, embed]
+
+
 def test_mask_decoder_shapes():
-    model = mask_decoder.build()
-    inputs = [np.zeros((1, 64, 64, 256), np.float32),
-              np.zeros((1, 256, 256, 32), np.float32),
-              np.zeros((1, 128, 128, 64), np.float32),
-              np.zeros((1, 2, 256), np.float32),
-              np.zeros((1, 64, 64, 256), np.float32),
-              np.zeros((1, 64, 64, 256), np.float32)]
-    masks, iou, obj = model(inputs)
+    masks, iou, obj = mask_decoder.build()(decoder_inputs())
     assert np.array(masks).shape == (1, 4, 256, 256)
     assert np.array(iou).shape == (1, 4)
     assert np.array(obj).shape == (1, 1)
@@ -110,26 +112,24 @@ def bundle():
 
 
 def test_single_and_multimask_selection(bundle):
-    image = np.zeros((80, 120, 3), np.uint8)
-    features = predict.encode_image(bundle, image)
-    multi, scores, _ = predict.predict(
-        bundle, features, points=[[60.0, 40.0]], labels=[1], multimask=True)
-    single, _, _ = predict.predict(
-        bundle, features, points=[[60.0, 40.0]], labels=[1], multimask=False)
+    state = predict.encode_image(bundle, np.zeros((80, 120, 3), np.uint8))
+    point = [[60.0, 40.0]]
+    masks, scores, low = predict.predict(state, points=point, labels=[1])
+    multi, multi_scores = predict.select(masks, scores, multimask=True)
+    single, _ = predict.select(masks, scores, multimask=False)
     assert np.array(multi).shape == (1, 3, 80, 120)
     assert np.array(single).shape == (1, 1, 80, 120)
-    assert np.array(scores).shape == (1, 3)
+    assert np.array(multi_scores).shape == (1, 3)
 
 
 def test_box_and_point_box_shapes(bundle):
-    image = np.zeros((80, 120, 3), np.uint8)
-    features = predict.encode_image(bundle, image)
-    box, _, _ = predict.predict(bundle, features, box=[10.0, 10.0, 60.0, 50.0])
-    combined, _, _ = predict.predict(
-        bundle, features, points=[[30.0, 30.0]], labels=[1],
-        box=[10.0, 10.0, 60.0, 50.0])
-    assert np.array(box).shape == (1, 3, 80, 120)
-    assert np.array(combined).shape == (1, 3, 80, 120)
+    state = predict.encode_image(bundle, np.zeros((80, 120, 3), np.uint8))
+    rectangle = [10.0, 10.0, 60.0, 50.0]
+    box = predict.predict(state, box=rectangle)[0]
+    kwargs = dict(points=[[30.0, 30.0]], labels=[1], box=rectangle)
+    combined = predict.predict(state, **kwargs)[0]
+    assert np.array(box).shape == (1, 4, 80, 120)
+    assert np.array(combined).shape == (1, 4, 80, 120)
 
 
 def test_window_partition_jit_cache_is_stable():

--- a/paz/models/foundation/sam2/sam2_test.py
+++ b/paz/models/foundation/sam2/sam2_test.py
@@ -1,0 +1,144 @@
+import numpy as np
+import jax
+import jax.numpy as jp
+import pytest
+
+from paz.models.foundation.sam2 import hiera, image_encoder
+from paz.models.foundation.sam2 import prompt_encoder, mask_decoder
+from paz.models.foundation.sam2 import model as sam2_model, predict
+from paz.models.foundation.sam2 import preprocessing
+from paz.models.foundation.sam2.windows import window_partition
+from paz.models.foundation.sam2.windows import window_unpartition
+from paz.models.foundation.sam2.configuration import TINY, backbone_channels
+
+
+def test_preprocess_shape_and_normalization():
+    image = np.full((30, 40, 3), 255, np.uint8)
+    output = np.array(preprocessing.preprocess_image(image))
+    assert output.shape == (1024, 1024, 3)
+    expected = (1.0 - np.array(preprocessing.MEAN)) / preprocessing.STDV
+    assert np.allclose(output[512, 512], expected, atol=1e-4)
+
+
+def test_transform_coords_maps_to_resolution():
+    coords = preprocessing.transform_coords([[50.0, 25.0]], (100, 200))
+    assert np.allclose(np.array(coords), [[256.0, 256.0]])
+
+
+def test_transform_boxes_reshapes_to_corners():
+    boxes = preprocessing.transform_boxes([0.0, 0.0, 200.0, 100.0], (100, 200))
+    assert np.array(boxes).shape == (1, 2, 2)
+    assert np.allclose(np.array(boxes)[0, 1], [1024.0, 1024.0])
+
+
+def test_window_partition_unpartition_roundtrip():
+    x = jp.asarray(np.random.RandomState(0).randn(2, 20, 28, 5), jp.float32)
+    windows, padded = window_partition(x, 8)
+    assert windows.shape[1:] == (8, 8, 5)
+    restored = window_unpartition(windows, 8, padded, (20, 28))
+    assert np.allclose(np.array(restored), np.array(x), atol=1e-6)
+
+
+def test_bicubic_matrix_rows_sum_to_one():
+    matrix = hiera.bicubic_resize_matrix(7, 64)
+    assert matrix.shape == (64, 7)
+    assert np.allclose(matrix.sum(axis=1), 1.0, atol=1e-5)
+
+
+def test_block_specifications_match_config():
+    specifications, stage_ends = hiera.build_block_specifications(TINY)
+    assert len(specifications) == sum(TINY.stages)
+    assert stage_ends == [0, 2, 9, 11]
+    pooled = [index for index, *_ , pool, _ in specifications if pool]
+    assert pooled == [1, 3, 10]
+
+
+def test_image_encoder_output_shapes():
+    model = image_encoder.build(TINY)
+    embedding, high_res_0, high_res_1 = model.outputs
+    assert tuple(embedding.shape) == (None, 64, 64, 256)
+    assert tuple(high_res_0.shape) == (None, 256, 256, 32)
+    assert tuple(high_res_1.shape) == (None, 128, 128, 64)
+
+
+def test_backbone_channels_follow_embed_dim():
+    assert backbone_channels(TINY) == [768, 384, 192, 96]
+
+
+def test_point_encoder_sparse_shape():
+    model = prompt_encoder.build_points()
+    coords = np.zeros((1, 3, 2), np.float32)
+    labels = np.zeros((1, 3), np.float32)
+    sparse = np.array(model((coords, labels)))
+    assert sparse.shape == (1, 3, 256)
+
+
+def test_point_label_semantics():
+    model = prompt_encoder.build_points()
+    layer = model.get_layer("point_label_embed")
+    corners = np.arange(4 * 256, dtype="float32").reshape(4, 256)
+    not_a_point = np.full((1, 256), -7.0, "float32")
+    layer.set_weights([corners, not_a_point])
+    coords = np.zeros((1, 3, 2), np.float32)
+    labels = np.array([[0, 1, -1]], np.float32)
+    sparse = np.array(model((coords, labels)))
+    difference = sparse[0, 1] - sparse[0, 0]
+    assert np.allclose(difference, corners[1] - corners[0], atol=1e-4)
+    assert np.allclose(sparse[0, 2], not_a_point[0], atol=1e-4)
+
+
+def test_mask_downscaling_shape():
+    model = prompt_encoder.build_mask_downscaling()
+    dense, no_mask = model(np.zeros((1, 256, 256, 1), np.float32))
+    assert np.array(dense).shape == (1, 64, 64, 256)
+    assert np.array(no_mask).shape == (1, 64, 64, 256)
+
+
+def test_mask_decoder_shapes():
+    model = mask_decoder.build()
+    inputs = [np.zeros((1, 64, 64, 256), np.float32),
+              np.zeros((1, 256, 256, 32), np.float32),
+              np.zeros((1, 128, 128, 64), np.float32),
+              np.zeros((1, 2, 256), np.float32),
+              np.zeros((1, 64, 64, 256), np.float32),
+              np.zeros((1, 64, 64, 256), np.float32)]
+    masks, iou, obj = model(inputs)
+    assert np.array(masks).shape == (1, 4, 256, 256)
+    assert np.array(iou).shape == (1, 4)
+    assert np.array(obj).shape == (1, 1)
+
+
+@pytest.fixture(scope="module")
+def bundle():
+    return sam2_model.build(TINY)
+
+
+def test_single_and_multimask_selection(bundle):
+    image = np.zeros((80, 120, 3), np.uint8)
+    features = predict.encode_image(bundle, image)
+    multi, scores, _ = predict.predict(
+        bundle, features, points=[[60.0, 40.0]], labels=[1], multimask=True)
+    single, _, _ = predict.predict(
+        bundle, features, points=[[60.0, 40.0]], labels=[1], multimask=False)
+    assert np.array(multi).shape == (1, 3, 80, 120)
+    assert np.array(single).shape == (1, 1, 80, 120)
+    assert np.array(scores).shape == (1, 3)
+
+
+def test_box_and_point_box_shapes(bundle):
+    image = np.zeros((80, 120, 3), np.uint8)
+    features = predict.encode_image(bundle, image)
+    box, _, _ = predict.predict(bundle, features, box=[10.0, 10.0, 60.0, 50.0])
+    combined, _, _ = predict.predict(
+        bundle, features, points=[[30.0, 30.0]], labels=[1],
+        box=[10.0, 10.0, 60.0, 50.0])
+    assert np.array(box).shape == (1, 3, 80, 120)
+    assert np.array(combined).shape == (1, 3, 80, 120)
+
+
+def test_window_partition_jit_cache_is_stable():
+    partition = jax.jit(lambda x: window_partition(x, 8)[0])
+    for seed in range(3):
+        data = jp.asarray(np.random.RandomState(seed).randn(1, 16, 16, 4))
+        partition(data)
+    assert partition._cache_size() == 1

--- a/paz/models/foundation/sam2/windows.py
+++ b/paz/models/foundation/sam2/windows.py
@@ -13,9 +13,8 @@ def window_partition(x, window):
     pad_w = (window - width % window) % window
     x = ops.pad(x, [[0, 0], [0, pad_h], [0, pad_w], [0, 0]])
     padded_h, padded_w = height + pad_h, width + pad_w
-    shape = (-1, padded_h // window, window, padded_w // window, window,
-             channels)
-    x = ops.reshape(x, shape)
+    rows, cols = padded_h // window, padded_w // window
+    x = ops.reshape(x, (-1, rows, window, cols, window, channels))
     x = ops.transpose(x, (0, 1, 3, 2, 4, 5))
     windows = ops.reshape(x, (-1, window, window, channels))
     return windows, (padded_h, padded_w)
@@ -25,9 +24,8 @@ def window_unpartition(windows, window, padded_size, size):
     padded_h, padded_w = padded_size
     height, width = size
     channels = windows.shape[-1]
-    shape = (-1, padded_h // window, padded_w // window, window, window,
-             channels)
-    x = ops.reshape(windows, shape)
+    rows, cols = padded_h // window, padded_w // window
+    x = ops.reshape(windows, (-1, rows, cols, window, window, channels))
     x = ops.transpose(x, (0, 1, 3, 2, 4, 5))
     x = ops.reshape(x, (-1, padded_h, padded_w, channels))
     return x[:, :height, :width, :]

--- a/paz/models/foundation/sam2/windows.py
+++ b/paz/models/foundation/sam2/windows.py
@@ -1,0 +1,33 @@
+"""Non-overlapping window partition and unpartition for Hiera attention.
+
+Operates on channels-last ``(batch, height, width, channels)`` tensors and
+pads to a whole number of windows, matching the official SAM 2 backbone. Pure
+``keras.ops`` so the functions trace inside functional models.
+"""
+from keras import ops
+
+
+def window_partition(x, window):
+    height, width, channels = x.shape[1], x.shape[2], x.shape[3]
+    pad_h = (window - height % window) % window
+    pad_w = (window - width % window) % window
+    x = ops.pad(x, [[0, 0], [0, pad_h], [0, pad_w], [0, 0]])
+    padded_h, padded_w = height + pad_h, width + pad_w
+    shape = (-1, padded_h // window, window, padded_w // window, window,
+             channels)
+    x = ops.reshape(x, shape)
+    x = ops.transpose(x, (0, 1, 3, 2, 4, 5))
+    windows = ops.reshape(x, (-1, window, window, channels))
+    return windows, (padded_h, padded_w)
+
+
+def window_unpartition(windows, window, padded_size, size):
+    padded_h, padded_w = padded_size
+    height, width = size
+    channels = windows.shape[-1]
+    shape = (-1, padded_h // window, padded_w // window, window, window,
+             channels)
+    x = ops.reshape(windows, shape)
+    x = ops.transpose(x, (0, 1, 3, 2, 4, 5))
+    x = ops.reshape(x, (-1, padded_h, padded_w, channels))
+    return x[:, :height, :width, :]


### PR DESCRIPTION
Static-image inference for all eight official SAM 2 / SAM 2.1 variants in
`paz.models.foundation.sam2`, built from existing PAZ transformer parts. One
shared architecture drives every factory; variants differ only by immutable
config and checkpoint. Channels-last throughout; all torch→Keras transposes
happen in the converter.

## Factories
`SAM2HieraTiny`, `SAM2HieraSmall`, `SAM2HieraBasePlus`, `SAM2HieraLarge`,
`SAM21HieraTiny`, `SAM21HieraSmall`, `SAM21HieraBasePlus`, `SAM21HieraLarge`.

## Architecture components
Hiera trunk (patch embed, windowed multiscale attention, query pooling,
interpolated windowed position embedding), FPN neck, SAM prompt encoder
(random-Fourier PE, point/box/label embeddings, mask downscaling), two-way
transformer, hypernetwork mask projection, IoU and object-score heads, and
mask upscaling to the original resolution.

## Reuse
- Transformer: `paz.models.transformers.attention.compute_attention` (Hiera
  and two-way attention), `feedforward.gelu` (Hiera MLPs).
- Backend: `paz.image.resize` for preprocessing and mask upscaling.
- Converter mirrors `dinov2/port_weights.py` (`take`/`used`/reject-unmapped).
- New SAM-local primitives: `windows.window_partition/unpartition`,
  `HieraPositionEmbedding` (exact torch-bicubic resize matrix),
  `RandomFourierEmbedding`, `PointLabelEmbedding`, `ChannelBias`,
  `BroadcastTokens`, and the two-way attention with query/key/value
  downsampling. All are SAM-specific and stay in the package.

## Scope decision
Builds only the image-required subgraph. The converter maps image parameters
strictly and lists video-memory prefixes as deferred (reported, never silently
dropped). Parameter counts are the image subgraph (both SAM 2 and 2.1 per
size): tiny 31,440,977; small 38,538,833; base+ 73,328,657; large
216,925,121. Full checkpoints are larger due to the deferred video params.

## Numerical validation (CPU, float32, vs official PyTorch)
Deterministic synthetic image, six prompt cases (positive point; positive +
negative; box; point + box; previous low-res mask; single and multimask).
Binary-mask IoU is 1.0 in every case below.

| model | image embed max abs | low-res logit max abs | IoU score max abs | binary IoU |
| --- | --- | --- | --- | --- |
| sam2_hiera_tiny | 1.3e-5 | 5.6e-5 | 3.9e-7 | 1.000 |
| sam2.1_hiera_tiny | 7.0e-6 | 4.7e-5 | 2.5e-7 | 1.000 |
| sam2.1_hiera_base_plus | 6.4e-5 | 2.2e-4 | 5.7e-7 | 1.000 |
| sam2.1_hiera_large | 9.0e-4 | 1.1e-3 | 7.6e-6 | 1.000 |

Large exercises the different `(8, 4, 16, 8)` window spec and wider channels;
its larger logit deltas are float accumulation over 48 blocks, with identical
selected masks. All eight variants: strict conversion (no unexpected image
keys), exact image-parameter counts, correct stage/embedding/mask shapes, and
converted-weight save/reload consistency.

## Reference
- Official repo: facebookresearch/sam2 @
  `2b90b9f5ceec907a1c18123530e92e794ad901a4`
- Checkpoint sha256:
  - sam2_hiera_tiny.pt `65b50056e05bcb13694174f51bb6da89c894b57b75ccdf0ba6352c597c5d1125`
  - sam2_hiera_small.pt `95949964d4e548409021d47b22712d5f1abf2564cc0c3c765ba599a24ac7dce3`
  - sam2_hiera_base_plus.pt `d0bb7f236400a49669ffdd1be617959a8b1d1065081789d7bbff88eded3a8071`
  - sam2_hiera_large.pt `7442e4e9b732a508f80e141e7c2913437a3610ee0c77381a66658c3a445df87b`
  - sam2.1_hiera_tiny.pt `7402e0d864fa82708a20fbd15bc84245c2f26dff0eb43a4b5b93452deb34be69`
  - sam2.1_hiera_small.pt `6d1aa6f30de5c92224f8172114de081d104bbd23dd9dc5c58996f0cad5dc4d38`
  - sam2.1_hiera_base_plus.pt `a2345aede8715ab1d5d31b4a509fb160c5a4af1970f199d9054ccfb746c004c5`
  - sam2.1_hiera_large.pt `2647878d5dfa5098f2f8649825738a9345572bae2d4350a2468587ece47dd318`

## Tests and example
`KERAS_BACKEND=jax pytest paz/models/foundation/sam2/` — 18 passed
(preprocessing, coordinate transforms, window round-trip, bicubic
interpolation, per-stage shapes, prompt semantics, decoder shapes,
single/multimask, JIT cache stability, strict converter coverage/round-trip
without torch). No test needs torch, internet, or checkpoints. Numerical
comparisons above are gated behind the developer reference env. The example
(`examples/sam2/segment_image.py`) runs on CPU with converted SAM 2.1 small
weights: segments the COCO demo image from one positive and one negative
point and overlays the best-scoring mask.

## Deferred
Memory encoder and memory attention, video propagation / streaming state /
multi-object tracking, automatic mask generation, training, connected-
component mask cleanup, and CUDA postprocessing. The static-image models leave
a clean seam for adding the memory path. Pretrained weight hosting is a
follow-up; `pretrained.convert_checkpoint` converts an official `.pt` offline.
