### PR TITLE
Host SAM 2 image weights

### DIFF
--- a/examples/sam2/segment_image.py
+++ b/examples/sam2/segment_image.py
@@ -1,8 +1,7 @@
 """Segment an object with SAM 2.1 from one positive and one negative point.
 
-Converted weights come from a directory produced by
-``paz.models.foundation.sam2.pretrained.convert_checkpoint``; pass it with
-``--weights``. The positive point marks the object, the negative point marks
+Runs out of the box: it downloads the pretrained SAM 2.1 small weights and a
+demo image. The positive point marks the object, the negative point marks
 background; the mask with the highest predicted quality is overlaid.
 """
 import argparse
@@ -26,7 +25,7 @@ def load_image(path):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--weights", required=True)
+    parser.add_argument("--weights", default="pretrained")
     parser.add_argument("--image", default=None)
     parser.add_argument("--positive", type=int, nargs=2, default=(340, 260))
     parser.add_argument("--negative", type=int, nargs=2, default=(50, 40))

--- a/paz/models/foundation/sam2/pretrained.py
+++ b/paz/models/foundation/sam2/pretrained.py
@@ -1,57 +1,76 @@
 """Public SAM 2 and SAM 2.1 image-model factories and weight utilities.
 
 The eight factories share four architectures and differ only by checkpoint.
-``weights`` accepts a directory holding the four converted ``.weights.h5``
-files; pass ``None`` for an uninitialized architecture. ``convert_checkpoint``
-turns an official ``.pt`` into such a directory and lazily imports torch, so
-the runtime never depends on it.
+``weights="pretrained"`` downloads and verifies the converted weights;
+a directory path loads local ``.weights.h5`` files; ``None`` leaves the
+architecture uninitialized. ``convert_checkpoint`` turns an official ``.pt``
+into such a directory and lazily imports torch, so the runtime never needs it.
 """
+import json
 from pathlib import Path
+
+from keras.utils import get_file
 
 from paz.models.foundation.sam2 import model as sam2_model
 from paz.models.foundation.sam2 import convert
 from paz.models.foundation.sam2 import configuration as cfg
 
 NAMES = "image_encoder point_encoder mask_downscaling mask_decoder".split()
+ALTAMIRA = "https://github.com/oarriaga/altamira-data/releases/download/"
+SAM2_WEIGHTS_URL = ALTAMIRA + "v0.30/"
+SAM2_CACHE = "paz/models/sam2"
 
 
-def SAM2HieraTiny(weights=None):
-    return build(cfg.TINY, weights)
+def SAM2HieraTiny(weights="pretrained"):
+    return build(cfg.TINY, "sam2_hiera_tiny", weights)
 
 
-def SAM2HieraSmall(weights=None):
-    return build(cfg.SMALL, weights)
+def SAM2HieraSmall(weights="pretrained"):
+    return build(cfg.SMALL, "sam2_hiera_small", weights)
 
 
-def SAM2HieraBasePlus(weights=None):
-    return build(cfg.BASE_PLUS, weights)
+def SAM2HieraBasePlus(weights="pretrained"):
+    return build(cfg.BASE_PLUS, "sam2_hiera_base_plus", weights)
 
 
-def SAM2HieraLarge(weights=None):
-    return build(cfg.LARGE, weights)
+def SAM2HieraLarge(weights="pretrained"):
+    return build(cfg.LARGE, "sam2_hiera_large", weights)
 
 
-def SAM21HieraTiny(weights=None):
-    return build(cfg.TINY, weights)
+def SAM21HieraTiny(weights="pretrained"):
+    return build(cfg.TINY, "sam2.1_hiera_tiny", weights)
 
 
-def SAM21HieraSmall(weights=None):
-    return build(cfg.SMALL, weights)
+def SAM21HieraSmall(weights="pretrained"):
+    return build(cfg.SMALL, "sam2.1_hiera_small", weights)
 
 
-def SAM21HieraBasePlus(weights=None):
-    return build(cfg.BASE_PLUS, weights)
+def SAM21HieraBasePlus(weights="pretrained"):
+    return build(cfg.BASE_PLUS, "sam2.1_hiera_base_plus", weights)
 
 
-def SAM21HieraLarge(weights=None):
-    return build(cfg.LARGE, weights)
+def SAM21HieraLarge(weights="pretrained"):
+    return build(cfg.LARGE, "sam2.1_hiera_large", weights)
 
 
-def build(config, weights):
+def build(config, variant, weights):
     bundle = sam2_model.build(config)
-    if weights is not None:
+    if weights == "pretrained":
+        load_weights(bundle, download_weights(variant))
+    elif weights is not None:
         load_weights(bundle, weights)
     return bundle
+
+
+def download_weights(variant):
+    subdir = f"{SAM2_CACHE}/{variant}"
+    asset = f"{variant}.manifest.json"
+    manifest = get_file(asset, SAM2_WEIGHTS_URL + asset, cache_subdir=subdir)
+    checksums = json.loads(Path(manifest).read_text())
+    for local, checksum in checksums.items():
+        origin = SAM2_WEIGHTS_URL + f"{variant}_{local}"
+        get_file(local, origin, cache_subdir=subdir, file_hash=checksum)
+    return Path(manifest).parent
 
 
 def save_weights(bundle, directory):

--- a/paz/models/foundation/sam2/sam2_test.py
+++ b/paz/models/foundation/sam2/sam2_test.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import jax
 import jax.numpy as jp
@@ -138,3 +140,12 @@ def test_window_partition_jit_cache_is_stable():
         data = jp.asarray(np.random.RandomState(seed).randn(1, 16, 16, 4))
         partition(data)
     assert partition._cache_size() == 1
+
+
+@pytest.mark.skipif(not os.environ.get("PAZ_SAM2_DOWNLOAD"),
+                    reason="set PAZ_SAM2_DOWNLOAD to fetch hosted weights")
+def test_pretrained_download_and_embed_shape():
+    from paz.models import SAM21HieraTiny
+    bundle = SAM21HieraTiny()
+    state = predict.encode_image(bundle, np.zeros((64, 96, 3), np.uint8))
+    assert np.array(state.features.image_embed).shape == (1, 64, 64, 256)


### PR DESCRIPTION
Follow-up to #407: host the converted SAM 2 / SAM 2.1 image weights so the
factories work out of the box.

## What changed
- All eight variants now default to `weights="pretrained"`, downloading their
  four converted `.weights.h5` files (image_encoder, point_encoder,
  mask_downscaling, mask_decoder) from altamira-data `v0.30`, verified against
  a per-variant `sha256` manifest via `keras.utils.get_file`. A directory path
  or `None` still work.
- The image example runs out of the box (no `--weights` required).
- Opt-in download smoke test gated by `PAZ_SAM2_DOWNLOAD`; ordinary tests stay
  offline.

## Hosting
`altamira-data` release `v0.30` — 32 weight files + 8 `manifest.json`
(sha256). Largest asset is the large image encoder (~812 MiB, < 2 GB, so no
sharding). Staged offline from the dumped checkpoints (no torch at runtime).

## Verification (CPU, float32)
Cleared the local cache and downloaded through `weights="pretrained"`:
- `SAM21HieraTiny`: point / box / point+box all binary-mask IoU **1.000**
  vs official PyTorch (low-res logit max ~4.7e-5, IoU score max ~1.2e-7).
- `SAM21HieraLarge` (851 MB image encoder + sha256 check): image embedding
  max abs err 9.0e-4, point binary-mask IoU **1.000**.
- `pytest paz/models/foundation/sam2/` — 18 passed, 1 skipped (download).
- Example downloads pretrained SAM 2.1 small and segments the demo image.
