### PR TITLE
Document hosted FLOWER weights and verified pretrained download path

### DIFF
--- a/docs/FLOWER_PROVENANCE.md
+++ b/docs/FLOWER_PROVENANCE.md
@@ -62,5 +62,18 @@ Inference-first port of FLOWER (Florence With Embodied Flow) to paz.
 - Florence-2 (Microsoft): MIT.
 - LIBERO: MIT.
 
-Parity results, converted-weight checksums, and known limitations are
-recorded in the pull request body and test suite.
+## Converted weights
+
+Hosted on the `oarriaga/altamira-data` GitHub release `v0.29` as sharded
+assets with a reassembly manifest; `FLOWER(weights="pretrained")`
+downloads, reassembles, and checksum-verifies them into the Keras cache.
+
+- `florence2.weights.h5` sha256
+  27d4197375f1c904c77fda85266e87f6a258d27d73d1a2342cfb6705a1c4d956
+- `flower_dit.weights.h5` sha256
+  7646f56063c62a85d3cc63a5df673cbd1775738b0971616ef727483bc1ec2888
+- `tokenizer.json` sha256
+  847bbeab6174d66a88898f729d52fa8d355fafe1bea101cf960dd404581df70e
+
+Parity results and known limitations are recorded in the pull request
+body and test suite.


### PR DESCRIPTION
Records the altamira-data v0.29 release hosting the converted
flower_libero_object weights in docs/FLOWER_PROVENANCE.md, with the
sha256 of each artifact.

Verification on a clean Keras cache: FLOWERLiberoObject() downloaded
the manifest and all shards from v0.29, reassembled and
checksum-verified the three artifacts, and loaded both models. The
checkpoint-scale parity tests pass against the downloaded files
(KERAS_BACKEND=jax FLOWER_WEIGHTS_TEST=1 pytest
paz/models/foundation/florence2 paz/models/foundation/flower =
18 passed), and the end-to-end check on the real LIBERO initial
observation reproduces the official action chunk at max abs error
3.4e-06.