### PR TITLE
Fix cached-decode vs full-forward divergence in bfloat16 Gemma4

### DIFF
--- a/paz/models/foundation/gemma4/layers/decoder.py
+++ b/paz/models/foundation/gemma4/layers/decoder.py
@@ -99,6 +99,14 @@ class Gemma4DecoderLayer(Layer):
 
     def call_with_cache(self, x, cache, index, positions=None,
                         per_layer_embedding=None, shared_kv_cache=None):
+        # `call` receives inputs autocast to compute_dtype by Keras __call__;
+        # this direct method must cast the same way or the two paths diverge.
+        x = ops.cast(x, self.compute_dtype)
+        if per_layer_embedding is not None:
+            per_layer_embedding = ops.cast(
+                per_layer_embedding, self.compute_dtype)
+        if shared_kv_cache is not None:
+            shared_kv_cache = ops.cast(shared_kv_cache, self.compute_dtype)
         x = clip_bfloat_guard(x)
         hidden, cache = self.cached_attention(
             x, cache, index, positions, shared_kv_cache)

--- a/paz/models/foundation/gemma4/model_test.py
+++ b/paz/models/foundation/gemma4/model_test.py
@@ -90,6 +90,28 @@ def test_prefill_parity_call_matches_call_with_cache():
         assert_close(step_logits[0, 0], full[0, position], tol=1e-3)
 
 
+def test_bfloat16_prefill_parity_beyond_sliding_window():
+    # Regression: the cached path once lost precision against the full
+    # forward in bfloat16 (float32 RoPE keys truncated by the bfloat16
+    # cache, missing __call__ autocast, bfloat16 RoPE positions past 256).
+    config = full_feature_config()._replace(dtype="bfloat16")
+    model = Gemma4Backbone(config)
+    length = 300
+    token_ids = jp.arange(length, dtype=jp.int32)[None] % 60 + 2
+    embedding = model.token_embedding(token_ids)
+    padding_mask = jp.ones_like(token_ids)
+    full = model.forward_from_embedding(embedding, padding_mask, token_ids)
+    per_layer = model.per_layer_lookup(token_ids)
+    cache = jp.asarray(model.build_cache(length))
+    positions = jp.arange(length, dtype=jp.int32)[None]
+    index = jp.array(0, dtype=jp.int32)
+    cached, _ = model.call_with_cache(
+        embedding, cache, index, positions, per_layer)
+    full = jp.asarray(full, jp.float32)
+    cached = jp.asarray(cached, jp.float32)
+    assert_close(full, cached, tol=1e-3)
+
+
 def test_causal_lm_cached_step_shapes():
     config = build_text_backbone_args(hidden_size_per_layer_input=2)
     model = Gemma4CausalLM(config)

--- a/paz/models/transformers/embeddings/rotary.py
+++ b/paz/models/transformers/embeddings/rotary.py
@@ -1,16 +1,11 @@
 """Rotary position embedding (RoPE)."""
 from keras import ops
 
-from paz.layers import MergeDims
-
 
 def apply(inputs, wavelength, scaling_factor, denominator, positions=None):
     args = (inputs, wavelength, scaling_factor, denominator, positions)
     cosine, sine = build(*args)
-    first_half, second_half = ops.split(inputs, 2, axis=-1)
-    rotated = ops.stack((-second_half, first_half), axis=-2)
-    rotated = MergeDims(axis=-2)(rotated)
-    return (inputs * cosine) + (rotated * sine)
+    return (inputs * cosine) + (rotate_half(inputs) * sine)
 
 
 def apply_2D(tokens, positions, base_frequency=100.0):
@@ -77,7 +72,7 @@ def build(inputs, wavelength, scaling_factor, denominator, positions=None):
 
 def build_positions(inputs):
     trailing = tuple(range(2, len(inputs.shape)))
-    ones = ops.ones_like(inputs)
+    ones = ops.ones_like(inputs, dtype="float32")
     if trailing:
         ones = ops.mean(ones, axis=trailing)
     ones = ops.mean(ones, axis=0, keepdims=False)


### PR DESCRIPTION
## What

`Gemma4Backbone.call_with_cache` diverged from `forward_from_embedding` on bfloat16 models: max hidden diff ~1.0 at length 40, growing with length (reported by a downstream KV-cache integration). Three root causes, all bfloat16-only:

1. `rotary.apply` routed the rotated half through the `MergeDims` layer, whose default float32 policy autocast it, so RoPE'd Q/K came out float32; the full path attended with float32 keys while the cached path truncated them to the bfloat16 cache. Now reuses the module's pure-ops `rotate_half` (bit-identical values, dtype preserved), matching upstream keras_hub which keeps RoPE in compute dtype.
2. `rotary.build_positions` computed cumsum positions in the input dtype; bfloat16 cannot represent integers above 256, corrupting full-path RoPE positions at long lengths. Now built in float32, matching the cached path and keras_hub.
3. `Gemma4DecoderLayer.call_with_cache` is a direct method call, so it skipped the input autocast Keras `__call__` applies on the full path (the layer is built without a dtype, so its policy is float32). It now mirrors those casts for `x`, `per_layer_embedding` and `shared_kv_cache`.

## Verification

- Both paths are now bit-exact (max abs diff 0.0) in float32 **and** bfloat16 at lengths 8/40/100/200/300 on the full-feature small config (KV sharing, global/local head dims, partial rotary, per-layer inputs, sliding window).
- float32 full-forward numerics are unchanged bit-for-bit, so previously validated upstream parity is unaffected.
- `pytest paz/models/foundation/gemma4 paz/models/transformers`: 100 passed, 4 skipped (opt-in weight tests) on CPU.
- New regression test: bfloat16 prefill parity at length 300, beyond the sliding window and beyond bfloat16 integer range.

Note for local runs: `test_prefill_parity_call_matches_call_with_cache` needs `JAX_DEFAULT_MATMUL_PRECISION=highest` on machines where XLA CPU defaults to reduced-precision float32 matmuls; the ~1.3e-3 diff seen otherwise is kernel noise, not a model bug.

Known, separate issue (not this PR): the multimodal per-layer zeroing at image positions (`build_prompt_rows`) is still inconsistent with the full forward.

Correction to an earlier version of this description: `Gemma4('gemma4_2b')` loading the hosted v0.26 weights is fine — the local failure I initially reported was host memory exhaustion (a machine-level 18 GB commit limit) while allocating the 4.7 GB per-layer embedding table. Keras's load-retry then masks the OOM with a misleading "expected 1 variables, received 0" error. Weights and loader are compatible.
