### PR TITLE
Port GEAR-WBC lower-body controller

### DIFF
--- a/examples/gear_wbc/README.md
+++ b/examples/gear_wbc/README.md
@@ -1,0 +1,78 @@
+# GEAR-WBC in MuJoCo
+
+This example runs the ported PAZ GEAR-WBC controller with the Keras JAX
+backend. GEAR-WBC is the decoupled whole-body controller used by GR00T N1.5
+and N1.6: a command-conditioned reinforcement learning policy that drives the
+G1's 12 leg joints and 3 waist joints at 50 Hz. It does not command the arms,
+which upstream are handled by a separate inverse-kinematics stack and which
+this demo simply holds at their default pose.
+
+Unlike SONIC, GEAR-WBC needs no reference motion. It takes a velocity
+command, a base height and a torso orientation, so it is steered directly
+from the keyboard.
+
+The release ships two experts over one architecture. The demo picks between
+them exactly as the deployment code does: a velocity command norm at or below
+0.05 uses `balance`, anything larger uses `walk`.
+
+## Install
+
+From the PAZ repository:
+
+    python3 -m pip install -e '.[gear_wbc]'
+
+The demo also needs the G1 MuJoCo plant from a local
+GR00T-WholeBodyControl checkout, at
+
+    decoupled_wbc/sim2mujoco/resources/robots/g1
+
+It finds that automatically when the repository is a sibling of PAZ. For
+another layout, pass the location explicitly:
+
+    python3 examples/gear_wbc/mujoco_demo.py \
+        --scene-dir /path/to/decoupled_wbc/sim2mujoco/resources/robots/g1
+
+`GEAR_WBC_SCENE_DIR` can be set instead of passing the flag every time.
+
+The meshes and policies in that directory are stored with git-lfs. Run
+`git lfs pull` in the GR00T-WholeBodyControl checkout first, otherwise
+MuJoCo fails to parse the pointer files that stand in for the STL meshes.
+
+## Run
+
+    python3 examples/gear_wbc/mujoco_demo.py
+
+The first launch compiles the actors with JAX and can take several seconds.
+CPU execution is available with:
+
+    JAX_PLATFORMS=cpu python3 examples/gear_wbc/mujoco_demo.py
+
+A fixed-length headless run is useful as a smoke check:
+
+    python3 examples/gear_wbc/mujoco_demo.py --headless --steps 1000
+
+## Controls
+
+| Key | Action |
+| --- | --- |
+| w / s | Increase or decrease forward velocity |
+| a / d | Increase or decrease lateral velocity |
+| q / e | Increase or decrease yaw rate |
+| z | Stop, returning to the balance expert |
+| 1 / 2 | Raise or lower the commanded base height |
+| 3 / 4 | Torso roll |
+| 5 / 6 | Torso pitch |
+| 7 / 8 | Torso yaw |
+
+## Weights
+
+`GearWBC(weights="pretrained")` downloads Keras weights converted from the
+released `GR00T-WholeBodyControl-Balance.onnx` and
+`GR00T-WholeBodyControl-Walk.onnx`. They are Model Derivatives licensed by
+NVIDIA Corporation under the NVIDIA Open Model License.
+
+To convert a local pair of release checkpoints instead:
+
+    python3 -m paz.models.foundation.gear_wbc.conversion \
+        --balance_onnx /path/to/GR00T-WholeBodyControl-Balance.onnx \
+        --walk_onnx /path/to/GR00T-WholeBodyControl-Walk.onnx

--- a/examples/gear_wbc/mujoco_demo.py
+++ b/examples/gear_wbc/mujoco_demo.py
@@ -1,0 +1,183 @@
+"""Interactive MuJoCo demonstration of the PAZ GEAR-WBC controller."""
+
+import argparse
+import os
+from pathlib import Path
+import time
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import mujoco
+import mujoco.viewer
+import numpy as np
+
+from paz.models import GearWBC
+from paz.models.foundation.gear_wbc.model import ACTION_DIM
+
+from simulation import CONTROL_DECIMATION
+from simulation import LOWER_BODY_ANGLES
+from simulation import SIMULATION_STEP
+from simulation import build_command
+from simulation import build_history
+from simulation import build_observation_frame
+from simulation import build_plant
+from simulation import compute_action
+from simulation import compute_control
+from simulation import compute_target_angles
+from simulation import update_history
+
+LINEAR_STEP = 0.2
+ANGULAR_STEP = 0.2
+HEIGHT_STEP = 0.1
+ORIENTATION_STEP = np.deg2rad(10)
+
+VELOCITY_KEYS = "w", "s", "a", "d", "q", "e", "z"
+HEIGHT_KEYS = "1", "2"
+ORIENTATION_KEYS = "3", "4", "5", "6", "7", "8"
+ORIENTATION_AXES = {"3": 0, "4": 0, "5": 1, "6": 1, "7": 2, "8": 2}
+
+CONTROLS = """GEAR-WBC / PAZ controls
+  w / s   forward velocity
+  a / d   lateral velocity
+  q / e   yaw rate
+  z       stop
+  1 / 2   base height
+  3 / 4   torso roll
+  5 / 6   torso pitch
+  7 / 8   torso yaw
+"""
+
+
+def apply_key(command, key):
+    if key in VELOCITY_KEYS:
+        command = apply_velocity_key(command, key)
+    elif key in HEIGHT_KEYS:
+        command = apply_height_key(command, key)
+    elif key in ORIENTATION_KEYS:
+        command = apply_orientation_key(command, key)
+    return command
+
+
+def apply_velocity_key(command, key):
+    velocity = command.velocity.copy()
+    if key == "w":
+        velocity[0] = velocity[0] + LINEAR_STEP
+    elif key == "s":
+        velocity[0] = velocity[0] - LINEAR_STEP
+    elif key == "a":
+        velocity[1] = velocity[1] + LINEAR_STEP
+    elif key == "d":
+        velocity[1] = velocity[1] - LINEAR_STEP
+    elif key == "q":
+        velocity[2] = velocity[2] + ANGULAR_STEP
+    elif key == "e":
+        velocity[2] = velocity[2] - ANGULAR_STEP
+    else:
+        velocity = np.zeros(3, "float32")
+    return command._replace(velocity=velocity)
+
+
+def apply_height_key(command, key):
+    if key == "1":
+        height = command.height + HEIGHT_STEP
+    else:
+        height = command.height - HEIGHT_STEP
+    return command._replace(height=height)
+
+
+def apply_orientation_key(command, key):
+    orientation = command.orientation.copy()
+    axis = ORIENTATION_AXES[key]
+    if key in ("3", "5", "7"):
+        orientation[axis] = orientation[axis] - ORIENTATION_STEP
+    else:
+        orientation[axis] = orientation[axis] + ORIENTATION_STEP
+    return command._replace(orientation=orientation)
+
+
+def describe(command):
+    velocity = np.round(command.velocity, 2)
+    orientation = np.round(np.rad2deg(command.orientation), 1)
+    height = round(command.height, 2)
+    return f"velocity {velocity}  height {height}  rpy_deg {orientation}"
+
+
+def sleep_to_rate(last_time, timestep):
+    next_time = last_time + timestep
+    now = time.perf_counter()
+    if next_time > now:
+        time.sleep(next_time - now)
+        rate_time = next_time
+    else:
+        rate_time = now
+    return rate_time
+
+
+def build_viewer(model, data, key_callback):
+    launch = mujoco.viewer.launch_passive
+    viewer = launch(model, data, key_callback=key_callback)
+    viewer.cam.azimuth = 120
+    viewer.cam.elevation = -20
+    viewer.cam.distance = 3.0
+    viewer.cam.lookat = np.asarray([0.0, 0.0, 0.8])
+    return viewer
+
+
+if __name__ == "__main__":
+    repositories = Path(__file__).resolve().parents[3]
+    sibling = repositories / "GR00T-WholeBodyControl" / "decoupled_wbc"
+    sibling = sibling / "sim2mujoco" / "resources" / "robots" / "g1"
+    default_scene_dir = os.environ.get("GEAR_WBC_SCENE_DIR", sibling)
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scene-dir", type=Path, default=default_scene_dir,
+                        help="g1 directory holding g1_gear_wbc.xml")
+    parser.add_argument("--steps", type=int, default=0,
+                        help="stop after this many simulation steps")
+    parser.add_argument("--headless", action="store_true")
+    arguments = parser.parse_args()
+
+    scene_path = Path(arguments.scene_dir) / "g1_gear_wbc.xml"
+    if not scene_path.exists():
+        raise SystemExit(f"Missing MuJoCo scene: {scene_path}")
+
+    print(CONTROLS)
+    print(f"Loading PAZ GEAR-WBC weights and scene from {scene_path}")
+    models = GearWBC(weights="pretrained")
+    model, data = build_plant(scene_path)
+
+    command = build_command()
+    history = build_history()
+    action = np.zeros(ACTION_DIM, "float32")
+    target_angles = LOWER_BODY_ANGLES.copy()
+
+    def key_callback(keycode):
+        global command
+        command = apply_key(command, chr(keycode).lower())
+        print(describe(command))
+
+    if arguments.headless:
+        viewer = None
+    else:
+        viewer = build_viewer(model, data, key_callback)
+
+    step, last_time = 0, time.perf_counter()
+    while arguments.steps == 0 or step < arguments.steps:
+        if viewer is not None and not viewer.is_running():
+            break
+        data.ctrl[:] = compute_control(data, target_angles)
+        mujoco.mj_step(model, data)
+        step = step + 1
+        if step % CONTROL_DECIMATION == 0:
+            frame = build_observation_frame(data, command, action)
+            observation = update_history(history, frame)
+            action = compute_action(models, observation, command)
+            target_angles = compute_target_angles(action)
+        if viewer is not None:
+            viewer.sync()
+            last_time = sleep_to_rate(last_time, SIMULATION_STEP)
+
+    print(f"Ran {step} steps. Final base height {data.qpos[2]:.3f} m")
+    if viewer is not None:
+        viewer.close()
+        time.sleep(0.25)

--- a/examples/gear_wbc/simulation.py
+++ b/examples/gear_wbc/simulation.py
@@ -1,0 +1,149 @@
+"""MuJoCo support code for the PAZ GEAR-WBC demonstration.
+
+The constants below are the released deployment values taken from
+decoupled_wbc/sim2mujoco/resources/robots/g1/g1_gear_wbc.yaml.
+"""
+
+from collections import deque
+from collections import namedtuple
+
+import mujoco
+import numpy as np
+
+from paz.backend.lie.quaternion import to_matrix
+from paz.models.foundation.gear_wbc.model import ACTION_DIM
+from paz.models.foundation.gear_wbc.model import FRAME_DIM
+from paz.models.foundation.gear_wbc.model import NUM_HISTORY_FRAMES
+
+NUM_JOINTS = 29
+SIMULATION_STEP = 0.005
+CONTROL_DECIMATION = 4
+ACTION_SCALE = 0.25
+ANGULAR_VELOCITY_SCALE = 0.5
+JOINT_VELOCITY_SCALE = 0.05
+VELOCITY_COMMAND_SCALE = np.array([2.0, 2.0, 0.5], "float32")
+DEFAULT_HEIGHT = 0.74
+BALANCE_SPEED = 0.05
+
+LOWER_BODY_ANGLES = np.array(
+    [-0.1, 0.0, 0.0, 0.3, -0.2, 0.0,
+     -0.1, 0.0, 0.0, 0.3, -0.2, 0.0,
+     0.0, 0.0, 0.0], "float32")
+LOWER_BODY_GAINS = np.array(
+    [150, 150, 150, 200, 40, 40,
+     150, 150, 150, 200, 40, 40,
+     250, 250, 250], "float32")
+LOWER_BODY_DAMPINGS = np.array(
+    [2.0, 2.0, 2.0, 4.0, 2.0, 2.0,
+     2.0, 2.0, 2.0, 4.0, 2.0, 2.0,
+     5.0, 5.0, 5.0], "float32")
+UPPER_BODY_GAIN = 100.0
+UPPER_BODY_DAMPING = 0.5
+
+# GEAR-WBC is a decoupled controller: it commands the lower body only, so
+# the arms are held at the zeros the observation is normalized against.
+UPPER_BODY_ANGLES = np.zeros(NUM_JOINTS - ACTION_DIM, "float32")
+DEFAULT_ANGLES = np.concatenate([LOWER_BODY_ANGLES, UPPER_BODY_ANGLES])
+
+Command = namedtuple("Command", "velocity height orientation")
+
+
+def build_command():
+    velocity = np.zeros(3, "float32")
+    orientation = np.zeros(3, "float32")
+    return Command(velocity, DEFAULT_HEIGHT, orientation)
+
+
+def build_plant(scene_path):
+    model = mujoco.MjModel.from_xml_path(str(scene_path))
+    model.opt.timestep = SIMULATION_STEP
+    return model, mujoco.MjData(model)
+
+
+def build_history():
+    empty_frame = np.zeros(FRAME_DIM, "float32")
+    frames = [empty_frame] * NUM_HISTORY_FRAMES
+    return deque(frames, maxlen=NUM_HISTORY_FRAMES)
+
+
+def build_observation_frame(data, command, previous_action):
+    joint_end = 13 + NUM_JOINTS
+    velocity_end = joint_end + NUM_JOINTS
+    frame = np.zeros(FRAME_DIM, "float32")
+    frame[0:7] = build_command_frame(command)
+    frame[7:10] = data.qvel[3:6] * ANGULAR_VELOCITY_SCALE
+    frame[10:13] = compute_gravity_direction(data.qpos[3:7])
+    frame[13:joint_end] = compute_joint_positions(data)
+    frame[joint_end:velocity_end] = compute_joint_velocities(data)
+    frame[velocity_end:] = previous_action
+    return frame
+
+
+def build_command_frame(command):
+    frame = np.zeros(7, "float32")
+    frame[0:3] = command.velocity * VELOCITY_COMMAND_SCALE
+    frame[3] = command.height
+    frame[4:7] = command.orientation
+    return frame
+
+
+def compute_joint_positions(data):
+    return data.qpos[7:7 + NUM_JOINTS] - DEFAULT_ANGLES
+
+
+def compute_joint_velocities(data):
+    return data.qvel[6:6 + NUM_JOINTS] * JOINT_VELOCITY_SCALE
+
+
+def compute_gravity_direction(orientation):
+    gravity = np.array([0.0, 0.0, -1.0], "float32")
+    rotation = np.asarray(to_matrix(orientation))
+    return rotation.transpose() @ gravity
+
+
+def update_history(history, frame):
+    history.append(frame)
+    return np.concatenate(history)[np.newaxis]
+
+
+def select_actor(models, command):
+    # The release disagrees with itself at exactly BALANCE_SPEED: the MuJoCo
+    # runner uses <= and the deploy policy uses <. This follows the runner.
+    if np.linalg.norm(command.velocity) <= BALANCE_SPEED:
+        actor = models.balance
+    else:
+        actor = models.walk
+    return actor
+
+
+def compute_action(models, observation, command):
+    actor = select_actor(models, command)
+    return np.asarray(actor(observation, training=False))[0]
+
+
+def compute_target_angles(action):
+    return action * ACTION_SCALE + LOWER_BODY_ANGLES
+
+
+def compute_control(data, target_angles):
+    lower_torques = compute_lower_body_torques(data, target_angles)
+    upper_torques = compute_upper_body_torques(data)
+    return np.concatenate([lower_torques, upper_torques])
+
+
+def compute_lower_body_torques(data, target_angles):
+    positions = data.qpos[7:7 + ACTION_DIM]
+    velocities = data.qvel[6:6 + ACTION_DIM]
+    args = target_angles, positions, velocities
+    return compute_torques(*args, LOWER_BODY_GAINS, LOWER_BODY_DAMPINGS)
+
+
+def compute_upper_body_torques(data):
+    positions = data.qpos[7 + ACTION_DIM:7 + NUM_JOINTS]
+    velocities = data.qvel[6 + ACTION_DIM:6 + NUM_JOINTS]
+    args = UPPER_BODY_ANGLES, positions, velocities
+    return compute_torques(*args, UPPER_BODY_GAIN, UPPER_BODY_DAMPING)
+
+
+def compute_torques(targets, positions, velocities, gains, dampings):
+    return (targets - positions) * gains - velocities * dampings

--- a/examples/gear_wbc/simulation_test.py
+++ b/examples/gear_wbc/simulation_test.py
@@ -1,0 +1,114 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+from collections import namedtuple
+
+import numpy as np
+import pytest
+
+from simulation import ACTION_SCALE
+from simulation import BALANCE_SPEED
+from simulation import DEFAULT_ANGLES
+from simulation import JOINT_VELOCITY_SCALE
+from simulation import LOWER_BODY_ANGLES
+from simulation import NUM_JOINTS
+from simulation import VELOCITY_COMMAND_SCALE
+from simulation import build_command
+from simulation import build_command_frame
+from simulation import build_history
+from simulation import build_observation_frame
+from simulation import compute_gravity_direction
+from simulation import compute_target_angles
+from simulation import compute_torques
+from simulation import select_actor
+from simulation import update_history
+
+FakeData = namedtuple("FakeData", "qpos qvel")
+
+
+def build_fake_data(seed=0):
+    rng = np.random.default_rng(seed)
+    qpos = rng.normal(size=7 + NUM_JOINTS)
+    qpos[3:7] = [1.0, 0.0, 0.0, 0.0]
+    qvel = rng.normal(size=6 + NUM_JOINTS)
+    return FakeData(qpos, qvel)
+
+
+def test_observation_frame_places_every_field_at_its_release_offset():
+    data = build_fake_data()
+    command = build_command()
+    action = np.arange(15, dtype="float32")
+    frame = build_observation_frame(data, command, action)
+    assert frame.shape == (86,)
+    assert np.allclose(frame[0:3], command.velocity * VELOCITY_COMMAND_SCALE)
+    assert frame[3] == pytest.approx(command.height)
+    assert np.allclose(frame[4:7], command.orientation)
+    assert np.allclose(frame[10:13], [0.0, 0.0, -1.0], atol=1e-6)
+    joints = data.qpos[7:7 + NUM_JOINTS] - DEFAULT_ANGLES
+    assert np.allclose(frame[13:42], joints, atol=1e-6)
+    velocities = data.qvel[6:6 + NUM_JOINTS] * JOINT_VELOCITY_SCALE
+    assert np.allclose(frame[42:71], velocities, atol=1e-6)
+    assert np.allclose(frame[71:86], action)
+
+
+def test_command_frame_scales_velocity_but_not_height_or_orientation():
+    velocity = np.array([1.0, 1.0, 1.0], "float32")
+    orientation = np.array([0.1, 0.2, 0.3], "float32")
+    command = build_command()._replace(velocity=velocity, height=0.5,
+                                       orientation=orientation)
+    frame = build_command_frame(command)
+    assert np.allclose(frame[0:3], VELOCITY_COMMAND_SCALE)
+    assert frame[3] == pytest.approx(0.5)
+    assert np.allclose(frame[4:7], orientation)
+
+
+def test_gravity_direction_is_down_for_an_upright_base():
+    upright = np.array([1.0, 0.0, 0.0, 0.0])
+    direction = compute_gravity_direction(upright)
+    assert np.allclose(direction, [0.0, 0.0, -1.0], atol=1e-6)
+
+
+def test_gravity_direction_tilts_with_a_pitched_base():
+    half = np.sqrt(0.5)
+    pitched = np.array([half, 0.0, half, 0.0])
+    direction = compute_gravity_direction(pitched)
+    assert np.allclose(direction, [1.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_history_starts_zeroed_and_keeps_the_newest_frame_last():
+    history = build_history()
+    frame = np.arange(86, dtype="float32")
+    observation = update_history(history, frame)
+    assert observation.shape == (1, 516)
+    assert np.allclose(observation[0, :-86], 0.0)
+    assert np.allclose(observation[0, -86:], frame)
+
+
+def test_history_drops_the_oldest_frame_after_six_updates():
+    history = build_history()
+    for index in range(7):
+        frame = np.full(86, index, dtype="float32")
+        observation = update_history(history, frame)
+    assert np.allclose(observation[0, :86], 1.0)
+    assert np.allclose(observation[0, -86:], 6.0)
+
+
+def test_select_actor_switches_experts_at_the_release_threshold():
+    models = namedtuple("Models", "balance walk")("balance", "walk")
+    standing = build_command()
+    assert select_actor(models, standing) == "balance"
+    fast = np.array([BALANCE_SPEED + 0.01, 0.0, 0.0], "float32")
+    assert select_actor(models, standing._replace(velocity=fast)) == "walk"
+
+
+def test_target_angles_offset_the_scaled_action_from_the_default_pose():
+    action = np.ones(15, dtype="float32")
+    targets = compute_target_angles(action)
+    assert np.allclose(targets, LOWER_BODY_ANGLES + ACTION_SCALE)
+
+
+def test_torques_oppose_position_error_and_velocity():
+    args = np.zeros(2), np.array([1.0, -1.0]), np.array([1.0, 1.0])
+    torques = compute_torques(*args, 10.0, 2.0)
+    assert np.allclose(torques, [-12.0, 8.0])

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -50,6 +50,7 @@ from .foundation.gemma4.causal_lm import Gemma4CausalLM
 from .foundation.flower.pretrained import FLOWER
 from .foundation.flower.pretrained import FLOWERLiberoObject
 from .foundation.sonic.pretrained import SONIC
+from .foundation.gear_wbc.pretrained import GearWBC
 from .feature.xfeat.model import XFeatModel
 from .feature.xfeat.model import XFeat
 from .feature.lightglue.model import LighterGlue

--- a/paz/models/foundation/gear_wbc/conftest.py
+++ b/paz/models/foundation/gear_wbc/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["KERAS_BACKEND"] = "jax"

--- a/paz/models/foundation/gear_wbc/conversion.py
+++ b/paz/models/foundation/gear_wbc/conversion.py
@@ -1,0 +1,57 @@
+"""Import released GEAR-WBC ONNX weights into the ported Keras actor."""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+import onnx
+from onnx import numpy_helper
+
+from paz.models.foundation.gear_wbc.model import build_actor
+
+
+def port_weights(onnx_path):
+    actor = build_actor()
+    apply_actor_weights(actor, onnx.load(str(onnx_path)))
+    return actor
+
+
+def apply_actor_weights(actor, actor_onnx):
+    initializers = load_onnx_initializers(actor_onnx)
+    for name, kernel in initializers.items():
+        stack, layer_index, kind = name.split(".")
+        if kind == "weight":
+            bias = initializers[f"{stack}.{layer_index}.bias"]
+            weights = [kernel.transpose(1, 0), bias]
+            actor.get_layer(f"{stack}_{layer_index}").set_weights(weights)
+
+
+def load_onnx_initializers(model):
+    initializers = {}
+    for tensor in model.graph.initializer:
+        initializers[tensor.name] = numpy_helper.to_array(tensor)
+    return initializers
+
+
+def save_actor(onnx_path, output_path):
+    port_weights(onnx_path).save_weights(output_path)
+
+
+def build_argument_parser():
+    parser = ArgumentParser()
+    parser.add_argument("--balance_onnx", required=True)
+    parser.add_argument("--walk_onnx", required=True)
+    parser.add_argument("--output_dir", default="~/.keras/paz/models/gear_wbc")
+    return parser
+
+
+def main():
+    args = build_argument_parser().parse_args()
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    save_actor(args.balance_onnx, output_dir / "gear_wbc_balance.weights.h5")
+    save_actor(args.walk_onnx, output_dir / "gear_wbc_walk.weights.h5")
+    print(f"Saved ported GEAR-WBC weights to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/paz/models/foundation/gear_wbc/conversion_test.py
+++ b/paz/models/foundation/gear_wbc/conversion_test.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("onnx")
+
+from onnx import helper
+from onnx import numpy_helper
+
+from paz.models.foundation.gear_wbc.conversion import apply_actor_weights
+from paz.models.foundation.gear_wbc.model import build_actor
+
+
+def find_dense_layers(actor):
+    return [layer for layer in actor.layers if layer.get_weights()]
+
+
+def build_fake_actor_onnx(actor):
+    initializers, expected = [], {}
+    for layer in find_dense_layers(actor):
+        stack, layer_index = layer.name.rsplit("_", 1)
+        in_dim, out_dim = layer.get_weights()[0].shape
+        rng = np.random.default_rng(len(initializers))
+        weight = rng.normal(size=(out_dim, in_dim)).astype("float32")
+        bias = rng.normal(size=(out_dim,)).astype("float32")
+        prefix = f"{stack}.{layer_index}"
+        weight_name, bias_name = f"{prefix}.weight", f"{prefix}.bias"
+        initializers.append(numpy_helper.from_array(weight, weight_name))
+        initializers.append(numpy_helper.from_array(bias, bias_name))
+        expected[layer.name] = (weight.transpose(1, 0), bias)
+    graph = helper.make_graph([], "actor", [], [], initializer=initializers)
+    return helper.make_model(graph), expected
+
+
+def test_apply_actor_weights_matches_injected_values():
+    actor = build_actor()
+    actor_onnx, expected = build_fake_actor_onnx(actor)
+    apply_actor_weights(actor, actor_onnx)
+    for layer_name, (kernel, bias) in expected.items():
+        actual_kernel, actual_bias = actor.get_layer(layer_name).get_weights()
+        assert np.array_equal(actual_kernel, kernel)
+        assert np.array_equal(actual_bias, bias)
+
+
+def test_apply_actor_weights_covers_every_dense_layer():
+    actor = build_actor()
+    _, expected = build_fake_actor_onnx(actor)
+    assert len(expected) == 7

--- a/paz/models/foundation/gear_wbc/gear_wbc_test.py
+++ b/paz/models/foundation/gear_wbc/gear_wbc_test.py
@@ -1,0 +1,53 @@
+"""Opt-in numeric parity check against the real released GEAR-WBC weights.
+
+Skipped unless GEAR_WBC_RELEASE_DIR points at the released policy directory
+holding GR00T-WholeBodyControl-Balance.onnx and
+GR00T-WholeBodyControl-Walk.onnx (decoupled_wbc/sim2mujoco/resources/robots/
+g1/policy in GR00T-WholeBodyControl, with git-lfs pulled).
+"""
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ort = pytest.importorskip("onnxruntime")
+
+from paz.models.foundation.gear_wbc.conversion import port_weights
+from paz.models.foundation.gear_wbc.model import OBSERVATION_DIM
+
+RELEASE_DIR = os.environ.get("GEAR_WBC_RELEASE_DIR")
+RELEASE_NAMES = ("GR00T-WholeBodyControl-Balance.onnx",
+                 "GR00T-WholeBodyControl-Walk.onnx")
+
+
+def release_files_exist():
+    if not RELEASE_DIR:
+        return False
+    release_dir = Path(RELEASE_DIR)
+    return all((release_dir / name).exists() for name in RELEASE_NAMES)
+
+
+pytestmark = pytest.mark.skipif(
+    not release_files_exist(),
+    reason="GEAR_WBC_RELEASE_DIR not set to a real release directory")
+
+
+@pytest.mark.parametrize("release_name", RELEASE_NAMES)
+def test_actor_matches_onnx_runtime(release_name):
+    onnx_path = Path(RELEASE_DIR) / release_name
+    actor = port_weights(onnx_path)
+    session = ort.InferenceSession(str(onnx_path))
+    x = np.random.default_rng(0).normal(size=(4, OBSERVATION_DIM))
+    x = x.astype("float32")
+    onnx_action = session.run(None, {"input": x})[0]
+    paz_action = np.array(actor(x, training=False))
+    assert np.abs(onnx_action - paz_action).max() < 1e-4
+
+
+def test_balance_and_walk_are_distinct_experts():
+    actors = [port_weights(Path(RELEASE_DIR) / n) for n in RELEASE_NAMES]
+    x = np.random.default_rng(1).normal(size=(1, OBSERVATION_DIM))
+    x = x.astype("float32")
+    actions = [np.array(actor(x, training=False)) for actor in actors]
+    assert not np.allclose(actions[0], actions[1])

--- a/paz/models/foundation/gear_wbc/model.py
+++ b/paz/models/foundation/gear_wbc/model.py
@@ -1,0 +1,49 @@
+"""Keras architecture for the ported GEAR-WBC lower-body controller."""
+
+import keras
+from keras import layers
+
+NUM_HISTORY_FRAMES = 6
+FRAME_DIM = 86
+OBSERVATION_DIM = NUM_HISTORY_FRAMES * FRAME_DIM
+VELOCITY_DIM = 3
+LATENT_DIM = 32
+ACTION_DIM = 15
+
+
+def build_actor():
+    observation = keras.Input((OBSERVATION_DIM,), name="observation")
+    estimate = compute_estimate(observation)
+    velocity = estimate[:, :VELOCITY_DIM]
+    latent = compute_unit_norm(estimate[:, VELOCITY_DIM:])
+    current_frame = observation[:, -FRAME_DIM:]
+    parts = [current_frame, velocity, latent]
+    features = keras.ops.concatenate(parts, axis=-1)
+    args = features, (512, 256, 256), ACTION_DIM, "actor"
+    action = compute_dense_stack(*args)
+    return keras.Model(observation, action, name="gear_wbc_actor")
+
+
+def compute_estimate(observation):
+    # Estimates the base linear velocity and a motion latent that the actor
+    # cannot read off the current frame alone.
+    output_dim = VELOCITY_DIM + LATENT_DIM
+    args = observation, (256, 256), output_dim, "estimator"
+    return compute_dense_stack(*args)
+
+
+def compute_unit_norm(latent):
+    # keras.ops.norm traces to an unhashable axis under the JAX backend, so
+    # the release's ReduceL2 is spelled out here instead.
+    squares = keras.ops.sum(keras.ops.square(latent), axis=-1, keepdims=True)
+    norm = keras.ops.sqrt(squares)
+    return latent / keras.ops.maximum(norm, 1e-12)
+
+
+def compute_dense_stack(inputs, hidden_dims, output_dim, prefix):
+    x, layer_index = inputs, 0
+    for units in hidden_dims:
+        x = layers.Dense(units, name=f"{prefix}_{layer_index}")(x)
+        x = layers.Activation("elu", name=f"{prefix}_elu_{layer_index}")(x)
+        layer_index = layer_index + 2
+    return layers.Dense(output_dim, name=f"{prefix}_{layer_index}")(x)

--- a/paz/models/foundation/gear_wbc/model_test.py
+++ b/paz/models/foundation/gear_wbc/model_test.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from paz.models.foundation.gear_wbc.model import ACTION_DIM
+from paz.models.foundation.gear_wbc.model import LATENT_DIM
+from paz.models.foundation.gear_wbc.model import OBSERVATION_DIM
+from paz.models.foundation.gear_wbc.model import build_actor
+from paz.models.foundation.gear_wbc.model import compute_unit_norm
+
+
+def test_actor_maps_observation_history_to_lower_body_action():
+    actor = build_actor()
+    x = np.zeros((1, OBSERVATION_DIM), dtype="float32")
+    action = np.array(actor(x, training=False))
+    assert action.shape == (1, ACTION_DIM)
+
+
+def test_actor_parameter_count_matches_release():
+    assert build_actor().count_params() == 470578
+
+
+def test_older_frames_reach_the_action_through_the_estimator():
+    # The actor trunk is fed the last frame only, so an older frame can move
+    # the action only through the estimator. This pins that path as wired.
+    actor = build_actor()
+    x = np.zeros((1, OBSERVATION_DIM), dtype="float32")
+    older = x.copy()
+    older[0, 0] = 1.0
+    assert not np.allclose(actor(x, training=False),
+                           actor(older, training=False))
+
+
+def test_unit_norm_rescales_latent_to_unit_length():
+    latent = np.random.default_rng(0).normal(size=(4, LATENT_DIM))
+    norms = np.linalg.norm(np.array(compute_unit_norm(latent)), axis=-1)
+    assert np.allclose(norms, 1.0, atol=1e-6)
+
+
+def test_unit_norm_keeps_zero_latent_finite():
+    latent = np.zeros((1, LATENT_DIM), dtype="float32")
+    assert np.isfinite(np.array(compute_unit_norm(latent))).all()

--- a/paz/models/foundation/gear_wbc/pretrained.py
+++ b/paz/models/foundation/gear_wbc/pretrained.py
@@ -1,0 +1,38 @@
+"""Download and build the pretrained GEAR-WBC lower-body actors.
+
+Weights are Model Derivatives licensed by NVIDIA Corporation under the
+NVIDIA Open Model License (see the release's gear_wbc_LICENSE.txt /
+gear_wbc_NOTICE.txt at GEAR_WBC_ASSETS_URL). By calling GearWBC(weights=
+"pretrained") you agree to that Agreement and to NVIDIA's Trustworthy AI
+terms (https://www.nvidia.com/en-us/agreements/trustworthy-ai/terms/).
+"""
+
+from collections import namedtuple
+
+from keras.utils import get_file
+
+from paz.models.foundation.gear_wbc.model import build_actor
+
+GEAR_WBC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.30/"  # fmt: skip
+GEAR_WBC_CACHE_SUBDIR = "paz/models/gear_wbc"
+
+# The release ships two experts over one architecture: "balance" holds a
+# stance under near-zero velocity commands, "walk" locomotes.
+GearWBCModels = namedtuple("GearWBCModels", "balance walk")
+
+
+def GearWBC(weights="pretrained"):
+    balance, walk = build_actor(), build_actor()
+    if weights == "pretrained":
+        load_pretrained_weights(balance, walk)
+    return GearWBCModels(balance, walk)
+
+
+def load_pretrained_weights(balance, walk):
+    balance.load_weights(fetch_asset("gear_wbc_balance.weights.h5"))
+    walk.load_weights(fetch_asset("gear_wbc_walk.weights.h5"))
+
+
+def fetch_asset(filename):
+    url = GEAR_WBC_ASSETS_URL + filename
+    return get_file(filename, url, cache_subdir=GEAR_WBC_CACHE_SUBDIR)

--- a/paz/models/foundation/gear_wbc/pretrained_test.py
+++ b/paz/models/foundation/gear_wbc/pretrained_test.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from paz.models.foundation.gear_wbc.model import ACTION_DIM
+from paz.models.foundation.gear_wbc.model import OBSERVATION_DIM
+from paz.models.foundation.gear_wbc.pretrained import GearWBC
+
+
+def test_pretrained_gear_wbc_downloads_and_runs():
+    models = GearWBC(weights="pretrained")
+    x = np.zeros((1, OBSERVATION_DIM), dtype="float32")
+    for actor in (models.balance, models.walk):
+        action = np.array(actor(x, training=False))
+        assert action.shape == (1, ACTION_DIM)
+        assert np.isfinite(action).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ sonic = [
     "mujoco>=3.3",
     "onnx>=1.16",
 ]
+gear_wbc = [
+    "mujoco>=3.3",
+    "onnx>=1.16",
+]
 
 [project.urls]
 Homepage = "https://github.com/oarriaga/paz"


### PR DESCRIPTION
Adds the GR00T-WholeBodyControl decoupled whole-body controller as
`paz.models.foundation.gear_wbc`, alongside the existing SONIC port.

Where SONIC is a motion-tracking behavior foundation model that drives all
29 joints from a reference, GEAR-WBC is command-conditioned: it takes a
velocity command, base height and torso orientation, and drives only the
G1's 12 leg and 3 waist joints at 50 Hz. The arms are left to a separate IK
stack, which is what "decoupled" refers to; the demo holds them at their
default pose. It is also ~48x smaller: 0.47M parameters per expert against
SONIC's 22.5M.

`GearWBC()` returns the release's two experts, `balance` and `walk`,
selected on the velocity command norm exactly as the deployment code does.
`examples/gear_wbc` adds a keyboard-steered MuJoCo demo.

## Architecture

Observation is a 6-frame history of an 86-dim vector (516). An estimator MLP
(516-256-256-35, ELU) produces a 3-dim base linear velocity estimate plus a
32-dim L2-normalized latent; those are concatenated with the most recent
frame only (121) and fed to the actor MLP (512-256-256-15, ELU).

## Verification

- Ported actor vs the release ONNX under onnxruntime: max diff **<1e-4** for
  both experts. Runs opt-in via `GEAR_WBC_RELEASE_DIR`.
- The demo's observation builder is **bit-exact** (0.0) against the upstream
  `run_mujoco_gear_wbc.py` math over 20 randomized MuJoCo states.
- Headless CPU demo: balances at 0.747 m against a 0.74 m command over 2000
  steps; walks +6.7 m on a 0.4 m/s command; turns in place on a yaw command.
- `pytest paz/models/foundation/gear_wbc/` 11 passed;
  `pytest examples/gear_wbc/simulation_test.py` 9 passed;
  `pytest paz/models/foundation/sonic/` 18 passed, 2 skipped (unchanged).

## Not in this PR

Weights are not yet hosted. `pretrained.py` points at altamira-data v0.30,
so `GearWBC(weights="pretrained")` 404s until that release is published; the
converted weights and their NVIDIA Open Model License / NOTICE files are
staged and ready to upload. Everything else is exercised by the opt-in
parity test against the release ONNX.

## Licensing

Upstream is dual-licensed: source Apache-2.0, weights NVIDIA Open Model
License. That is the same license as the SONIC weights already hosted in
altamira-data v0.28, which permits redistribution given a copy of the
Agreement and an attribution NOTICE, so the hosting follows that precedent.

## Upstream quirks, deliberately preserved

- The gait clock (`gait_indices`, `clock_inputs`, `freq_cmd`) is computed
  upstream but commented out of the observation. It is dead code in the
  released 86-dim contract and is not ported.
- `g1_gear_wbc.yaml` still names `policy/ft92.onnx` and `ft109.onnx`; the
  shipped checkpoints are `GR00T-WholeBodyControl-{Balance,Walk}.onnx`.
- The expert threshold is `<=` in the MuJoCo runner but `<` in the deploy
  policy class. This follows the runner; noted in a comment at the call site.