### PR TITLE
Point GEAR-WBC weights at altamira-data v0.31

### DIFF
--- a/paz/models/foundation/gear_wbc/pretrained.py
+++ b/paz/models/foundation/gear_wbc/pretrained.py
@@ -13,7 +13,7 @@ from keras.utils import get_file
 
 from paz.models.foundation.gear_wbc.model import build_actor
 
-GEAR_WBC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.30/"  # fmt: skip
+GEAR_WBC_ASSETS_URL = "https://github.com/oarriaga/altamira-data/releases/download/v0.31/"  # fmt: skip
 GEAR_WBC_CACHE_SUBDIR = "paz/models/gear_wbc"
 
 # The release ships two experts over one architecture: "balance" holds a


### PR DESCRIPTION
Follow-up to #417, which landed with the weights not yet hosted.

`pretrained.py` pointed at altamira-data **v0.30**, but that tag was already
taken by the SAM 2 image weights, so `GearWBC(weights="pretrained")` fetched
from the wrong release and 404'd. v0.31 was the next free tag in the active
sequence — v0.32 and v0.33 exist but are legacy releases backdated to 2019
and 2023, so they could not be reused.

The GEAR-WBC weights are now published:
https://github.com/oarriaga/altamira-data/releases/tag/v0.31

The release carries `gear_wbc_balance.weights.h5`,
`gear_wbc_walk.weights.h5`, and the NVIDIA Open Model License plus an
attribution NOTICE, matching the SONIC v0.28 layout.

## Verification

- Cache cleared, then `GearWBC(weights="pretrained")` downloads both experts;
  their sha256 match the uploaded artifacts exactly
  (`379ef32b…` balance, `f90e23a6…` walk).
- The **downloaded** weights reproduce the release ONNX under onnxruntime to
  **4.8e-06**, confirming the hosted artifacts are the right files rather
  than just loadable ones.
- `pytest paz/models/foundation/gear_wbc/` 11 passed — `pretrained_test.py`
  now exercises a real download instead of failing on a 404.
- `pytest examples/gear_wbc/simulation_test.py` 9 passed;
  `pytest paz/models/foundation/sonic/` 18 passed, 2 skipped (unchanged).
- Headless CPU demo on the hosted weights: balances at 0.747 m against a
  0.74 m command over 2000 steps.