### PR TITLE
Point SAM 2 video weights at altamira-data v0.34

### DIFF
--- a/paz/models/foundation/sam2/pretrained.py
+++ b/paz/models/foundation/sam2/pretrained.py
@@ -20,7 +20,7 @@ from paz.models.foundation.sam2 import configuration as cfg
 
 ALTAMIRA = "https://github.com/oarriaga/altamira-data/releases/download/"
 SAM2_IMAGE_URL = ALTAMIRA + "v0.30/"
-SAM2_VIDEO_URL = ALTAMIRA + "v0.32/"
+SAM2_VIDEO_URL = ALTAMIRA + "v0.34/"
 SAM2_CACHE = "paz/models/sam2"
 
 


### PR DESCRIPTION
The tag baked into #411 was already taken by unrelated data, so every
`SAMHiera*Video` factory, every `TrackSAMHiera*` application and
`examples/sam2/track_video.py` failed on `weights="pretrained"` with a 404. The
video weights are now hosted at altamira-data
[v0.34](https://github.com/oarriaga/altamira-data/releases/tag/v0.34): five
files plus a sha256 manifest per variant, 48 assets and 233 MB in total. The
image weights keep coming from v0.30, so nothing is duplicated.

## Verification
- Emptied the weight cache, then `paz.models.SAMHieraTiny21Video()` downloaded
  and checksum-verified all five video files, loaded nine sub-models, and
  reproduced the reference masks: worst IoU 0.999979 against the official
  `SAM2VideoPredictor` over six frames, identical to the pre-hosting numbers.
- `examples/sam2/track_video.py` runs with no arguments and writes the overlay
  video (20 frames in 20 s on an RTX A4000).
- `pytest paz/models/foundation/sam2 paz/applications/trackers_test.py` — 46
  passed, 2 skipped; 16 passed with `PAZ_SAM2_DOWNLOAD=1`, which exercises the
  download path for both the image and video factories.