### PR TITLE
Drive the GEAR-WBC demo with a PlayStation controller

### DIFF
--- a/examples/gear_wbc/README.md
+++ b/examples/gear_wbc/README.md
@@ -9,7 +9,9 @@ this demo simply holds at their default pose.
 
 Unlike SONIC, GEAR-WBC needs no reference motion. It takes a velocity
 command, a base height and a torso orientation, so it is steered directly
-from the keyboard.
+from a PlayStation controller. The pad is read outside the MuJoCo viewer,
+which leaves the viewer's own key bindings alone instead of toggling
+visualization state on every steering input.
 
 The release ships two experts over one architecture. The demo picks between
 them exactly as the deployment code does: a velocity command norm at or below
@@ -20,6 +22,10 @@ them exactly as the deployment code does: a velocity command norm at or below
 From the PAZ repository:
 
     python3 -m pip install -e '.[gear_wbc]'
+
+A PlayStation controller has to be connected before launching, over USB or
+Bluetooth. SDL reads it through `/dev/input/js0`, so no driver setup is
+needed beyond pairing it.
 
 The demo also needs the G1 MuJoCo plant from a local
 GR00T-WholeBodyControl checkout, at
@@ -42,27 +48,44 @@ MuJoCo fails to parse the pointer files that stand in for the STL meshes.
 
     python3 examples/gear_wbc/mujoco_demo.py
 
-The first launch compiles the actors with JAX and can take several seconds.
-CPU execution is available with:
+Both experts are compiled with `jax.jit` up front, so the first launch takes
+several seconds and neither expert stalls the loop when a command first
+selects it. This matters more than it looks: called eagerly, one actor costs
+7.7 ms on the CPU and 18.5 ms on a laptop GPU, against a 20 ms control
+period, which is enough on its own to drop the demo below real time.
 
-    JAX_PLATFORMS=cpu python3 examples/gear_wbc/mujoco_demo.py
+    eager   7.74 ms/call CPU   18.52 ms/call GPU
+    jitted  0.27 ms/call CPU    1.15 ms/call GPU
 
-A fixed-length headless run is useful as a smoke check:
+The demo therefore runs on the CPU by default. A single 15-joint actor at
+batch one is bound by launch latency rather than throughput, so the CPU wins
+per call and leaves the GPU free. To override:
+
+    JAX_PLATFORMS=cuda python3 examples/gear_wbc/mujoco_demo.py
+
+A fixed-length headless run is useful as a smoke check. It still needs the
+pad connected, and holds whatever command the pad reports:
 
     python3 examples/gear_wbc/mujoco_demo.py --headless --steps 1000
 
 ## Controls
 
-| Key | Action |
+Every input self-centers, so the whole command is a pure function of the
+pad: release it and the robot returns to standing at the default 0.74 m
+height with a level torso, back on the balance expert.
+
+| Input | Action |
 | --- | --- |
-| w / s | Increase or decrease forward velocity |
-| a / d | Increase or decrease lateral velocity |
-| q / e | Increase or decrease yaw rate |
-| z | Stop, returning to the balance expert |
-| 1 / 2 | Raise or lower the commanded base height |
-| 3 / 4 | Torso roll |
-| 5 / 6 | Torso pitch |
-| 7 / 8 | Torso yaw |
+| Left stick | Forward and lateral velocity, up to 0.5 and 0.4 m/s |
+| Right stick, left / right | Yaw rate, up to 1.0 rad/s |
+| Right stick, up / down | Base height, 0.74 m plus or minus 0.15 m |
+| L2 / R2 | Torso roll, up to 20 degrees each way |
+| D-pad up / down | Torso pitch |
+| D-pad left / right | Torso yaw |
+
+Lateral speed is capped lower than forward speed on purpose: upstream
+recommends staying near 0.4 m/s when strafing, because the cross-legged
+foot placement of a side step collides at higher speeds.
 
 ## Weights
 

--- a/examples/gear_wbc/controller.py
+++ b/examples/gear_wbc/controller.py
@@ -1,0 +1,88 @@
+"""PlayStation controller input for the PAZ GEAR-WBC demonstration.
+
+The axis order is the one SDL reports for the Sony Wireless Controller on
+Linux: both sticks, both analog triggers, and the d-pad as a hat.
+"""
+
+import os
+
+# SDL pumps joystick state from the video event loop, so the dummy driver
+# keeps the pad readable headless. It never opens a window of its own.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
+import numpy as np
+import pygame
+
+from simulation import Command
+from simulation import DEFAULT_HEIGHT
+
+LEFT_X, LEFT_Y, LEFT_TRIGGER = 0, 1, 2
+RIGHT_X, RIGHT_Y, RIGHT_TRIGGER = 3, 4, 5
+NUM_AXES = 6
+
+DEADZONE = 0.1
+MAX_FORWARD_SPEED = 0.5
+MAX_LATERAL_SPEED = 0.4
+MAX_YAW_RATE = 1.0
+HEIGHT_RANGE = 0.15
+MAX_TORSO_ANGLE = np.deg2rad(20)
+
+CONTROLS = """GEAR-WBC / PAZ controller
+  left stick         forward and lateral velocity
+  right stick x      yaw rate
+  right stick y      base height
+  L2 / R2            torso roll
+  d-pad up / down    torso pitch
+  d-pad left / right torso yaw
+
+Every input self-centers: release the pad to stand at the default pose.
+"""
+
+
+def build_pad():
+    pygame.init()
+    pygame.joystick.init()
+    if pygame.joystick.get_count() == 0:
+        raise SystemExit("Connect a PlayStation controller and rerun.")
+    return pygame.joystick.Joystick(0)
+
+
+def read_command(pad):
+    pygame.event.pump()
+    axes = [pad.get_axis(index) for index in range(NUM_AXES)]
+    return compute_command(axes, pad.get_hat(0))
+
+
+def compute_command(axes, hat):
+    height_offset = apply_deadzone(axes[RIGHT_Y]) * HEIGHT_RANGE
+    velocity = compute_velocity(axes)
+    orientation = compute_orientation(axes, hat)
+    return Command(velocity, DEFAULT_HEIGHT - height_offset, orientation)
+
+
+def compute_velocity(axes):
+    forward = apply_deadzone(-axes[LEFT_Y]) * MAX_FORWARD_SPEED
+    lateral = apply_deadzone(-axes[LEFT_X]) * MAX_LATERAL_SPEED
+    yaw_rate = apply_deadzone(-axes[RIGHT_X]) * MAX_YAW_RATE
+    return np.array([forward, lateral, yaw_rate], "float32")
+
+
+def compute_orientation(axes, hat):
+    right_trigger = to_unit_range(axes[RIGHT_TRIGGER])
+    left_trigger = to_unit_range(axes[LEFT_TRIGGER])
+    hat_x, hat_y = hat
+    angles = right_trigger - left_trigger, hat_y, -hat_x
+    return (np.array(angles) * MAX_TORSO_ANGLE).astype("float32")
+
+
+def apply_deadzone(value):
+    if abs(value) < DEADZONE:
+        scaled = 0.0
+    else:
+        scaled = (value - np.sign(value) * DEADZONE) / (1.0 - DEADZONE)
+    return scaled
+
+
+def to_unit_range(value):
+    return (value + 1.0) / 2.0

--- a/examples/gear_wbc/controller_test.py
+++ b/examples/gear_wbc/controller_test.py
@@ -1,0 +1,94 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import pytest
+
+from controller import DEADZONE
+from controller import HEIGHT_RANGE
+from controller import LEFT_X
+from controller import LEFT_Y
+from controller import MAX_FORWARD_SPEED
+from controller import MAX_LATERAL_SPEED
+from controller import MAX_TORSO_ANGLE
+from controller import MAX_YAW_RATE
+from controller import RIGHT_TRIGGER
+from controller import RIGHT_X
+from controller import RIGHT_Y
+from controller import apply_deadzone
+from controller import compute_command
+from simulation import DEFAULT_HEIGHT
+
+CENTERED = 0, 0
+
+
+def build_released_axes():
+    return [0.0, 0.0, -1.0, 0.0, 0.0, -1.0]
+
+
+def test_released_pad_commands_the_default_standing_pose():
+    command = compute_command(build_released_axes(), CENTERED)
+    assert np.allclose(command.velocity, 0.0)
+    assert command.height == pytest.approx(DEFAULT_HEIGHT)
+    assert np.allclose(command.orientation, 0.0)
+
+
+def test_resting_stick_offset_stays_inside_the_deadzone():
+    axes = build_released_axes()
+    axes[LEFT_Y] = -0.05
+    axes[RIGHT_Y] = 0.05
+    command = compute_command(axes, CENTERED)
+    assert np.allclose(command.velocity, 0.0)
+    assert command.height == pytest.approx(DEFAULT_HEIGHT)
+
+
+def test_left_stick_forward_commands_forward_velocity_alone():
+    axes = build_released_axes()
+    axes[LEFT_Y] = -1.0
+    command = compute_command(axes, CENTERED)
+    assert command.velocity[0] == pytest.approx(MAX_FORWARD_SPEED)
+    assert np.allclose(command.velocity[1:], 0.0)
+
+
+def test_left_stick_left_commands_positive_lateral_velocity():
+    axes = build_released_axes()
+    axes[LEFT_X] = -1.0
+    command = compute_command(axes, CENTERED)
+    assert command.velocity[1] == pytest.approx(MAX_LATERAL_SPEED)
+
+
+def test_right_stick_left_commands_a_positive_yaw_rate():
+    axes = build_released_axes()
+    axes[RIGHT_X] = -1.0
+    command = compute_command(axes, CENTERED)
+    assert command.velocity[2] == pytest.approx(MAX_YAW_RATE)
+
+
+def test_right_stick_down_lowers_the_commanded_base_height():
+    axes = build_released_axes()
+    axes[RIGHT_Y] = 1.0
+    command = compute_command(axes, CENTERED)
+    assert command.height == pytest.approx(DEFAULT_HEIGHT - HEIGHT_RANGE)
+
+
+def test_right_trigger_rolls_the_torso_to_its_right():
+    axes = build_released_axes()
+    axes[RIGHT_TRIGGER] = 1.0
+    command = compute_command(axes, CENTERED)
+    assert command.orientation[0] == pytest.approx(MAX_TORSO_ANGLE)
+    assert np.allclose(command.orientation[1:], 0.0)
+
+
+def test_hat_commands_torso_pitch_forward_and_yaw_toward_its_right():
+    axes = build_released_axes()
+    pitched = compute_command(axes, (0, 1))
+    yawed = compute_command(axes, (1, 0))
+    assert pitched.orientation[1] == pytest.approx(MAX_TORSO_ANGLE)
+    assert yawed.orientation[2] == pytest.approx(-MAX_TORSO_ANGLE)
+
+
+def test_deadzone_rescales_so_full_deflection_still_reaches_one():
+    assert apply_deadzone(DEADZONE / 2) == pytest.approx(0.0)
+    assert apply_deadzone(1.0) == pytest.approx(1.0)
+    assert apply_deadzone(-1.0) == pytest.approx(-1.0)

--- a/examples/gear_wbc/mujoco_demo.py
+++ b/examples/gear_wbc/mujoco_demo.py
@@ -3,9 +3,15 @@
 import argparse
 import os
 from pathlib import Path
+import signal
 import time
 
 os.environ.setdefault("KERAS_BACKEND", "jax")
+
+# One 15-joint actor at batch one is bound by launch latency, not by
+# throughput, so the CPU runs it faster per call than a GPU and leaves the
+# GPU free. Set JAX_PLATFORMS to override.
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
 
 import mujoco
 import mujoco.viewer
@@ -14,6 +20,9 @@ import numpy as np
 from paz.models import GearWBC
 from paz.models.foundation.gear_wbc.model import ACTION_DIM
 
+from controller import CONTROLS
+from controller import build_pad
+from controller import read_command
 from simulation import CONTROL_DECIMATION
 from simulation import LOWER_BODY_ANGLES
 from simulation import SIMULATION_STEP
@@ -21,78 +30,13 @@ from simulation import build_command
 from simulation import build_history
 from simulation import build_observation_frame
 from simulation import build_plant
+from simulation import compile_actors
 from simulation import compute_action
 from simulation import compute_control
 from simulation import compute_target_angles
 from simulation import update_history
 
-LINEAR_STEP = 0.2
-ANGULAR_STEP = 0.2
-HEIGHT_STEP = 0.1
-ORIENTATION_STEP = np.deg2rad(10)
-
-VELOCITY_KEYS = "w", "s", "a", "d", "q", "e", "z"
-HEIGHT_KEYS = "1", "2"
-ORIENTATION_KEYS = "3", "4", "5", "6", "7", "8"
-ORIENTATION_AXES = {"3": 0, "4": 0, "5": 1, "6": 1, "7": 2, "8": 2}
-
-CONTROLS = """GEAR-WBC / PAZ controls
-  w / s   forward velocity
-  a / d   lateral velocity
-  q / e   yaw rate
-  z       stop
-  1 / 2   base height
-  3 / 4   torso roll
-  5 / 6   torso pitch
-  7 / 8   torso yaw
-"""
-
-
-def apply_key(command, key):
-    if key in VELOCITY_KEYS:
-        command = apply_velocity_key(command, key)
-    elif key in HEIGHT_KEYS:
-        command = apply_height_key(command, key)
-    elif key in ORIENTATION_KEYS:
-        command = apply_orientation_key(command, key)
-    return command
-
-
-def apply_velocity_key(command, key):
-    velocity = command.velocity.copy()
-    if key == "w":
-        velocity[0] = velocity[0] + LINEAR_STEP
-    elif key == "s":
-        velocity[0] = velocity[0] - LINEAR_STEP
-    elif key == "a":
-        velocity[1] = velocity[1] + LINEAR_STEP
-    elif key == "d":
-        velocity[1] = velocity[1] - LINEAR_STEP
-    elif key == "q":
-        velocity[2] = velocity[2] + ANGULAR_STEP
-    elif key == "e":
-        velocity[2] = velocity[2] - ANGULAR_STEP
-    else:
-        velocity = np.zeros(3, "float32")
-    return command._replace(velocity=velocity)
-
-
-def apply_height_key(command, key):
-    if key == "1":
-        height = command.height + HEIGHT_STEP
-    else:
-        height = command.height - HEIGHT_STEP
-    return command._replace(height=height)
-
-
-def apply_orientation_key(command, key):
-    orientation = command.orientation.copy()
-    axis = ORIENTATION_AXES[key]
-    if key in ("3", "5", "7"):
-        orientation[axis] = orientation[axis] - ORIENTATION_STEP
-    else:
-        orientation[axis] = orientation[axis] + ORIENTATION_STEP
-    return command._replace(orientation=orientation)
+STATUS_STEPS = 100
 
 
 def describe(command):
@@ -113,13 +57,22 @@ def sleep_to_rate(last_time, timestep):
     return rate_time
 
 
-def build_viewer(model, data, key_callback):
-    launch = mujoco.viewer.launch_passive
-    viewer = launch(model, data, key_callback=key_callback)
+def restore_interrupt():
+    # launch_passive keeps SIGINT for itself, so Ctrl-C never reaches Python
+    # and the loop runs until the process is killed. Take the signal back.
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+
+
+def build_viewer(model, data):
+    # The camera tracks the pelvis. Left at the origin it loses the robot
+    # after a couple of metres, which reads as a frozen scene.
+    pelvis = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "pelvis")
+    viewer = mujoco.viewer.launch_passive(model, data)
+    viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
+    viewer.cam.trackbodyid = pelvis
     viewer.cam.azimuth = 120
     viewer.cam.elevation = -20
     viewer.cam.distance = 3.0
-    viewer.cam.lookat = np.asarray([0.0, 0.0, 0.8])
     return viewer
 
 
@@ -143,41 +96,45 @@ if __name__ == "__main__":
 
     print(CONTROLS)
     print(f"Loading PAZ GEAR-WBC weights and scene from {scene_path}")
-    models = GearWBC(weights="pretrained")
+    actors = compile_actors(GearWBC(weights="pretrained"))
     model, data = build_plant(scene_path)
+    pad = build_pad()
 
     command = build_command()
     history = build_history()
     action = np.zeros(ACTION_DIM, "float32")
     target_angles = LOWER_BODY_ANGLES.copy()
 
-    def key_callback(keycode):
-        global command
-        command = apply_key(command, chr(keycode).lower())
-        print(describe(command))
-
     if arguments.headless:
         viewer = None
     else:
-        viewer = build_viewer(model, data, key_callback)
+        viewer = build_viewer(model, data)
+        restore_interrupt()
 
+    control_period = SIMULATION_STEP * CONTROL_DECIMATION
     step, last_time = 0, time.perf_counter()
-    while arguments.steps == 0 or step < arguments.steps:
-        if viewer is not None and not viewer.is_running():
-            break
-        data.ctrl[:] = compute_control(data, target_angles)
-        mujoco.mj_step(model, data)
-        step = step + 1
-        if step % CONTROL_DECIMATION == 0:
-            frame = build_observation_frame(data, command, action)
-            observation = update_history(history, frame)
-            action = compute_action(models, observation, command)
-            target_angles = compute_target_angles(action)
-        if viewer is not None:
-            viewer.sync()
-            last_time = sleep_to_rate(last_time, SIMULATION_STEP)
+    try:
+        while arguments.steps == 0 or step < arguments.steps:
+            if viewer is not None and not viewer.is_running():
+                break
+            data.ctrl[:] = compute_control(data, target_angles)
+            mujoco.mj_step(model, data)
+            step = step + 1
+            if step % CONTROL_DECIMATION == 0:
+                command = read_command(pad)
+                frame = build_observation_frame(data, command, action)
+                observation = update_history(history, frame)
+                action = compute_action(actors, observation, command)
+                target_angles = compute_target_angles(action)
+                if viewer is not None:
+                    viewer.sync()
+                    last_time = sleep_to_rate(last_time, control_period)
+            if step % STATUS_STEPS == 0:
+                print(describe(command), end="\r", flush=True)
+    except KeyboardInterrupt:
+        pass
 
-    print(f"Ran {step} steps. Final base height {data.qpos[2]:.3f} m")
+    print(f"\nRan {step} steps. Final base height {data.qpos[2]:.3f} m")
     if viewer is not None:
         viewer.close()
         time.sleep(0.25)

--- a/examples/gear_wbc/simulation.py
+++ b/examples/gear_wbc/simulation.py
@@ -6,7 +6,9 @@ decoupled_wbc/sim2mujoco/resources/robots/g1/g1_gear_wbc.yaml.
 
 from collections import deque
 from collections import namedtuple
+from functools import partial
 
+import jax
 import mujoco
 import numpy as np
 
@@ -106,19 +108,31 @@ def update_history(history, frame):
     return np.concatenate(history)[np.newaxis]
 
 
-def select_actor(models, command):
+def compile_actors(models):
+    # Called eagerly, these actors cost 7.7 ms and dominate the 20 ms
+    # control period. Both are compiled here so neither expert stalls the
+    # loop the first time a command selects it.
+    balance = jax.jit(partial(models.balance, training=False))
+    walk = jax.jit(partial(models.walk, training=False))
+    observation = np.zeros((1, FRAME_DIM * NUM_HISTORY_FRAMES), "float32")
+    balance(observation)
+    walk(observation)
+    return models._replace(balance=balance, walk=walk)
+
+
+def select_actor(actors, command):
     # The release disagrees with itself at exactly BALANCE_SPEED: the MuJoCo
     # runner uses <= and the deploy policy uses <. This follows the runner.
     if np.linalg.norm(command.velocity) <= BALANCE_SPEED:
-        actor = models.balance
+        actor = actors.balance
     else:
-        actor = models.walk
+        actor = actors.walk
     return actor
 
 
-def compute_action(models, observation, command):
-    actor = select_actor(models, command)
-    return np.asarray(actor(observation, training=False))[0]
+def compute_action(actors, observation, command):
+    actor = select_actor(actors, command)
+    return np.asarray(actor(observation))[0]
 
 
 def compute_target_angles(action):

--- a/examples/sonic/mujoco_demo.py
+++ b/examples/sonic/mujoco_demo.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 from pathlib import Path
+import signal
 import time
 
 os.environ.setdefault("KERAS_BACKEND", "jax")
@@ -108,6 +109,12 @@ def close_viewer(viewer):
     # launch_passive owns a daemon render thread. Give it time to destroy its
     # GLFW resources before Python unloads MuJoCo during a scripted shutdown.
     time.sleep(0.25)
+
+
+def restore_interrupt():
+    # launch_passive keeps SIGINT for itself, so Ctrl-C never reaches Python
+    # and the loop runs until the process is killed. Take the signal back.
+    signal.signal(signal.SIGINT, signal.default_int_handler)
 
 
 if __name__ == "__main__":
@@ -302,6 +309,7 @@ if __name__ == "__main__":
             show_left_ui=False,
             show_right_ui=False,
         )
+        restore_interrupt()
         viewer.cam.azimuth = 120
         viewer.cam.elevation = -20
         viewer.cam.distance = 3.0
@@ -412,6 +420,8 @@ if __name__ == "__main__":
             if realtime:
                 last_time = sleep_to_rate(last_time, args.sim_dt)
             step += 1
+    except KeyboardInterrupt:
+        pass
     finally:
         if viewer is not None:
             close_viewer(viewer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ sonic = [
 gear_wbc = [
     "mujoco>=3.3",
     "onnx>=1.16",
+    "pygame>=2.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
Steers the GEAR-WBC MuJoCo demo from a PlayStation pad instead of the
keyboard, and fixes two problems found while testing it.

## Controller

The keyboard `key_callback` is gone. MuJoCo's passive viewer keeps its own
key bindings live, so every steering key also toggled viewer state. The pad
is read outside the viewer, so nothing leaks into it.

Every input self-centers, which makes the command a pure function of pad
state: no accumulated globals, no drift, and releasing the pad returns the
robot to standing at 0.74 m with a level torso.

| Input | Command |
| --- | --- |
| Left stick | forward / lateral velocity, 0.5 and 0.4 m/s |
| Right stick left / right | yaw rate, 1.0 rad/s |
| Right stick up / down | base height, 0.74 m ± 0.15 m |
| L2 / R2 | torso roll, ±20° |
| D-pad up / down, left / right | torso pitch, torso yaw |

Only axes and the hat are used, so no button indices are involved. Lateral
speed is capped below forward speed because upstream recommends staying near
0.4 m/s when strafing.

The full-deflection caps are a judgement call: upstream has no clip ranges
for GEAR-WBC, so 0.4 m/s comes from its strafing note and the rest from
reading `cmd_scale: [2.0, 2.0, 0.5]` as 1/range. They are single constants
in `controller.py` if you want them louder.

## jit, and CPU by default

`compute_action` called the Keras actor eagerly every control step:

| | eager | jitted |
| --- | --- | --- |
| CPU | 7.74 ms/call | 0.27 ms/call |
| GPU | 18.52 ms/call | 1.15 ms/call |

Against a 20 ms control period, eager GPU inference alone ran the loop at
0.96x real time before the viewer drew anything. `compile_actors` now jits
both experts and warms them up, so neither stalls the loop when a command
first selects it. The loop went from 0.96x to 9.61x real time. The demo
defaults to CPU because one 15-joint actor at batch one is bound by launch
latency, not throughput; `JAX_PLATFORMS` overrides it.

## Two demo fixes

`mujoco.viewer.launch_passive` keeps SIGINT for itself, so Ctrl-C never
became a `KeyboardInterrupt` and neither MuJoCo demo could be stopped
without `kill`. Reproduced with a viewer-only script containing no pygame and
no JAX, so this is pre-existing. Both demos now restore
`signal.default_int_handler` after `launch_passive`.

The gear_wbc camera also tracks the pelvis. Fixed at the origin it lost the
robot after about 2.5 m of walking, which reads as a frozen scene.

## Verification

- `pytest examples/gear_wbc` — 18 passed (9 new, covering the pad mapping and
  every sign convention)
- `pytest examples/sonic` — 11 passed
- `python3 mujoco_demo.py --headless --steps 1000` — ends upright at 0.747 m
- SIGINT to both running demos — exits cleanly; both hung before
- Scripted drive through every full-deflection command — never falls, stays
  upright, tracks the height command exactly
- pyflakes clean, nothing over 79 columns

Adds `pygame` to the `gear_wbc` extra.