### PR TITLE
Let the Florence-2 encoder skip padded instruction tokens

### DIFF
--- a/paz/models/foundation/florence2/florence2_test.py
+++ b/paz/models/foundation/florence2/florence2_test.py
@@ -67,3 +67,41 @@ def test_encoder_hidden_states_match_torch_fixture():
     hidden = model.predict([static, gripper, flow_and_text], verbose=0)
     reference = fixtures["encoder_hidden_states"]
     assert np.abs(hidden - reference).max() < 1e-4
+
+
+def test_default_attends_padding():
+    # The default has to behave like the reference, which attends every token,
+    # so appending padding must reach the real tokens as well.
+    model = build(**TINY)
+    images = np.random.default_rng(2).normal(size=(1, 32, 32, 3))
+    images = images.astype("float32")
+    short = np.array([[5, 6, 7]], "int32")
+    padded = np.array([[5, 6, 7, 1, 1]], "int32")
+    kept = model.predict([images, images, short], verbose=0)
+    grown = model.predict([images, images, padded], verbose=0)
+    assert np.abs(kept - grown[:, :kept.shape[1]]).max() > 1e-6
+
+
+def test_pad_id_hides_padding_from_real_tokens():
+    # With pad_id set, appending padding must not change the real tokens.
+    model = build(pad_id=1, **TINY)
+    images = np.random.default_rng(0).normal(size=(1, 32, 32, 3))
+    images = images.astype("float32")
+    short = np.array([[5, 6, 7]], "int32")
+    padded = np.array([[5, 6, 7, 1, 1]], "int32")
+    kept = model.predict([images, images, short], verbose=0)
+    grown = model.predict([images, images, padded], verbose=0)
+    assert np.abs(kept - grown[:, :kept.shape[1]]).max() < 1e-4
+
+
+def test_pad_id_changes_the_result_when_padding_is_present():
+    # Guard against the mask silently doing nothing.
+    images = np.random.default_rng(1).normal(size=(1, 32, 32, 3))
+    images = images.astype("float32")
+    padded = np.array([[5, 6, 7, 1, 1]], "int32")
+    masked = build(pad_id=1, **TINY)
+    unmasked = build(**TINY)
+    unmasked.set_weights(masked.get_weights())
+    with_mask = masked.predict([images, images, padded], verbose=0)
+    without = unmasked.predict([images, images, padded], verbose=0)
+    assert np.abs(with_mask - without).max() > 1e-6

--- a/paz/models/foundation/florence2/model.py
+++ b/paz/models/foundation/florence2/model.py
@@ -5,8 +5,15 @@ the FLOWER checkpoints. Two 112x112 views run through a shared DaViT
 image encoder (17 tokens each), token ids (leading ``<Flow>`` prompt
 token plus tokenized instruction) are embedded, and the concatenated
 sequence goes through the BART encoder with BART learned positions
-(offset 2) over the full merged sequence and an all-ones attention
-mask, exactly as FLOWER does at inference.
+(offset 2) over the full merged sequence, exactly as FLOWER does at
+inference.
+
+Pass ``pad_id`` to skip padded instruction tokens in self attention. It
+is off by default because the reference sends one exact-length prompt and
+attends everything; leaving it off keeps the encoder output identical to
+that reference. Batched training pads, so it opts in. The mask is derived
+from the token ids rather than taken as a separate input, so a caller
+cannot hand over a mask that disagrees with the tokens it sent.
 """
 from keras import ops
 from keras.layers import Embedding, Input, Lambda, LayerNormalization
@@ -19,7 +26,7 @@ from paz.models.foundation.florence2.vision import ImageEncoder
 
 def build(image_size=112, vocabulary_size=51290, hidden_dim=1024,
           num_layers=12, num_heads=16, ffn_dim=4096, max_positions=4098,
-          position_offset=2, stage_dims=(256, 512, 1024, 2048),
+          position_offset=2, pad_id=None, stage_dims=(256, 512, 1024, 2048),
           stage_depths=(1, 1, 9, 1), stage_heads=(8, 16, 32, 64),
           stage_groups=(8, 16, 32, 64), window_size=12):
     static_images = Input((image_size, image_size, 3), name="static_images")
@@ -34,12 +41,24 @@ def build(image_size=112, vocabulary_size=51290, hidden_dim=1024,
     text_tokens = embed(token_ids)
     tokens = (static_tokens, wrist_tokens, text_tokens)
     context = ops.concatenate(tokens, axis=1)
+    num_image = static_tokens.shape[1] + wrist_tokens.shape[1]
+    mask = build_padding_mask(token_ids, num_image, pad_id)
     x = add_positions(context, max_positions, position_offset)
     norm = LayerNormalization(epsilon=1e-5, name="layernorm_embedding")
-    encoder_args = (norm(x), None, num_layers, num_heads, ffn_dim)
+    encoder_args = (norm(x), mask, num_layers, num_heads, ffn_dim)
     context_tokens = build_encoder(*encoder_args)
     inputs = [static_images, wrist_images, token_ids]
     return Model(inputs, context_tokens, name="florence2_flower")
+
+
+def build_padding_mask(token_ids, num_image, pad_id):
+    if pad_id is None:
+        return None
+    # Every image token is real, so only the instruction can be padded.
+    text = ops.not_equal(token_ids, pad_id)
+    valid = ops.ones_like(text[:, :1])
+    images = ops.repeat(valid, num_image, axis=1)
+    return ops.concatenate([images, text], axis=1)
 
 
 def add_positions(x, max_positions, position_offset):


### PR DESCRIPTION
Required by bulkington `main`, which already calls
`florence2.build(image_size=..., pad_id=...)` after bulkington#24 merged. Without
this the FLOWER policy fails to build.

`build_encoder` already threaded a mask to `masked_attend`, but `model.build`
passed `None`, so a batched caller that pads its prompts had the padding attended
by self attention. Adds a `pad_id` parameter that derives the key padding mask
from the token ids, keeping image tokens always valid. Deriving it rather than
accepting it as an input means a caller cannot send a mask that disagrees with
its tokens.

`pad_id` defaults to `None` so the reference path is untouched: it sends one
exact-length prompt and attends everything, which is what
`test_encoder_hidden_states_match_torch_fixture` compares against. I could not
run that fixture (`FLORENCE2_WEIGHTS`/`FLORENCE2_FIXTURES` are not on this
machine), which is exactly why masking is opt-in rather than default.

Worth a reviewer's eye: whether upstream FLOWER masked padding during its own
training. If it did, masking matches pretraining. If it fed padded batches with
an all-ones mask, masking is a small distribution shift from what the pretrained
encoder saw. `intuitive-robots/flower_vla_calvin` at
`acb32ee85719e51aa94139b184c64b1b29f11d33` would settle it.

**Verification.** `florence2_test.py` + `flower_test.py`: 14 passed, 2 skipped
(both fixture tests, missing env vars). Three new tests cover the mask: the
default still lets padding reach the real tokens, `pad_id` hides it, and `pad_id`
demonstrably changes the result so the mask cannot silently no-op.

Supersedes #421, which also carried a Gemma4 gradient-checkpointing change. Only
FLOWER is being served, so nothing Gemma4-side is being landed for now.