### PR TITLE
Replace soft shadow occlusion sigmoid with a hard binary test

### DIFF
--- a/examples/differentiable_shape_rendering/phong_realism_levels.py
+++ b/examples/differentiable_shape_rendering/phong_realism_levels.py
@@ -1,10 +1,6 @@
 import jax
 import jax.numpy as jp
 import paz
-from paz.graphics.renderer import shadow
-
-soft_occlusion = shadow.compute_soft_occlusion
-shadow.compute_soft_occlusion = paz.partial(soft_occlusion, slope=1.0)
 
 H, W = 480, 640
 

--- a/examples/differentiable_shape_rendering/realistic_primitives.py
+++ b/examples/differentiable_shape_rendering/realistic_primitives.py
@@ -1,10 +1,6 @@
 import jax
 import jax.numpy as jp
 import paz
-from paz.graphics.renderer import shadow
-
-soft_occlusion = shadow.compute_soft_occlusion
-shadow.compute_soft_occlusion = paz.partial(soft_occlusion, slope=1.0)
 
 BLUE = jp.array([0.324, 0.692, 0.863])  # MyBlue
 GREEN = jp.array([154 / 255, 213 / 255, 135 / 255])  # YlGnI

--- a/examples/differentiable_shape_rendering/visualize_scene_gradients.py
+++ b/examples/differentiable_shape_rendering/visualize_scene_gradients.py
@@ -8,7 +8,6 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import paz
-from paz.graphics.renderer import shadow
 import paz.utils.plot as plot
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
@@ -23,7 +22,6 @@ OUTLIER_RATIO = 1.25
 CURVATURE_RATIO = 1e-3
 LUMINANCE_WEIGHTS = jp.array([0.2126, 0.7152, 0.0722])
 SIGNED_CMAP = "RdBu_r"
-SOFT_OCCLUSION = shadow.compute_soft_occlusion
 CAMERA_ARGS = (
     jp.array([0.0, 2.0, 2.0]),
     jp.array([0.0, 0.0, 0.0]),
@@ -74,10 +72,6 @@ def build_plane():
 def build_scene(shape_transform=jp.eye(4)):
     sphere = paz.graphics.Sphere(shape_transform, SHAPE_MATERIAL)
     return paz.graphics.Scene([sphere, build_plane()])
-
-
-def configure_soft_occlusion():
-    shadow.compute_soft_occlusion = paz.partial(SOFT_OCCLUSION, slope=1.0)
 
 
 def compute_autodiff_gradient(function, args, basis):
@@ -346,7 +340,6 @@ def plot_jacobian(function, args):
 
 
 def main():
-    configure_soft_occlusion()
     render = build_render(IMAGE_SHAPE)
     image, _ = render(scene=build_scene())
     image = paz.image.resize(image, (H // 2, W // 2), "bilinear")

--- a/paz/graphics/renderer/shadow.py
+++ b/paz/graphics/renderer/shadow.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 
-import jax
 import jax.numpy as jp
 
 import paz
@@ -40,7 +39,7 @@ def compute_occlusion(compiled, receiver, light, face_chunk):
         rows.append(compute_triangle_blockers(*blocker_args))
     masks = jp.concatenate([row[0] for row in rows], axis=0)
     depths = jp.concatenate([row[1] for row in rows], axis=0)
-    return compute_soft_occlusion(masks, depths, distance)
+    return compute_occlusion_mask(masks, depths, distance)
 
 
 def compute_light_directions(light, points):
@@ -144,12 +143,10 @@ def compute_shadow_depth_thresholds(same_shape):
     return jp.where(same_shape, SHADOW_SELF_HIT_EPSILON, paz.graphics.EPSILON)
 
 
-def compute_soft_occlusion(hit_masks, depths, light_lengths, slope=0.01):
+def compute_occlusion_mask(hit_masks, depths, light_lengths):
     closest_depths = jp.where(hit_masks, depths, paz.graphics.FARAWAY)
     closest_depths = jp.min(closest_depths, axis=0)
     scene_hit_mask = compute_scene_hit_mask(hit_masks)
     blockers = closest_depths <= light_lengths
     blocker_mask = jp.logical_and(scene_hit_mask, blockers)
-    difference = light_lengths - closest_depths
-    occlusion = jax.nn.sigmoid(slope * difference)
-    return jp.where(blocker_mask, occlusion, 0.0)
+    return jp.where(blocker_mask, 1.0, 0.0)

--- a/paz/graphics/renderer/shadow_test.py
+++ b/paz/graphics/renderer/shadow_test.py
@@ -129,15 +129,15 @@ def test_select_shadow_depths_keep_back_side_second_root():
     args += receiver_normals, light_directions
     hit_masks, depths = shadow.select_shadow_depths(*args)
     occlusion_args = hit_masks, depths, jp.array([0.01])
-    result = shadow.compute_soft_occlusion(*occlusion_args)
+    result = shadow.compute_occlusion_mask(*occlusion_args)
     assert bool(hit_masks[0, 0])
     assert float(depths[0, 0]) == pytest.approx(0.2)
     assert bool(hit_masks[1, 0])
     assert float(depths[1, 0]) == pytest.approx(5e-4)
-    assert float(result[0]) > 0.5
+    assert float(result[0]) == 1.0
 
 
-def test_compute_soft_occlusion():
+def test_compute_occlusion_mask():
     light_lengths = jp.array([10.0, 10.0, 10.0, 10.0])
     depths = jp.array(
         [[paz.graphics.FARAWAY, 5.0, 10.0, 15.0], [11.0, 11.0, 10.0, 11.0]]
@@ -145,11 +145,11 @@ def test_compute_soft_occlusion():
     rows = [[True, True, True, True], [False, False, True, False]]
     hit_masks = jp.array(rows)
     args = hit_masks, depths, light_lengths
-    result = shadow.compute_soft_occlusion(*args, slope=10.0)
-    assert float(result[1]) > 0.9
-    assert float(result[2]) == pytest.approx(0.5)
-    assert float(result[3]) == 0.0
+    result = shadow.compute_occlusion_mask(*args)
     assert float(result[0]) == 0.0
+    assert float(result[1]) == 1.0
+    assert float(result[2]) == 1.0
+    assert float(result[3]) == 0.0
 
 
 def test_saved_pose_sphere_self_shadow_keeps_later_roots():


### PR DESCRIPTION
## Summary
- The old shadow occlusion sigmoid derived softness from how far a blocker's depth exceeded the light distance, which has no physical basis and was discontinuous exactly at that boundary.
- Occlusion is now a plain blocked/not-blocked classification, matching the boolean hit tests already used elsewhere in the renderer.
- Updated the three example scripts that monkey-patched the removed function's `slope` for tuning.

## Test plan
- `pytest paz/graphics/renderer/shadow_test.py` — 8 passed
- `pytest paz/graphics/` — 285 passed, 1 pre-existing unrelated skip, including the shadow render snapshot test (unchanged at existing tolerance)
- `pytest tests/` — 260 passed, excluding two pre-existing `tf_keras` import failures unrelated to this change