### PR TITLE
Add a learning_to_walk MuJoCo example

### DIFF
--- a/examples/learning_to_walk/.gitignore
+++ b/examples/learning_to_walk/.gitignore
@@ -1,0 +1,1 @@
+unitree_g1_29dof_velocity_robust/

--- a/examples/learning_to_walk/README.md
+++ b/examples/learning_to_walk/README.md
@@ -1,0 +1,359 @@
+# A learned G1 walking policy in MuJoCo
+
+This example replays a `unitree_rl_lab` velocity-tracking policy for the
+Unitree G1 29-DoF, trained in IsaacLab under
+`Unitree-G1-29dof-Velocity-Robust`, inside MuJoCo. It is a sim-to-sim test:
+the policy never saw MuJoCo, so what it does here is a fair proxy for what
+it would do on hardware.
+
+The actor runs as pure Keras 3 on the JAX backend, compiled with
+`jax.jit`. There is no ONNX runtime anywhere in the loop; the weights are
+read straight out of the rsl_rl `model_*.pt` and copied into a functional
+Keras model.
+
+The point of the example is measurement. It drives the robot over the same
+five terrains it trained on, shoves it with a configurable force, and
+reports how often it goes down.
+
+## Install
+
+From the PAZ repository:
+
+    python3 -m pip install -e '.[learning_to_walk]'
+
+`torch` is only used to read the checkpoint. Nothing in the control loop
+touches it.
+
+A PlayStation controller is optional. Connect one over USB or Bluetooth to
+steer; SDL reads it through `/dev/input/js0`, so no driver setup is needed
+beyond pairing it. With no pad connected the robot holds `--speed` forward
+for the whole run, which is what makes a terrain measurable.
+
+The demo also needs the G1 MuJoCo plant from a local `unitree_mujoco`
+checkout, at `unitree_robots/g1/scene_29dof.xml`. It finds that
+automatically when the repository is a sibling of PAZ. For another layout,
+pass the location explicitly:
+
+    python3 examples/learning_to_walk/mujoco_demo.py \
+        --scene-dir /path/to/unitree_mujoco/unitree_robots/g1
+
+`WALK_SCENE_DIR` can be set instead of passing the flag every time.
+
+## Checkpoints
+
+Training runs go in `unitree_g1_29dof_velocity_robust/` next to this
+README, one directory per run, exactly as `unitree_rl_lab` writes them:
+
+    unitree_g1_29dof_velocity_robust/
+        2026-08-18_08-19-08/
+            model_28100.pt
+            params/deploy.yaml
+            params/env.yaml
+
+Both scripts pick the newest run's highest iteration by default. Pass
+`--checkpoint` to replay a specific one. The directory is gitignored, since
+a single run is a couple of hundred megabytes.
+
+## Run
+
+    python3 examples/learning_to_walk/mujoco_demo.py
+
+The actor is compiled with `jax.jit` up front, so the first launch takes a
+few seconds. Compiling matters less here than for a larger controller, but
+it is still worth an order of magnitude:
+
+    eager   0.72 ms/call CPU   1.94 ms/call GPU
+    jitted  0.03 ms/call CPU   0.12 ms/call GPU
+
+A single 29-joint actor at batch one is bound by launch latency rather than
+throughput, so the CPU wins per call and leaves the GPU free. The demo
+therefore runs on the CPU by default. To override:
+
+    JAX_PLATFORMS=cuda python3 examples/learning_to_walk/mujoco_demo.py
+
+The policy pins `jax_default_matmul_precision` to `float32`. Left at the
+XLA default a GPU runs these matmuls as TF32, which moves an action by
+about 6e-3 against the checkpoint, roughly a thousand times the error the
+CPU makes.
+
+A fixed-length headless run is a useful smoke check:
+
+    python3 examples/learning_to_walk/mujoco_demo.py --headless \
+        --steps 4000 --speed 0.5
+
+`--headless` drops the viewer and ignores the pad, so a scripted run always
+holds `--speed` and repeats. With the viewer, a connected pad steers and
+`--speed` takes over when there is none.
+
+## Controls
+
+| Input | Action |
+| --- | --- |
+| Left stick up / down | Forward velocity, 1.0 m/s ahead and 0.5 m/s back |
+| Left stick left / right | Lateral velocity, up to 0.3 m/s |
+| Right stick left / right | Yaw rate, up to 0.2 rad/s |
+| Cross | Shove the torso |
+
+Forward tracks well and lateral tracks weakly, but this policy does not
+turn: commanded at its trained maximum of 0.2 rad/s it yaws at 0.014 rad/s,
+and even at 1.0 rad/s it only reaches 0.107. `track_ang_vel_z` uses
+`exp(-error^2 / 0.5^2)` against a command range of only 0.2, so never
+turning already scores 0.85 of the available reward and there is almost
+nothing to learn from. Widening `ang_vel_z` and narrowing that std are
+training changes, not demo ones.
+
+Those limits are the command `limit_ranges` the policy was trained against,
+so a fully deflected stick asks for exactly the fastest thing it has seen.
+Yaw is the narrow one: this policy only ever trained on 0.2 rad/s, so it
+turns slowly no matter how hard the stick is pushed.
+
+The robot stands back up wherever it falls, so a run keeps going and the
+final line reports how many times it went down.
+
+## Terrain
+
+`--terrain` picks the ground and `--difficulty` scales it, where 1 is
+exactly what the training config specified. The four generated terrains
+rebuild the sub-terrains of
+`ROBUST_TERRAINS_CFG` as MuJoCo heightfields, keeping the cell size, height
+step and grade the training config asked for:
+
+| Name | Training sub-terrain | At difficulty 1 |
+| --- | --- | --- |
+| `flat` | `MeshPlaneTerrain` | the released ground plane |
+| `rough` | `HfRandomUniformTerrain` | rocks of 0 to 6 cm in 1 cm steps, on a 10 cm grid |
+| `slope` | `HfPyramidSlopedTerrain` | a 20 % grade falling away from a 2 m platform |
+| `inverted_slope` | `HfInvertedPyramidSlopedTerrain` | the same grade climbing away from it |
+| `boxes` | `MeshRandomGridTerrain` | a grid of 45 cm boxes, 0 to 5 cm tall |
+| `hills` | none, see below | rolling ground 6 cm deep, 2 m down to 25 cm |
+
+Difficulty scales the tallest feature or the grade and nothing else, so the
+`rough` height step stays at 1 cm and the box grid stays 45 cm wide at every
+setting. Below difficulty 0.084 the rough terrain would round to zero height
+levels, so it clamps to a single level rather than dividing by it.
+
+IsaacLab lays its sub-terrains out as 8 by 8 metre tiles. These patches
+span 20 metres instead, which keeps the local grade and cell size, what the
+feet actually feel, rather than the tile size. The released ground plane
+stays underneath the heightfield, so a fast run that reaches the edge of the
+patch walks off onto flat ground instead of out of the world.
+
+    python3 examples/learning_to_walk/mujoco_demo.py --terrain boxes
+    python3 examples/learning_to_walk/mujoco_demo.py --terrain rough \
+        --difficulty 0.5 --seed 3
+
+### Correlated ground
+
+Every terrain in the training mix is spatially uncorrelated. `rough` draws
+each 10 cm cell independently of its neighbours and `boxes` draws each box
+independently, so neither carries structure wider than one cell or one box.
+Real ground does. `hills` sums four octaves of smooth noise, halving the
+wavelength and the amplitude each time, which is the standard way to build a
+surface with the roughly fractal spectrum natural terrain has.
+
+    python3 examples/learning_to_walk/mujoco_demo.py --terrain hills
+
+Its default relief is 6 cm, the same as `rough` at difficulty 1, so the
+comparison isolates shape rather than height. At matched relief the two are
+not remotely the same surface:
+
+| Terrain | Relief | Mean local slope | Largest step between cells | Correlation length |
+| --- | --- | --- | --- | --- |
+| `rough` | 6 cm | 22.8 % | 6.0 cm | 10 cm, one cell |
+| `boxes` | 5 cm | 3.8 % | 4.9 cm | 30 cm |
+| `hills` | 6 cm | 1.1 % | 0.6 cm | 150 cm |
+
+Which says something about the training terrain as much as about this one:
+6 cm steps across 10 cm cells is rubble, not ground, and a policy trained on
+it has only ever seen relief arriving as high-frequency noise. `hills` at
+equal relief is twenty times gentler underfoot, so it gets hard through
+amplitude rather than through steps, and `--difficulty 10` is 60 cm of
+relief over 2 m, which is ordinary rough countryside.
+
+`hills` is reported as out of distribution at every difficulty, including
+below 1, because no amount of scaling turns an uncorrelated surface into a
+correlated one.
+
+### Out of distribution
+
+`--difficulty` is not capped at 1. Above it the terrain keeps scaling
+linearly past anything the policy trained on, which is the point: `rough`
+holds its 1 cm height step and just stacks more of them, and the slopes keep
+the same shape at a steeper grade.
+
+    python3 examples/learning_to_walk/mujoco_demo.py --terrain rough \
+        --difficulty 2.5
+
+Both scripts say what a difficulty actually builds, and flag it when it
+leaves the training range, so a number in the flag is never the only record
+of what was tested:
+
+    Control 50 Hz over physics at 200 Hz, decimation 4
+    Terrain rough at difficulty 2.50: rocks up to 15.0 cm in 1.0 cm steps
+      OUT OF DISTRIBUTION: 2.50x the 6.0 cm rocks it trained on
+    Pushes shove the torso at 400 N for 0.2 s, worth 2.28 m/s
+      OUT OF DISTRIBUTION: 2.28x the 1.0 m/s it trained on
+
+A push is measured against the 1.0 m/s velocity kick `push_robot` applied
+during training, so both axes of the test report the same way.
+
+## Perturbations
+
+`--push-force` shoves the torso through `xfrc_applied` for 0.2 s, in a
+random horizontal direction, on the 3 to 8 second interval the training
+config pushed at. On this plant a newton is worth 0.0057 m/s of base
+speed, so the 1.0 m/s velocity kick `push_robot` applied during training
+lands at about 175 N.
+
+    python3 examples/learning_to_walk/mujoco_demo.py --push-force 300
+
+The pad's cross button shoves on demand whenever the viewer is running.
+Holding it keeps shoving, one push per 0.2 s. `--headless` ignores the pad,
+so a scripted run only ever takes the scheduled shoves.
+
+An active shove draws an orange arrow into the torso, pointing the way the
+force is applied and growing with its magnitude, so a scheduled push is
+visible rather than an unexplained stumble. The status line carries the same
+number, which is what the headless runs have to go on:
+
+    command [0.5 0. 0.]  height 0.79  tilt 2.1 deg  push  300 N
+
+## Measuring
+
+`evaluate.py` runs the sweep: every terrain, every seed, one command held
+throughout, no viewer and no pad. A run ends when the base tilts past
+0.8 rad or drops below 0.2 m, the `bad_orientation` and `base_height`
+terminations the policy trained under. Left running past that point, the
+joint gains keep driving a collapsed robot until MuJoCo blows up.
+
+Each seed draws a starting heading and a set of joint speeds, the way the
+training reset did. Without that the deterministic terrains would replay one
+identical rollout for every seed.
+
+    python3 examples/learning_to_walk/evaluate.py --seeds 10 --steps 4000
+
+All numbers below hold 0.5 m/s forward for 20 seconds over 10 seeds, at
+difficulty 1, against `2026-08-18_08-19-08/model_28100.pt` at 28100
+iterations. That run reached the full command curriculum and terrain level
+4.8 of 8.
+
+### Terrain alone
+
+Falls out of 10, no pushes, holding 0.5 m/s forward for 20 seconds at
+difficulty 1:
+
+| Terrain | Falls | Median distance |
+| --- | --- | --- |
+| flat | 0/10 | 9.62 m |
+| rough | 2/10 | 8.75 m |
+| slope | 1/10 | 7.62 m |
+| inverted_slope | 0/10 | 9.92 m |
+| boxes | 0/10 | 9.56 m |
+| hills | 0/10 | 9.61 m |
+
+Nothing the policy trained on troubles it much. A run that stays up covers
+the ground it covers on flat, so the rocks, the grade and the boxes cost
+almost no speed inside the training range.
+
+Sweeping the height confirms there is no interesting structure below
+difficulty 1 either:
+
+| Tallest step | `rough` falls | `boxes` falls |
+| --- | --- | --- |
+| 1 cm | 0/10 | 0/10 |
+| 2 cm | 0/10 | 0/10 |
+| 3 cm | 0/10 | 1/10 |
+| 4 cm | 1/10 | 0/10 |
+| 5 cm | 1/10 | 0/10 |
+| 6 cm | 2/10 | -- |
+
+### Pushes
+
+Falls out of 10, holding 0.5 m/s forward over 20 seconds at difficulty 1:
+
+| Push | Base speed | flat | rough | boxes |
+| --- | --- | --- | --- | --- |
+| 0 N | -- | 0/10 | 2/10 | 0/10 |
+| 100 N | 0.57 m/s | 0/10 | 5/10 | 6/10 |
+| 200 N | 1.14 m/s | 0/10 | 10/10 | 10/10 |
+| 300 N | 1.71 m/s | 9/10 | 10/10 | 10/10 |
+| 400 N | 2.28 m/s | 10/10 | 10/10 | 10/10 |
+
+On flat ground the policy is solid up to 200 N and fails almost completely
+at 300 N. That threshold sits just above the 1.0 m/s velocity kick
+`push_robot` applied during training, which is the result you would hope
+for: it holds everything it was shown and a little more.
+
+The interesting number is the combination. Terrain alone is nearly free and
+a 100 N shove on flat is entirely free, but the same shove on rocks or boxes
+takes it down half the time. Standing on uneven ground the policy has little
+push margin left, and it loses that margin below the disturbance it trained
+against.
+
+Part of that gap is the disturbance itself. `push_by_setting_velocity`
+overwrites the base velocity, which leaves the feet where they are; a force
+applied while a foot is loaded against an edge is the harder of the two, and
+training on the velocity kick does not obviously prepare the policy for it.
+
+### Past the training range
+
+Falls out of 10, no pushes, 0.5 m/s for 20 seconds:
+
+| Difficulty | `rough` | `boxes` | `slope` | `inverted_slope` |
+| --- | --- | --- | --- | --- |
+| 1.0 | 2/10 | 0/10 | 1/10 | 0/10 |
+| 1.5 | 5/10 | 3/10 | 2/10 | 5/10 |
+| 2.0 | 10/10 | 4/10 | 8/10 | 10/10 |
+| 2.5 | 10/10 | 10/10 | 10/10 | 10/10 |
+| 3.0 | 10/10 | 10/10 | 10/10 | 10/10 |
+
+Everything survives a little past its training range and nothing survives
+much. `rough` is the first to go, gone by twice its trained rock height.
+`boxes` extrapolates furthest, still walking on 6 seeds in 10 with steps
+twice as tall as anything it saw. The two slopes are the surprise: climbing
+is harder than descending, 5/10 against 2/10 at a 30 % grade, which is the
+opposite of what the downhill runaway suggests.
+
+### Correlated ground, measured
+
+Falls out of 10, no pushes, 0.5 m/s for 20 seconds:
+
+| Difficulty | Relief | Falls | Median distance |
+| --- | --- | --- | --- |
+| 1 | 6 cm | 0/10 | 9.61 m |
+| 2 | 12 cm | 0/10 | 9.63 m |
+| 4 | 24 cm | 0/10 | 9.55 m |
+| 6 | 36 cm | 0/10 | 9.47 m |
+| 8 | 48 cm | 0/10 | 8.94 m |
+| 10 | 60 cm | 2/10 | 8.64 m |
+
+Correlated ground is nearly free. The policy walks over 48 cm of relief
+without a fall and pays almost nothing in distance, at eight times the
+tallest rock it trained on. Set against `rough` at the same relief the two
+are opposite: 12 cm of rock is 10/10 falls, 12 cm of hill is 0/10.
+
+Adding shoves at 24 cm of relief costs that margin anyway:
+
+| Push | flat | `hills` at 24 cm | `rough` at 6 cm |
+| --- | --- | --- | --- |
+| 0 N | 0/10 | 0/10 | 2/10 |
+| 100 N | 0/10 | 3/10 | 5/10 |
+| 200 N | 0/10 | 9/10 | 10/10 |
+
+So relief the policy handles perfectly on its own still removes almost all
+of its ability to reject a disturbance.
+
+## Reading the numbers
+
+Ten seeds is few. The 95 % interval on 5/10 runs from roughly 0.2 to 0.8, so
+neighbouring rows in these tables are mostly not distinguishable and only the
+shape of a column is worth reading. Individual runs are chaotic on top of
+that: shifting the control phase by a few simulation steps flips a marginal
+seed from walking to falling.
+
+This is also sim-to-sim, not ground truth. The policy trained on
+`g1_29dof_rev_1_0.urdf` under PhysX and runs here on `unitree_mujoco`'s
+MJCF, which differs in contact model and in the foot collision geometry --
+four small spheres per sole rather than a mesh. The absolute thresholds
+would move on hardware. The ordering between terrains is the part worth
+trusting.

--- a/examples/learning_to_walk/controller.py
+++ b/examples/learning_to_walk/controller.py
@@ -1,0 +1,82 @@
+"""PlayStation controller input for the learning-to-walk demonstration.
+
+The axis order is the one SDL reports for the Sony Wireless Controller on
+Linux. The speed limits are the command limit_ranges the policy was trained
+against, so a fully deflected stick asks for exactly what it has seen.
+"""
+
+import os
+
+# SDL pumps joystick state from the video event loop, so the dummy driver
+# keeps the pad readable headless. It never opens a window of its own.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
+import numpy as np
+import pygame
+
+from simulation import MAX_BACKWARD_SPEED
+from simulation import MAX_FORWARD_SPEED
+from simulation import MAX_LATERAL_SPEED
+from simulation import MAX_YAW_RATE
+
+LEFT_X, LEFT_Y = 0, 1
+RIGHT_X = 3
+NUM_AXES = 4
+PUSH_BUTTON = 0
+
+DEADZONE = 0.1
+
+CONTROLS = """unitree_rl_lab G1 velocity policy / PAZ
+  left stick up      forward velocity, up to 1.0 m/s
+  left stick down    backward velocity, up to 0.5 m/s
+  left stick sides   lateral velocity, up to 0.3 m/s
+  right stick sides  yaw rate, up to 0.2 rad/s
+  cross              shove the torso
+
+Every stick self-centers: release the pad to command a standstill.
+"""
+
+
+def find_pad():
+    pygame.init()
+    pygame.joystick.init()
+    if pygame.joystick.get_count() == 0:
+        pad = None
+    else:
+        pad = pygame.joystick.Joystick(0)
+        if pad.get_numaxes() < NUM_AXES:
+            pad = None
+    return pad
+
+
+def read_command(pad):
+    pygame.event.pump()
+    return compute_command([pad.get_axis(i) for i in range(NUM_AXES)])
+
+
+def read_push(pad):
+    return pad.get_button(PUSH_BUTTON) == 1
+
+
+def compute_command(axes):
+    forward = compute_forward_speed(apply_deadzone(-axes[LEFT_Y]))
+    lateral = apply_deadzone(-axes[LEFT_X]) * MAX_LATERAL_SPEED
+    yaw_rate = apply_deadzone(-axes[RIGHT_X]) * MAX_YAW_RATE
+    return np.array([forward, lateral, yaw_rate], "float32")
+
+
+def compute_forward_speed(value):
+    if value >= 0.0:
+        speed = value * MAX_FORWARD_SPEED
+    else:
+        speed = value * MAX_BACKWARD_SPEED
+    return speed
+
+
+def apply_deadzone(value):
+    if abs(value) < DEADZONE:
+        scaled = 0.0
+    else:
+        scaled = (value - np.sign(value) * DEADZONE) / (1.0 - DEADZONE)
+    return scaled

--- a/examples/learning_to_walk/controller_test.py
+++ b/examples/learning_to_walk/controller_test.py
@@ -1,0 +1,65 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import pytest
+
+from controller import DEADZONE
+from controller import LEFT_X
+from controller import LEFT_Y
+from controller import NUM_AXES
+from controller import RIGHT_X
+from controller import apply_deadzone
+from controller import compute_command
+from simulation import MAX_BACKWARD_SPEED
+from simulation import MAX_FORWARD_SPEED
+from simulation import MAX_LATERAL_SPEED
+from simulation import MAX_YAW_RATE
+
+
+def build_released_axes():
+    return [0.0] * NUM_AXES
+
+
+def test_released_pad_commands_a_standstill():
+    assert np.allclose(compute_command(build_released_axes()), 0.0)
+
+
+def test_resting_stick_offset_stays_inside_the_deadzone():
+    axes = build_released_axes()
+    axes[LEFT_Y] = -0.05
+    axes[RIGHT_X] = 0.05
+    assert np.allclose(compute_command(axes), 0.0)
+
+
+def test_left_stick_forward_commands_the_fastest_trained_walk():
+    axes = build_released_axes()
+    axes[LEFT_Y] = -1.0
+    command = compute_command(axes)
+    assert command[0] == pytest.approx(MAX_FORWARD_SPEED)
+    assert np.allclose(command[1:], 0.0)
+
+
+def test_left_stick_back_is_capped_lower_than_forward():
+    axes = build_released_axes()
+    axes[LEFT_Y] = 1.0
+    assert compute_command(axes)[0] == pytest.approx(-MAX_BACKWARD_SPEED)
+
+
+def test_left_stick_left_commands_positive_lateral_velocity():
+    axes = build_released_axes()
+    axes[LEFT_X] = -1.0
+    assert compute_command(axes)[1] == pytest.approx(MAX_LATERAL_SPEED)
+
+
+def test_right_stick_left_commands_a_positive_yaw_rate():
+    axes = build_released_axes()
+    axes[RIGHT_X] = -1.0
+    assert compute_command(axes)[2] == pytest.approx(MAX_YAW_RATE)
+
+
+def test_deadzone_rescales_so_full_deflection_still_reaches_one():
+    assert apply_deadzone(DEADZONE / 2) == pytest.approx(0.0)
+    assert apply_deadzone(1.0) == pytest.approx(1.0)
+    assert apply_deadzone(-1.0) == pytest.approx(-1.0)

--- a/examples/learning_to_walk/evaluate.py
+++ b/examples/learning_to_walk/evaluate.py
@@ -1,0 +1,137 @@
+"""Headless robustness sweep for the unitree_rl_lab G1 velocity policy.
+
+Holds one velocity command over every terrain and seed, shoving the torso on
+the training push schedule, and reports how often the robot goes down.
+"""
+
+import argparse
+from collections import namedtuple
+import os
+from pathlib import Path
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import mujoco
+import numpy as np
+
+from policy import compile_actor
+from policy import find_latest_checkpoint
+from policy import load_actor
+from simulation import CONTROL_DECIMATION
+from simulation import CONTROL_FREQUENCY
+from simulation import PUSH_DURATION
+from simulation import SIMULATION_FREQUENCY
+from simulation import SIMULATION_STEP
+from simulation import apply_push
+from simulation import build_flat_plant
+from simulation import build_rollout
+from simulation import build_terrain_plant
+from simulation import compute_control
+from simulation import compute_push_speed
+from simulation import find_torso
+from simulation import has_fallen
+from simulation import randomize_plant
+from simulation import sample_push
+from simulation import sample_push_step
+from simulation import update_rollout
+from terrain import TERRAIN_NAMES
+from terrain import build_terrain
+from terrain import describe_terrain
+
+Result = namedtuple("Result", "distance steps fell")
+
+
+def build_plant(scene_path, name, seed, difficulty):
+    if name == "flat":
+        plant = build_flat_plant(scene_path)
+    else:
+        terrain = build_terrain(name, seed, difficulty)
+        plant = build_terrain_plant(scene_path, terrain)
+    return plant
+
+
+def run_rollout(plant, actor, command, steps, force, seed):
+    # The rollout ends at the fall the way the trained episode does. Left
+    # running, the gains keep driving a collapsed robot until MuJoCo blows up.
+    data, rng = plant.data, np.random.default_rng(seed)
+    randomize_plant(plant.model, data, plant.height, rng)
+    torso = find_torso(plant.model)
+    rollout = build_rollout(data, command)
+    push_step, release_step, step = sample_push_step(rng, 0), -1, 0
+    fallen = False
+    while step < steps and not fallen:
+        if step >= push_step:
+            apply_push(data, torso, sample_push(rng, force))
+            release_step = step + round(PUSH_DURATION / SIMULATION_STEP)
+            push_step = sample_push_step(rng, release_step)
+        if step == release_step:
+            apply_push(data, torso, np.zeros(3))
+        data.ctrl[:] = compute_control(data, rollout.targets)
+        mujoco.mj_step(plant.model, data)
+        step = step + 1
+        if step % CONTROL_DECIMATION == 0:
+            rollout = update_rollout(rollout, actor, data, command)
+            fallen = has_fallen(data)
+    distance = float(np.linalg.norm(data.qpos[:2]))
+    return Result(distance, step, fallen)
+
+
+def report(name, results, steps):
+    falls = sum(result.fell for result in results)
+    distances = [result.distance for result in results]
+    survived = [result.steps * SIMULATION_STEP for result in results]
+    print(f"| {name} | {falls}/{len(results)} | {np.median(distances):.2f} m"
+          f" | {np.median(survived):.1f} s |")
+
+
+if __name__ == "__main__":
+    example_dir = Path(__file__).resolve().parent
+    repositories = example_dir.parents[2]
+    sibling = repositories / "unitree_mujoco" / "unitree_robots" / "g1"
+    default_scene = os.environ.get("WALK_SCENE_DIR", sibling)
+    experiment = example_dir / "unitree_g1_29dof_velocity_robust"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scene-dir", type=Path, default=default_scene)
+    parser.add_argument("--checkpoint", type=Path)
+    parser.add_argument("--terrains", nargs="+", default=TERRAIN_NAMES,
+                        choices=TERRAIN_NAMES)
+    parser.add_argument("--seeds", type=int, default=10)
+    parser.add_argument("--difficulty", type=float, default=1.0,
+                        help="1 is the tallest trained; above 1 is out"
+                             " of distribution")
+    parser.add_argument("--push-force", type=float, default=0.0)
+    parser.add_argument("--speed", type=float, default=0.5)
+    parser.add_argument("--steps", type=int, default=2000)
+    arguments = parser.parse_args()
+
+    scene_path = Path(arguments.scene_dir) / "scene_29dof.xml"
+    if not scene_path.exists():
+        raise SystemExit(f"Missing MuJoCo scene: {scene_path}")
+    checkpoint = arguments.checkpoint
+    if checkpoint is None:
+        checkpoint = find_latest_checkpoint(experiment)
+    actor = compile_actor(load_actor(checkpoint))
+    command = np.array([arguments.speed, 0.0, 0.0], "float32")
+
+    seconds = arguments.steps * SIMULATION_STEP
+    reference = build_plant(scene_path, "flat", 0, 1.0)
+    speed = compute_push_speed(reference.model, arguments.push_force)
+    print(f"{checkpoint.parent.name}/{checkpoint.name}, {seconds:.0f} s at"
+          f" {arguments.speed} m/s, {arguments.push_force:.0f} N pushes"
+          f" worth {speed:.2f} m/s")
+    print(f"Control {CONTROL_FREQUENCY:.0f} Hz over physics at"
+          f" {SIMULATION_FREQUENCY:.0f} Hz, decimation {CONTROL_DECIMATION}")
+    for name in arguments.terrains:
+        print("Terrain " + describe_terrain(name, arguments.difficulty))
+    print("| Terrain | Falls | Median distance | Median time up |")
+    print("| --- | --- | --- | --- |")
+    for name in arguments.terrains:
+        results = []
+        for seed in range(arguments.seeds):
+            ground = scene_path, name, seed, arguments.difficulty
+            plant = build_plant(*ground)
+            run = actor, command, arguments.steps, arguments.push_force, seed
+            results.append(run_rollout(plant, *run))
+        report(name, results, arguments.steps)

--- a/examples/learning_to_walk/mujoco_demo.py
+++ b/examples/learning_to_walk/mujoco_demo.py
@@ -1,0 +1,227 @@
+"""Interactive MuJoCo demonstration of the unitree_rl_lab G1 policy."""
+
+import argparse
+import os
+from pathlib import Path
+import signal
+import time
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+# One 29-joint actor at batch one is bound by launch latency, not by
+# throughput, so the CPU runs it faster per call than a GPU and leaves the
+# GPU free. Set JAX_PLATFORMS to override.
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import mujoco
+import mujoco.viewer
+import numpy as np
+
+from controller import CONTROLS
+from controller import find_pad
+from controller import read_command
+from controller import read_push
+from policy import compile_actor
+from policy import find_latest_checkpoint
+from policy import load_actor
+from simulation import CONTROL_DECIMATION
+from simulation import CONTROL_FREQUENCY
+from simulation import PUSH_DURATION
+from simulation import PUSH_FORCE
+from simulation import SIMULATION_FREQUENCY
+from simulation import SIMULATION_STEP
+from simulation import TRAINED_PUSH_SPEED
+from simulation import apply_push
+from simulation import build_flat_plant
+from simulation import build_rollout
+from simulation import build_terrain_plant
+from simulation import compute_control
+from simulation import compute_push_speed
+from simulation import compute_tilt
+from simulation import draw_push
+from simulation import find_torso
+from simulation import has_fallen
+from simulation import randomize_plant
+from simulation import sample_push
+from simulation import sample_push_step
+from simulation import update_rollout
+from terrain import TERRAIN_NAMES
+from terrain import build_terrain
+from terrain import describe_terrain
+
+# A shove lasts 0.2 s, so a slower status line misses most of them.
+STATUS_STEPS = 20
+
+
+def describe_rates():
+    return (f"Control {CONTROL_FREQUENCY:.0f} Hz over physics at"
+            f" {SIMULATION_FREQUENCY:.0f} Hz, decimation {CONTROL_DECIMATION}")
+
+
+def describe_push(force, speed):
+    ratio = speed / TRAINED_PUSH_SPEED
+    if ratio > 1.0:
+        note = f"OUT OF DISTRIBUTION: {ratio:.2f}x the 1.0 m/s it trained on"
+    else:
+        note = f"inside the {TRAINED_PUSH_SPEED} m/s kick it trained on"
+    shove = f"{force:.0f} N for {PUSH_DURATION} s, worth {speed:.2f} m/s"
+    return f"Pushes shove the torso at {shove}\n  {note}"
+
+
+def describe(data, command, torso):
+    velocity = np.round(command, 2)
+    tilt = round(float(np.rad2deg(compute_tilt(data))), 1)
+    push = np.linalg.norm(data.xfrc_applied[torso, 0:3])
+    return (f"command {velocity}  height {data.qpos[2]:.2f}"
+            f"  tilt {tilt} deg  push {push:5.0f} N")
+
+
+def sleep_to_rate(last_time, timestep):
+    next_time = last_time + timestep
+    now = time.perf_counter()
+    if next_time > now:
+        time.sleep(next_time - now)
+        rate_time = next_time
+    else:
+        rate_time = now
+    return rate_time
+
+
+def restore_interrupt():
+    # launch_passive keeps SIGINT for itself, so Ctrl-C never reaches Python
+    # and the loop runs until the process is killed. Take the signal back.
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+
+
+def build_viewer(model, data):
+    # The camera tracks the pelvis. Left at the origin it loses the robot
+    # after a couple of metres, which reads as a frozen scene.
+    pelvis = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "pelvis")
+    viewer = mujoco.viewer.launch_passive(model, data)
+    viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
+    viewer.cam.trackbodyid = pelvis
+    viewer.cam.azimuth = 120
+    viewer.cam.elevation = -20
+    viewer.cam.distance = 3.0
+    return viewer
+
+
+if __name__ == "__main__":
+    example_dir = Path(__file__).resolve().parent
+    repositories = example_dir.parents[2]
+    sibling = repositories / "unitree_mujoco" / "unitree_robots" / "g1"
+    default_scene = os.environ.get("WALK_SCENE_DIR", sibling)
+    experiment = example_dir / "unitree_g1_29dof_velocity_robust"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scene-dir", type=Path, default=default_scene,
+                        help="g1 directory holding scene_29dof.xml")
+    parser.add_argument("--checkpoint", type=Path,
+                        help="rsl_rl model_*.pt, newest run by default")
+    parser.add_argument("--terrain", default="flat", choices=TERRAIN_NAMES,
+                        help="ground the robot walks over")
+    parser.add_argument("--difficulty", type=float, default=1.0,
+                        help="terrain height or grade, 1 is the tallest"
+                             " trained; above 1 is out of distribution")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="terrain layout and push schedule")
+    parser.add_argument("--push-force", type=float, default=PUSH_FORCE,
+                        help="torso shove in newtons, held for 0.2 s")
+    parser.add_argument("--speed", type=float, default=0.5,
+                        help="forward velocity held with no pad, in m/s")
+    parser.add_argument("--steps", type=int, default=0,
+                        help="stop after this many simulation steps")
+    parser.add_argument("--headless", action="store_true")
+    arguments = parser.parse_args()
+
+    scene_path = Path(arguments.scene_dir) / "scene_29dof.xml"
+    if not scene_path.exists():
+        raise SystemExit(f"Missing MuJoCo scene: {scene_path}")
+
+    checkpoint = arguments.checkpoint
+    if checkpoint is None:
+        checkpoint = find_latest_checkpoint(experiment)
+
+    if arguments.headless:
+        pad = None
+    else:
+        pad = find_pad()
+    if pad is None:
+        print(f"No pad. Holding {arguments.speed} m/s forward.")
+    else:
+        print(CONTROLS)
+    print(f"Loading {checkpoint} and scene {scene_path}")
+    actor = compile_actor(load_actor(checkpoint))
+    if arguments.terrain == "flat":
+        plant = build_flat_plant(scene_path)
+    else:
+        ground = arguments.terrain, arguments.seed, arguments.difficulty
+        plant = build_terrain_plant(scene_path, build_terrain(*ground))
+
+    model, data = plant.model, plant.data
+    torso = find_torso(model)
+    push_speed = compute_push_speed(model, arguments.push_force)
+    print(describe_rates())
+    print("Terrain " + describe_terrain(arguments.terrain,
+                                        arguments.difficulty))
+    print(describe_push(arguments.push_force, push_speed))
+
+    rng = np.random.default_rng(arguments.seed)
+    command = np.array([arguments.speed, 0.0, 0.0], "float32")
+    rollout = build_rollout(data, command)
+    push_step, release_step = sample_push_step(rng, 0), -1
+    pushes, falls = 0, 0
+
+    if arguments.headless:
+        viewer = None
+    else:
+        viewer = build_viewer(model, data)
+        restore_interrupt()
+
+    control_period = SIMULATION_STEP * CONTROL_DECIMATION
+    step, last_time = 0, time.perf_counter()
+    try:
+        while arguments.steps == 0 or step < arguments.steps:
+            if viewer is not None and not viewer.is_running():
+                break
+            if step >= push_step:
+                apply_push(data, torso, sample_push(rng, arguments.push_force))
+                release_step = step + round(PUSH_DURATION / SIMULATION_STEP)
+                push_step = sample_push_step(rng, release_step)
+                pushes = pushes + 1
+            if step == release_step:
+                apply_push(data, torso, np.zeros(3))
+            data.ctrl[:] = compute_control(data, rollout.targets)
+            mujoco.mj_step(model, data)
+            step = step + 1
+            if step % CONTROL_DECIMATION == 0:
+                if pad is not None:
+                    command = read_command(pad)
+                    if read_push(pad) and step > release_step:
+                        push_step = step
+                if has_fallen(data):
+                    # Left standing, the gains keep driving a collapsed
+                    # robot until MuJoCo blows up. Put it back on its feet.
+                    randomize_plant(model, data, plant.height, rng)
+                    rollout = build_rollout(data, command)
+                    falls = falls + 1
+                else:
+                    rollout = update_rollout(rollout, actor, data, command)
+                if viewer is not None:
+                    draw_push(viewer.user_scn, data, torso)
+                    viewer.sync()
+                    last_time = sleep_to_rate(last_time, control_period)
+            if step % STATUS_STEPS == 0:
+                print(describe(data, command, torso), end="\r", flush=True)
+    except KeyboardInterrupt:
+        pass
+
+    distance = float(np.linalg.norm(data.qpos[:2]))
+    print(f"\nRan {step} steps, took {pushes} pushes of"
+          f" {arguments.push_force:.0f} N and fell {falls} times."
+          f" Travelled {distance:.2f} m since the last spawn."
+          f" Final base height {data.qpos[2]:.3f} m,"
+          f" tilt {np.rad2deg(compute_tilt(data)):.1f} deg")
+    if viewer is not None:
+        viewer.close()
+        time.sleep(0.25)

--- a/examples/learning_to_walk/policy.py
+++ b/examples/learning_to_walk/policy.py
@@ -1,0 +1,67 @@
+"""Keras actor for the unitree_rl_lab G1 velocity policy.
+
+The checkpoints are rsl_rl ActorCritic saves. Deployment only needs the
+actor, so the critic and the optimizer state are dropped here. The layer
+sizes come from actor_hidden_dims in the run's params/agent.yaml.
+"""
+
+from functools import partial
+from pathlib import Path
+
+import jax
+import keras
+import numpy as np
+import torch
+
+# On a GPU, XLA defaults float32 matmuls to TF32, which moves an action
+# by a few parts in a thousand against the checkpoint it came from.
+jax.config.update("jax_default_matmul_precision", "float32")
+
+NUM_JOINTS = 29
+NUM_HISTORY_FRAMES = 5
+FRAME_DIM = 96
+OBSERVATION_DIM = FRAME_DIM * NUM_HISTORY_FRAMES
+HIDDEN_UNITS = (512, 256, 128)
+
+
+def load_actor(checkpoint_path):
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    weights = checkpoint["model_state_dict"]
+    actor = build_actor()
+    for index, layer in enumerate(actor.layers[1:]):
+        set_layer_weights(layer, weights, 2 * index)
+    return actor
+
+
+def build_actor():
+    inputs = keras.Input(shape=(OBSERVATION_DIM,))
+    outputs = inputs
+    for units in HIDDEN_UNITS:
+        outputs = keras.layers.Dense(units, activation="elu")(outputs)
+    return keras.Model(inputs, keras.layers.Dense(NUM_JOINTS)(outputs))
+
+
+def set_layer_weights(layer, weights, position):
+    # rsl_rl saves the actor as a Sequential with an ELU between the
+    # linear layers, so weights sit at every other position.
+    kernel = weights[f"actor.{position}.weight"].numpy().transpose()
+    layer.set_weights([kernel, weights[f"actor.{position}.bias"].numpy()])
+
+
+def compile_actor(actor):
+    # Called eagerly, the actor costs milliseconds against a 20 ms
+    # control period. Compile and warm it up before the loop starts.
+    call = jax.jit(partial(actor, training=False))
+    call(np.zeros((1, OBSERVATION_DIM), "float32"))
+    return call
+
+
+def find_latest_checkpoint(experiment_dir):
+    paths = sorted(Path(experiment_dir).glob("*/model_*.pt"), key=order_by_run)
+    if not paths:
+        raise SystemExit(f"No rsl_rl model_*.pt under {experiment_dir}")
+    return paths[-1]
+
+
+def order_by_run(path):
+    return path.parent.name, int(path.stem.split("_")[1])

--- a/examples/learning_to_walk/policy_test.py
+++ b/examples/learning_to_walk/policy_test.py
@@ -1,0 +1,84 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+from pathlib import Path
+
+import jax
+import numpy as np
+import pytest
+import torch
+
+from policy import HIDDEN_UNITS
+from policy import NUM_JOINTS
+from policy import OBSERVATION_DIM
+from policy import build_actor
+from policy import compile_actor
+from policy import find_latest_checkpoint
+from policy import load_actor
+from policy import order_by_run
+
+EXPERIMENT = Path(__file__).parent / "unitree_g1_29dof_velocity_robust"
+
+needs_checkpoint = pytest.mark.skipif(
+    not list(EXPERIMENT.glob("*/model_*.pt")),
+    reason="no unitree_rl_lab run directory next to this example")
+
+
+def build_torch_actor(weights):
+    widths = (OBSERVATION_DIM,) + HIDDEN_UNITS + (NUM_JOINTS,)
+    modules = []
+    for index in range(len(widths) - 1):
+        linear = torch.nn.Linear(widths[index], widths[index + 1])
+        linear.weight.data = weights[f"actor.{2 * index}.weight"]
+        linear.bias.data = weights[f"actor.{2 * index}.bias"]
+        modules.append(linear)
+        modules.append(torch.nn.ELU())
+    return torch.nn.Sequential(*modules[:-1])
+
+
+def build_observations(seed=0):
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=(4, OBSERVATION_DIM)).astype("float32")
+
+
+def test_actor_maps_the_trained_observation_onto_one_action_per_joint():
+    outputs = build_actor()(build_observations())
+    assert outputs.shape == (4, NUM_JOINTS)
+
+
+def test_actor_has_the_widths_the_run_configuration_asked_for():
+    units = [layer.units for layer in build_actor().layers[1:]]
+    assert units == list(HIDDEN_UNITS) + [NUM_JOINTS]
+
+
+def test_actor_keeps_full_float32_precision_against_the_checkpoint():
+    # XLA defaults float32 matmuls to TF32 on a GPU, which is worth about
+    # three decimal digits of every action.
+    assert jax.config.jax_default_matmul_precision == "float32"
+
+
+def test_checkpoints_order_by_run_then_by_iteration():
+    older = Path("2026-08-18_08-10-46/model_900.pt")
+    newer = Path("2026-08-18_08-10-46/model_1000.pt")
+    latest = Path("2026-08-18_08-19-08/model_100.pt")
+    assert order_by_run(older) < order_by_run(newer) < order_by_run(latest)
+
+
+@needs_checkpoint
+def test_loaded_actor_matches_the_torch_checkpoint_it_came_from():
+    checkpoint = find_latest_checkpoint(EXPERIMENT)
+    weights = torch.load(checkpoint, map_location="cpu")["model_state_dict"]
+    observations = build_observations()
+    expected = build_torch_actor(weights)(torch.from_numpy(observations))
+    outputs = np.asarray(load_actor(checkpoint)(observations))
+    assert np.allclose(outputs, expected.detach().numpy(), atol=1e-4)
+
+
+@needs_checkpoint
+def test_compiled_actor_returns_what_the_eager_actor_returns():
+    actor = load_actor(find_latest_checkpoint(EXPERIMENT))
+    observations = build_observations()
+    expected = np.asarray(actor(observations))
+    outputs = np.asarray(compile_actor(actor)(observations))
+    assert np.allclose(outputs, expected, atol=1e-4)

--- a/examples/learning_to_walk/simulation.py
+++ b/examples/learning_to_walk/simulation.py
@@ -1,0 +1,276 @@
+"""MuJoCo support code for the unitree_rl_lab G1 velocity policy.
+
+The constants are the exported deployment values from a run's
+params/deploy.yaml, converted where needed. Two joint orders meet here.
+The observation and the action live in the Isaac order the policy was
+trained in. Everything touching the plant lives in the Unitree SDK order
+the MuJoCo model declares: DEFAULT_ANGLES, GAINS, DAMPINGS, the target
+angles and the control vector. SDK_INDICES converts between them.
+"""
+
+from collections import namedtuple
+
+import mujoco
+import numpy as np
+
+from paz.backend.lie.quaternion import to_matrix
+from policy import FRAME_DIM
+from policy import NUM_HISTORY_FRAMES
+from policy import NUM_JOINTS
+
+SIMULATION_STEP = 0.005
+CONTROL_DECIMATION = 4
+CONTROL_FREQUENCY = 1.0 / (SIMULATION_STEP * CONTROL_DECIMATION)
+SIMULATION_FREQUENCY = 1.0 / SIMULATION_STEP
+ACTION_SCALE = 0.25
+ANGULAR_VELOCITY_SCALE = 0.2
+JOINT_VELOCITY_SCALE = 0.05
+
+SPAWN_HEIGHT = 0.8
+SPAWN_RADIUS = 0.5
+FALL_ANGLE = 0.8
+FALL_HEIGHT = 0.2
+SPAWN_JOINT_SPEED = 1.0
+
+MAX_FORWARD_SPEED = 1.0
+MAX_BACKWARD_SPEED = 0.5
+MAX_LATERAL_SPEED = 0.3
+MAX_YAW_RATE = 0.2
+
+PUSH_INTERVAL = (3.0, 8.0)
+PUSH_DURATION = 0.2
+PUSH_FORCE = 200.0
+TRAINED_PUSH_SPEED = 1.0
+PUSH_ARROW_SCALE = 0.002
+PUSH_ARROW_WIDTH = 0.02
+PUSH_ARROW_COLOR = np.array([1.0, 0.35, 0.1, 1.0], "float32")
+
+TERRAIN_NAME = "terrain"
+TERRAIN_BASE = 1.0
+
+# deploy.yaml joint_ids_map: for every Isaac joint the policy was trained
+# on, its index in the Unitree SDK order the MuJoCo model declares.
+SDK_INDICES = np.array(
+    [0, 6, 12, 1, 7, 13, 2, 8, 14, 3, 9, 15, 22, 4, 10, 16, 23,
+     5, 11, 17, 24, 18, 25, 19, 26, 20, 27, 21, 28])
+
+DEFAULT_ANGLES = np.array(
+    [-0.1, 0.0, 0.0, 0.3, -0.2, 0.0,
+     -0.1, 0.0, 0.0, 0.3, -0.2, 0.0,
+     0.0, 0.0, 0.0,
+     0.3, 0.25, 0.0, 0.97, 0.15, 0.0, 0.0,
+     0.3, -0.25, 0.0, 0.97, -0.15, 0.0, 0.0], "float32")
+
+GAINS = np.array(
+    [100.0, 100.0, 100.0, 150.0, 40.0, 40.0,
+     100.0, 100.0, 100.0, 150.0, 40.0, 40.0,
+     200.0, 40.0, 40.0,
+     40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0,
+     40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0], "float32")
+
+DAMPINGS = np.array(
+    [2.0, 2.0, 2.0, 4.0, 2.0, 2.0,
+     2.0, 2.0, 2.0, 4.0, 2.0, 2.0,
+     5.0, 5.0, 5.0,
+     1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+     1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "float32")
+
+# IsaacLab keeps one history per observation term rather than one history of
+# whole frames, so the flat observation groups every term's five samples
+# together. These split a frame back into its terms.
+TERM_OFFSETS = (3, 6, 9, 38, 67)
+
+Plant = namedtuple("Plant", "model data height")
+Rollout = namedtuple("Rollout", "history action targets")
+
+
+def build_flat_plant(scene_path):
+    model, data = compile_plant(mujoco.MjSpec.from_file(str(scene_path)))
+    reset_plant(model, data, SPAWN_HEIGHT)
+    return Plant(model, data, SPAWN_HEIGHT)
+
+
+def build_terrain_plant(scene_path, terrain):
+    spec = mujoco.MjSpec.from_file(str(scene_path))
+    add_terrain(spec, terrain)
+    model, data = compile_plant(spec)
+    height = SPAWN_HEIGHT + compute_spawn_rise(terrain)
+    reset_plant(model, data, height)
+    return Plant(model, data, height)
+
+
+def compile_plant(spec):
+    model = spec.compile()
+    model.opt.timestep = SIMULATION_STEP
+    return model, mujoco.MjData(model)
+
+
+def reset_plant(model, data, height):
+    mujoco.mj_resetData(model, data)
+    data.qpos[2] = height
+    data.qpos[7:7 + NUM_JOINTS] = DEFAULT_ANGLES
+    mujoco.mj_forward(model, data)
+
+
+def randomize_plant(model, data, height, rng):
+    # The training reset drew a heading and joint speeds. Without them a
+    # deterministic terrain gives every seed the same rollout.
+    reset_plant(model, data, height)
+    data.qpos[3:7] = sample_heading(rng)
+    speeds = rng.uniform(-SPAWN_JOINT_SPEED, SPAWN_JOINT_SPEED, NUM_JOINTS)
+    data.qvel[6:6 + NUM_JOINTS] = speeds
+    mujoco.mj_forward(model, data)
+
+
+def sample_heading(rng):
+    # MuJoCo orders a quaternion w, x, y, z, which the paz
+    # from_rotation_vector helper does not, so the yaw is written out here.
+    yaw = rng.uniform(-np.pi, np.pi)
+    return np.array([np.cos(yaw / 2), 0.0, 0.0, np.sin(yaw / 2)])
+
+
+def add_terrain(spec, terrain):
+    cells = terrain.elevations.shape[0]
+    size = [terrain.radius, terrain.radius, terrain.peak, TERRAIN_BASE]
+    field = spec.add_hfield(name=TERRAIN_NAME, size=size)
+    field.nrow, field.ncol = cells, cells
+    field.userdata = terrain.elevations.ravel()
+    add_terrain_geom(spec)
+
+
+def add_terrain_geom(spec):
+    # The released ground plane stays underneath. Replacing it leaves
+    # nothing to walk on past the edge of the patch, and a run that reaches
+    # the edge then falls out of the world rather than off the terrain.
+    geom = spec.worldbody.add_geom()
+    geom.name = TERRAIN_NAME
+    geom.type = mujoco.mjtGeom.mjGEOM_HFIELD
+    geom.hfieldname = TERRAIN_NAME
+    geom.material = spec.geom("floor").material
+
+
+def compute_spawn_rise(terrain):
+    # Spawn on the tallest cell the feet can reach, so the robot never
+    # starts inside a rock or above the far side of a slope.
+    cells = terrain.elevations.shape[0]
+    span = round(SPAWN_RADIUS * cells / (2 * terrain.radius))
+    center = slice(cells // 2 - span, cells // 2 + span)
+    return terrain.elevations[center, center].max() * terrain.peak
+
+
+def build_rollout(data, command):
+    action = np.zeros(NUM_JOINTS, "float32")
+    frame = build_observation_frame(data, command, action)
+    targets = compute_target_angles(action)
+    return Rollout(build_history(frame), action, targets)
+
+
+def update_rollout(rollout, actor, data, command):
+    frame = build_observation_frame(data, command, rollout.action)
+    history = update_history(rollout.history, frame)
+    action = np.asarray(actor(build_observation(history)))[0]
+    return Rollout(history, action, compute_target_angles(action))
+
+
+def build_observation_frame(data, command, action):
+    frame = np.zeros(FRAME_DIM, "float32")
+    frame[0:3] = data.qvel[3:6] * ANGULAR_VELOCITY_SCALE
+    frame[3:6] = compute_gravity_direction(data.qpos[3:7])
+    frame[6:9] = command
+    frame[9:38] = compute_joint_positions(data)
+    frame[38:67] = compute_joint_velocities(data)
+    frame[67:96] = action
+    return frame
+
+
+def compute_joint_positions(data):
+    positions = data.qpos[7:7 + NUM_JOINTS] - DEFAULT_ANGLES
+    return positions[SDK_INDICES]
+
+
+def compute_joint_velocities(data):
+    velocities = data.qvel[6:6 + NUM_JOINTS] * JOINT_VELOCITY_SCALE
+    return velocities[SDK_INDICES]
+
+
+def compute_gravity_direction(orientation):
+    gravity = np.array([0.0, 0.0, -1.0], "float32")
+    rotation = np.asarray(to_matrix(orientation))
+    return rotation.transpose() @ gravity
+
+
+def build_history(frame):
+    # IsaacLab fills every history slot with the first sample on reset.
+    return np.repeat(frame[np.newaxis], NUM_HISTORY_FRAMES, axis=0)
+
+
+def update_history(history, frame):
+    return np.concatenate([history[1:], frame[np.newaxis]])
+
+
+def build_observation(history):
+    terms = np.split(history, TERM_OFFSETS, axis=1)
+    return np.concatenate([term.ravel() for term in terms])[np.newaxis]
+
+
+def compute_target_angles(action):
+    targets = np.empty(NUM_JOINTS, "float32")
+    targets[SDK_INDICES] = action * ACTION_SCALE
+    return targets + DEFAULT_ANGLES
+
+
+def compute_control(data, targets):
+    positions = data.qpos[7:7 + NUM_JOINTS]
+    velocities = data.qvel[6:6 + NUM_JOINTS]
+    return (targets - positions) * GAINS - velocities * DAMPINGS
+
+
+def find_torso(model):
+    return mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "torso_link")
+
+
+def apply_push(data, torso, force):
+    data.xfrc_applied[torso, 0:3] = force
+
+
+def sample_push(rng, force):
+    angle = rng.uniform(0.0, 2 * np.pi)
+    return force * np.array([np.cos(angle), np.sin(angle), 0.0])
+
+
+def sample_push_step(rng, step):
+    interval = rng.uniform(*PUSH_INTERVAL) / SIMULATION_STEP
+    return step + round(interval)
+
+
+def draw_push(scene, data, torso):
+    # xfrc_applied is the only record of a shove, so the arrow reads it back
+    # and clears itself the moment the shove is released.
+    force = data.xfrc_applied[torso, 0:3]
+    scene.ngeom = 0
+    if np.any(force):
+        tip = data.xpos[torso]
+        add_arrow(scene, tip - force * PUSH_ARROW_SCALE, tip)
+
+
+def add_arrow(scene, start, end):
+    geom = scene.geoms[scene.ngeom]
+    arrow = mujoco.mjtGeom.mjGEOM_ARROW
+    # size, pos and mat are all overwritten by the connector below.
+    blank = np.zeros(3), np.zeros(3), np.zeros(9)
+    mujoco.mjv_initGeom(geom, arrow, *blank, PUSH_ARROW_COLOR)
+    mujoco.mjv_connector(geom, arrow, PUSH_ARROW_WIDTH, start, end)
+    scene.ngeom = scene.ngeom + 1
+
+
+def compute_tilt(data):
+    upright = compute_gravity_direction(data.qpos[3:7])[2]
+    return np.arccos(np.clip(-upright, -1.0, 1.0))
+
+
+def has_fallen(data):
+    return compute_tilt(data) > FALL_ANGLE or data.qpos[2] < FALL_HEIGHT
+
+
+def compute_push_speed(model, force):
+    return force * PUSH_DURATION / sum(model.body_mass)

--- a/examples/learning_to_walk/simulation_test.py
+++ b/examples/learning_to_walk/simulation_test.py
@@ -1,0 +1,254 @@
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+from collections import namedtuple
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import pytest
+import yaml
+
+from policy import FRAME_DIM
+from policy import NUM_HISTORY_FRAMES
+from policy import NUM_JOINTS
+from policy import OBSERVATION_DIM
+from simulation import ACTION_SCALE
+from simulation import ANGULAR_VELOCITY_SCALE
+from simulation import CONTROL_DECIMATION
+from simulation import DAMPINGS
+from simulation import DEFAULT_ANGLES
+from simulation import GAINS
+from simulation import JOINT_VELOCITY_SCALE
+from simulation import MAX_BACKWARD_SPEED
+from simulation import MAX_FORWARD_SPEED
+from simulation import MAX_LATERAL_SPEED
+from simulation import MAX_YAW_RATE
+from simulation import SDK_INDICES
+from simulation import SIMULATION_STEP
+from simulation import TERM_OFFSETS
+from simulation import build_history
+from simulation import build_observation
+from simulation import build_observation_frame
+from simulation import compute_control
+from simulation import compute_gravity_direction
+from simulation import compute_joint_positions
+from simulation import compute_target_angles
+from simulation import FALL_HEIGHT
+from simulation import compute_tilt
+from simulation import draw_push
+from simulation import has_fallen
+from simulation import sample_heading
+from simulation import update_history
+
+TERM_NAMES = ["base_ang_vel", "projected_gravity", "velocity_commands",
+              "joint_pos_rel", "joint_vel_rel", "last_action"]
+
+EXPERIMENT = Path(__file__).parent / "unitree_g1_29dof_velocity_robust"
+
+FakeData = namedtuple("FakeData", "qpos qvel")
+
+
+def build_fake_data(seed=0):
+    rng = np.random.default_rng(seed)
+    qpos = rng.normal(size=7 + NUM_JOINTS)
+    qpos[3:7] = [1.0, 0.0, 0.0, 0.0]
+    qvel = rng.normal(size=6 + NUM_JOINTS)
+    return FakeData(qpos, qvel)
+
+
+def load_deploy_configuration():
+    paths = sorted(EXPERIMENT.glob("*/params/deploy.yaml"))
+    return yaml.safe_load(paths[-1].read_text())
+
+
+needs_checkpoint = pytest.mark.skipif(
+    not list(EXPERIMENT.glob("*/params/deploy.yaml")),
+    reason="no unitree_rl_lab run directory next to this example")
+
+
+def test_observation_frame_places_every_term_at_its_trained_offset():
+    data = build_fake_data()
+    command = np.array([0.5, 0.1, -0.2], "float32")
+    action = np.arange(NUM_JOINTS, dtype="float32")
+    frame = build_observation_frame(data, command, action)
+    assert frame.shape == (FRAME_DIM,)
+    angular = data.qvel[3:6] * ANGULAR_VELOCITY_SCALE
+    assert np.allclose(frame[0:3], angular)
+    assert np.allclose(frame[3:6], [0.0, 0.0, -1.0], atol=1e-6)
+    assert np.allclose(frame[6:9], command)
+    joints = (data.qpos[7:7 + NUM_JOINTS] - DEFAULT_ANGLES)[SDK_INDICES]
+    assert np.allclose(frame[9:38], joints, atol=1e-6)
+    velocities = data.qvel[6:6 + NUM_JOINTS] * JOINT_VELOCITY_SCALE
+    assert np.allclose(frame[38:67], velocities[SDK_INDICES], atol=1e-6)
+    assert np.allclose(frame[67:96], action)
+
+
+def test_joint_permutation_pairs_the_two_legs_in_the_trained_order():
+    data = build_fake_data()
+    positions = compute_joint_positions(data)
+    raw = data.qpos[7:7 + NUM_JOINTS] - DEFAULT_ANGLES
+    assert positions[0] == pytest.approx(raw[0])
+    assert positions[1] == pytest.approx(raw[6])
+    assert positions[2] == pytest.approx(raw[12])
+
+
+def test_target_angles_scatter_back_to_the_mujoco_joint_order():
+    action = np.arange(NUM_JOINTS, dtype="float32")
+    targets = compute_target_angles(action)
+    assert np.allclose(targets[SDK_INDICES], action * ACTION_SCALE
+                       + DEFAULT_ANGLES[SDK_INDICES])
+
+
+def test_target_angles_of_a_zero_action_are_the_default_pose():
+    targets = compute_target_angles(np.zeros(NUM_JOINTS, "float32"))
+    assert np.allclose(targets, DEFAULT_ANGLES)
+
+
+def test_gravity_direction_is_down_for_an_upright_base():
+    upright = np.array([1.0, 0.0, 0.0, 0.0])
+    assert np.allclose(compute_gravity_direction(upright), [0, 0, -1], 1e-6)
+
+
+def test_gravity_direction_tilts_with_a_pitched_base():
+    half = np.sqrt(0.5)
+    pitched = np.array([half, 0.0, half, 0.0])
+    direction = compute_gravity_direction(pitched)
+    assert np.allclose(direction, [1.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_tilt_grows_from_zero_as_the_base_rolls_over():
+    upright = build_fake_data()
+    assert compute_tilt(upright) == pytest.approx(0.0, abs=1e-6)
+    half = np.sqrt(0.5)
+    upright.qpos[3:7] = [half, 0.0, half, 0.0]
+    assert compute_tilt(upright) == pytest.approx(np.pi / 2, abs=1e-6)
+
+
+def test_history_repeats_the_first_frame_the_way_a_reset_does():
+    frame = np.arange(FRAME_DIM, dtype="float32")
+    history = build_history(frame)
+    assert history.shape == (NUM_HISTORY_FRAMES, FRAME_DIM)
+    assert np.allclose(history, frame)
+
+
+def test_history_drops_the_oldest_frame_and_keeps_the_newest_last():
+    history = build_history(np.zeros(FRAME_DIM, "float32"))
+    for index in range(1, NUM_HISTORY_FRAMES + 2):
+        history = update_history(history, np.full(FRAME_DIM, index, "f4"))
+    assert np.allclose(history[0], 2.0)
+    assert np.allclose(history[-1], NUM_HISTORY_FRAMES + 1)
+
+
+def test_observation_groups_every_term_history_instead_of_whole_frames():
+    frames = np.arange(NUM_HISTORY_FRAMES * FRAME_DIM, dtype="float32")
+    history = frames.reshape(NUM_HISTORY_FRAMES, FRAME_DIM)
+    observation = build_observation(history)
+    assert observation.shape == (1, OBSERVATION_DIM)
+    assert np.allclose(observation[0, 0:3], history[0, 0:3])
+    assert np.allclose(observation[0, 3:6], history[1, 0:3])
+    assert np.allclose(observation[0, 12:15], history[4, 0:3])
+    assert np.allclose(observation[0, 15:18], history[0, 3:6])
+
+
+def test_observation_terms_have_the_trained_widths():
+    widths = np.diff((0,) + TERM_OFFSETS + (FRAME_DIM,))
+    assert widths.tolist() == [3, 3, 3, 29, 29, 29]
+
+
+def test_control_opposes_position_error_and_joint_velocity():
+    data = build_fake_data()
+    targets = data.qpos[7:7 + NUM_JOINTS].astype("float32")
+    control = compute_control(data, targets)
+    expected = -data.qvel[6:6 + NUM_JOINTS] * DAMPINGS
+    assert np.allclose(control, expected, atol=1e-4)
+
+
+def build_pushed_body():
+    xml = ("<mujoco><worldbody><body name='torso'><freejoint/>"
+           "<geom size='0.1'/></body></worldbody></mujoco>")
+    model = mujoco.MjModel.from_xml_string(xml)
+    return mujoco.MjData(model), mujoco.MjvScene(model, 10)
+
+
+def test_push_arrow_is_drawn_only_while_a_shove_is_applied():
+    data, scene = build_pushed_body()
+    draw_push(scene, data, 1)
+    assert scene.ngeom == 0
+    data.xfrc_applied[1, 0:3] = [300.0, 0.0, 0.0]
+    draw_push(scene, data, 1)
+    assert scene.ngeom == 1
+
+
+def test_push_arrow_length_grows_with_the_force():
+    data, scene = build_pushed_body()
+    data.xfrc_applied[1, 0:3] = [100.0, 0.0, 0.0]
+    draw_push(scene, data, 1)
+    short = scene.geoms[0].size[2]
+    data.xfrc_applied[1, 0:3] = [300.0, 0.0, 0.0]
+    draw_push(scene, data, 1)
+    assert scene.geoms[0].size[2] == pytest.approx(3 * short)
+
+
+@needs_checkpoint
+def test_constants_match_the_exported_deployment_configuration():
+    config = load_deploy_configuration()
+    assert config["joint_ids_map"] == SDK_INDICES.tolist()
+    assert config["stiffness"] == GAINS.tolist()
+    assert config["damping"] == DAMPINGS.tolist()
+    assert config["step_dt"] == SIMULATION_STEP * CONTROL_DECIMATION
+    defaults = np.array(config["default_joint_pos"])
+    assert np.allclose(DEFAULT_ANGLES[SDK_INDICES], defaults)
+
+
+@needs_checkpoint
+def test_action_scale_and_offset_match_the_exported_configuration():
+    action = load_deploy_configuration()["actions"]["JointPositionAction"]
+    defaults = np.array(load_deploy_configuration()["default_joint_pos"])
+    assert action["scale"] == [ACTION_SCALE] * NUM_JOINTS
+    assert np.allclose(action["offset"], defaults)
+
+
+@needs_checkpoint
+def test_observation_terms_and_scales_match_the_exported_configuration():
+    terms = load_deploy_configuration()["observations"]
+    assert list(terms) == TERM_NAMES
+    lengths = [len(np.atleast_1d(term["scale"])) for term in terms.values()]
+    assert lengths == [3, 3, 3, 29, 29, 29]
+    assert terms["base_ang_vel"]["scale"][0] == ANGULAR_VELOCITY_SCALE
+    assert terms["joint_vel_rel"]["scale"][0] == JOINT_VELOCITY_SCALE
+    histories = [term["history_length"] for term in terms.values()]
+    assert histories == [NUM_HISTORY_FRAMES] * len(TERM_NAMES)
+
+
+@needs_checkpoint
+def test_speed_limits_match_the_exported_command_ranges():
+    ranges = load_deploy_configuration()["commands"]["base_velocity"]
+    ranges = ranges["ranges"]
+    assert ranges["lin_vel_x"] == [-MAX_BACKWARD_SPEED, MAX_FORWARD_SPEED]
+    assert ranges["lin_vel_y"] == [-MAX_LATERAL_SPEED, MAX_LATERAL_SPEED]
+    assert ranges["ang_vel_z"] == [-MAX_YAW_RATE, MAX_YAW_RATE]
+
+
+def test_fall_is_detected_by_a_dropped_base_as_well_as_by_tilt():
+    data = build_fake_data()
+    data.qpos[2] = 0.8
+    assert not has_fallen(data)
+    data.qpos[2] = FALL_HEIGHT - 0.01
+    assert has_fallen(data)
+
+
+def test_sampled_heading_is_a_unit_yaw_quaternion_in_mujoco_order():
+    rng = np.random.default_rng(0)
+    for _ in range(8):
+        heading = sample_heading(rng)
+        assert np.linalg.norm(heading) == pytest.approx(1.0)
+        assert np.allclose(heading[1:3], 0.0)
+        direction = compute_gravity_direction(heading)
+        assert np.allclose(direction, [0.0, 0.0, -1.0], atol=1e-6)
+
+
+def test_sampled_headings_differ_between_seeds():
+    first = sample_heading(np.random.default_rng(0))
+    assert not np.allclose(first, sample_heading(np.random.default_rng(1)))

--- a/examples/learning_to_walk/terrain.py
+++ b/examples/learning_to_walk/terrain.py
@@ -1,0 +1,195 @@
+"""Heightfields for testing the policy on and off its training terrain.
+
+The cell sizes, height ranges and slopes of rough, the slopes and boxes
+come from ROBUST_TERRAINS_CFG in the run's params/velocity_env_robust_cfg.py.
+IsaacLab lays those out as 8 by 8 metre tiles. The patches here span 20
+metres so a run never walks off one, which keeps the local grade and cell
+size rather than the tile size.
+
+Hills is the exception and is in no training mix at all. It exists to test
+a surface whose relief is spatially correlated, which none of the others
+are at any difficulty.
+"""
+
+from collections import namedtuple
+
+import numpy as np
+from scipy import ndimage
+
+TERRAIN_NAMES = ("flat", "rough", "slope", "inverted_slope", "boxes",
+                 "hills")
+
+ROUGH_CELL = 0.1
+ROUGH_CELLS = 200
+ROUGH_STEP = 0.01
+ROUGH_HEIGHT = 0.06
+ROUGH_RADIUS = (ROUGH_CELLS - 1) * ROUGH_CELL / 2
+
+SLOPE_CELL = 0.1
+SLOPE_CELLS = 200
+SLOPE = 0.2
+SLOPE_RADIUS = (SLOPE_CELLS - 1) * SLOPE_CELL / 2
+PLATFORM_RADIUS = 1.0
+
+BOX_CELL = 0.05
+BOX_WIDTH = 0.45
+BOX_CELLS = round(BOX_WIDTH / BOX_CELL)
+BOX_ROWS = 45
+BOX_HEIGHT = 0.05
+BOX_CELL_COUNT = BOX_ROWS * BOX_CELLS
+BOX_RADIUS = (BOX_CELL_COUNT - 1) * BOX_CELL / 2
+
+# Nothing in the training mix is spatially correlated: every rock and every
+# box is drawn independently of its neighbours. These hills sum smooth
+# octaves instead, so the ground rolls the way real ground does, and no
+# amount of difficulty turns one terrain into the other.
+HILL_CELL = 0.1
+HILL_CELLS = 200
+HILL_RADIUS = (HILL_CELLS - 1) * HILL_CELL / 2
+HILL_HEIGHT = 0.06
+HILL_WAVELENGTH = 2.0
+HILL_OCTAVES = 4
+HILL_PERSISTENCE = 0.5
+
+Terrain = namedtuple("Terrain", "elevations peak radius")
+Extent = namedtuple("Extent", "summary limit trained")
+
+
+def build_terrain(name, seed, difficulty):
+    if name == "rough":
+        terrain = build_rough(seed, difficulty)
+    elif name == "slope":
+        terrain = build_pyramid(difficulty)
+    elif name == "inverted_slope":
+        terrain = build_inverted_pyramid(difficulty)
+    elif name == "boxes":
+        terrain = build_boxes(seed, difficulty)
+    elif name == "hills":
+        terrain = build_hills(seed, difficulty)
+    else:
+        raise ValueError(f"{name} has no heightfield")
+    return terrain
+
+
+def describe_terrain(name, difficulty):
+    if name == "flat":
+        description = "flat, the released ground plane"
+    else:
+        extent = compute_extent(name, difficulty)
+        note = describe_distribution(difficulty, extent)
+        header = f"{name} at difficulty {difficulty:.2f}"
+        description = f"{header}: {extent.summary}\n  {note}"
+    return description
+
+
+def describe_distribution(difficulty, extent):
+    if not extent.trained:
+        note = f"OUT OF DISTRIBUTION: {extent.limit}"
+    elif difficulty > 1.0:
+        ratio = f"{difficulty:.2f}x the {extent.limit}"
+        note = f"OUT OF DISTRIBUTION: {ratio} it trained on"
+    else:
+        note = f"inside the training range, which reached {extent.limit}"
+    return note
+
+
+def compute_extent(name, difficulty):
+    if name == "rough":
+        extent = compute_rough_extent(difficulty)
+    elif name in ("slope", "inverted_slope"):
+        extent = compute_slope_extent(difficulty)
+    elif name == "boxes":
+        extent = compute_boxes_extent(difficulty)
+    elif name == "hills":
+        extent = compute_hills_extent(difficulty)
+    else:
+        raise ValueError(f"{name} has no extent")
+    return extent
+
+
+def compute_rough_extent(difficulty):
+    peak, step = ROUGH_HEIGHT * difficulty * 100, ROUGH_STEP * 100
+    summary = f"rocks up to {peak:.1f} cm in {step:.1f} cm steps"
+    return Extent(summary, f"{ROUGH_HEIGHT * 100:.1f} cm rocks", True)
+
+
+def compute_slope_extent(difficulty):
+    summary = f"a {SLOPE * difficulty * 100:.0f} percent grade"
+    return Extent(summary, f"{SLOPE * 100:.0f} percent grade", True)
+
+
+def compute_boxes_extent(difficulty):
+    peak, width = BOX_HEIGHT * difficulty * 100, BOX_WIDTH * 100
+    summary = f"{width:.0f} cm boxes up to {peak:.1f} cm tall"
+    return Extent(summary, f"{BOX_HEIGHT * 100:.1f} cm boxes", True)
+
+
+def compute_hills_extent(difficulty):
+    relief = HILL_HEIGHT * difficulty * 100
+    finest = HILL_WAVELENGTH / 2 ** (HILL_OCTAVES - 1)
+    summary = (f"rolling ground {relief:.1f} cm deep, from"
+               f" {HILL_WAVELENGTH:.1f} m down to {finest:.2f} m")
+    novelty = "training never showed it correlated ground"
+    return Extent(summary, novelty, False)
+
+
+def build_rough(seed, difficulty):
+    peak = ROUGH_HEIGHT * difficulty
+    levels = max(round(peak / ROUGH_STEP), 1)
+    shape = (ROUGH_CELLS, ROUGH_CELLS)
+    steps = np.random.default_rng(seed).integers(levels + 1, size=shape)
+    return Terrain(steps / levels, peak, ROUGH_RADIUS)
+
+
+def build_pyramid(difficulty):
+    ramp = build_ramp()
+    return Terrain(1.0 - ramp, compute_rise(difficulty), SLOPE_RADIUS)
+
+
+def build_inverted_pyramid(difficulty):
+    ramp = build_ramp()
+    return Terrain(ramp, compute_rise(difficulty), SLOPE_RADIUS)
+
+
+def build_boxes(seed, difficulty):
+    shape = (BOX_ROWS, BOX_ROWS)
+    heights = np.random.default_rng(seed).uniform(size=shape)
+    block = np.ones((BOX_CELLS, BOX_CELLS))
+    peak = BOX_HEIGHT * difficulty
+    elevations = np.kron(normalize(heights), block)
+    return Terrain(elevations, peak, BOX_RADIUS)
+
+
+def build_hills(seed, difficulty):
+    rng = np.random.default_rng(seed)
+    heights = np.zeros((HILL_CELLS, HILL_CELLS))
+    for octave in range(HILL_OCTAVES):
+        heights = heights + build_octave(rng, octave)
+    peak = HILL_HEIGHT * difficulty
+    return Terrain(normalize(heights), peak, HILL_RADIUS)
+
+
+def build_octave(rng, octave):
+    wavelength = HILL_WAVELENGTH / 2 ** octave
+    cells = round(HILL_CELLS * HILL_CELL / wavelength)
+    coarse = rng.normal(size=(cells, cells))
+    zoom = HILL_CELLS / cells
+    smooth = ndimage.zoom(coarse, zoom, order=3, mode="grid-wrap")
+    return smooth * HILL_PERSISTENCE ** octave
+
+
+def normalize(heights):
+    # MuJoCo rescales every heightfield to span [0, 1]. Doing it here keeps
+    # these elevations equal to the ones the simulator ends up rendering.
+    return (heights - heights.min()) / np.ptp(heights)
+
+
+def build_ramp():
+    axis = np.linspace(-SLOPE_RADIUS, SLOPE_RADIUS, SLOPE_CELLS)
+    distance = np.maximum(np.abs(axis[:, np.newaxis]), np.abs(axis))
+    span = SLOPE_RADIUS - PLATFORM_RADIUS
+    return np.clip((distance - PLATFORM_RADIUS) / span, 0.0, 1.0)
+
+
+def compute_rise(difficulty):
+    return SLOPE * difficulty * (SLOPE_RADIUS - PLATFORM_RADIUS)

--- a/examples/learning_to_walk/terrain_test.py
+++ b/examples/learning_to_walk/terrain_test.py
@@ -1,0 +1,196 @@
+import numpy as np
+import pytest
+
+from terrain import BOX_CELL
+from terrain import BOX_CELLS
+from terrain import BOX_HEIGHT
+from terrain import HILL_CELL
+from terrain import HILL_HEIGHT
+from terrain import HILL_OCTAVES
+from terrain import HILL_WAVELENGTH
+from terrain import BOX_ROWS
+from terrain import BOX_WIDTH
+from terrain import PLATFORM_RADIUS
+from terrain import ROUGH_HEIGHT
+from terrain import ROUGH_STEP
+from terrain import SLOPE
+from terrain import SLOPE_CELL
+from terrain import SLOPE_RADIUS
+from terrain import TERRAIN_NAMES
+from terrain import build_boxes
+from terrain import build_hills
+from terrain import build_inverted_pyramid
+from terrain import build_pyramid
+from terrain import build_rough
+from terrain import build_terrain
+from terrain import describe_terrain
+
+
+def compute_heights(terrain):
+    return terrain.elevations * terrain.peak
+
+
+def test_every_terrain_spans_the_full_normalized_elevation_range():
+    # MuJoCo rescales a heightfield to [0, 1], so an elevation that fell
+    # short here would come out taller than the peak asked for.
+    for name in TERRAIN_NAMES[1:]:
+        terrain = build_terrain(name, 0, 1.0)
+        assert terrain.elevations.min() == pytest.approx(0.0)
+        assert terrain.elevations.max() == pytest.approx(1.0)
+
+
+def test_rough_only_uses_the_trained_one_centimetre_height_steps():
+    heights = compute_heights(build_terrain("rough", 0, 1.0))
+    steps = np.unique(np.round(heights, 6))
+    assert np.allclose(steps, np.arange(0.0, ROUGH_HEIGHT + 1e-9, ROUGH_STEP))
+
+
+def test_rough_difficulty_scales_the_tallest_rock():
+    assert build_terrain("rough", 0, 0.5).peak == pytest.approx(0.03)
+
+
+def test_rough_redraws_its_layout_for_a_new_seed():
+    first = build_terrain("rough", 0, 1.0).elevations
+    assert not np.allclose(first, build_terrain("rough", 1, 1.0).elevations)
+
+
+def test_slope_holds_the_trained_grade_outside_the_platform():
+    heights = compute_heights(build_terrain("slope", 0, 1.0))
+    center = heights.shape[0] // 2
+    outside = round((PLATFORM_RADIUS + 1.0) / SLOPE_CELL)
+    grades = np.diff(heights[center, center + outside:-1]) / SLOPE_CELL
+    assert np.allclose(grades, -SLOPE)
+
+
+def test_inverted_slope_climbs_where_the_slope_descends():
+    down = compute_heights(build_terrain("slope", 0, 1.0))
+    up = compute_heights(build_terrain("inverted_slope", 0, 1.0))
+    assert np.allclose(down + up, down.max())
+
+
+def test_slope_is_flat_across_the_platform_the_robot_spawns_on():
+    heights = compute_heights(build_terrain("slope", 0, 1.0))
+    center = heights.shape[0] // 2
+    inside = round(PLATFORM_RADIUS / SLOPE_CELL) - 1
+    platform = heights[center, center - inside:center + inside]
+    assert np.allclose(platform, heights.max())
+
+
+def test_slope_rises_over_the_patch_at_the_trained_grade():
+    terrain = build_terrain("slope", 0, 1.0)
+    span = SLOPE_RADIUS - PLATFORM_RADIUS
+    assert terrain.peak == pytest.approx(SLOPE * span)
+
+
+def test_boxes_are_flat_topped_squares_of_the_trained_width():
+    terrain = build_terrain("boxes", 0, 1.0)
+    box = terrain.elevations[:BOX_CELLS, :BOX_CELLS]
+    assert np.allclose(box, box[0, 0])
+    assert BOX_CELLS * BOX_CELL == pytest.approx(BOX_WIDTH)
+    assert terrain.radius * 2 == pytest.approx(BOX_ROWS * BOX_WIDTH - BOX_CELL)
+    neighbour = terrain.elevations[0, BOX_CELLS]
+    assert not np.isclose(neighbour, box[0, 0])
+
+
+def test_boxes_never_step_higher_than_the_trained_five_centimetres():
+    assert compute_heights(build_terrain("boxes", 0, 1.0)).max() <= BOX_HEIGHT
+
+
+def test_rough_keeps_its_height_step_beyond_the_trained_range():
+    heights = compute_heights(build_terrain("rough", 0, 2.0))
+    steps = np.unique(np.round(heights, 6))
+    assert steps.max() == pytest.approx(2 * ROUGH_HEIGHT)
+    assert np.allclose(np.diff(steps), ROUGH_STEP)
+
+
+def test_slope_keeps_scaling_its_grade_beyond_the_trained_range():
+    terrain = build_terrain("slope", 0, 3.0)
+    span = SLOPE_RADIUS - PLATFORM_RADIUS
+    assert terrain.peak / span == pytest.approx(3 * SLOPE)
+
+
+def test_every_terrain_stays_finite_at_a_difficulty_near_zero():
+    for name in TERRAIN_NAMES[1:]:
+        terrain = build_terrain(name, 0, 0.01)
+        assert np.isfinite(terrain.elevations).all()
+
+
+def test_description_flags_a_difficulty_past_the_trained_range():
+    assert "OUT OF DISTRIBUTION" in describe_terrain("rough", 1.01)
+    assert "OUT OF DISTRIBUTION" not in describe_terrain("rough", 1.0)
+    assert "OUT OF DISTRIBUTION" not in describe_terrain("flat", 9.0)
+
+
+def test_description_states_the_height_the_terrain_is_built_to():
+    assert "12.0 cm" in describe_terrain("rough", 2.0)
+    assert "10.0 cm" in describe_terrain("boxes", 2.0)
+    assert "40 percent" in describe_terrain("inverted_slope", 2.0)
+
+
+def compute_correlation_length(terrain):
+    heights = compute_heights(terrain)
+    row = heights[heights.shape[0] // 2]
+    correlation = np.correlate(row - row.mean(), row - row.mean(), "full")
+    correlation = correlation[len(row) - 1:] / correlation[len(row) - 1]
+    cell = 2 * terrain.radius / (heights.shape[0] - 1)
+    return np.argmax(correlation < 1 / np.e) * cell
+
+
+def compute_largest_step(terrain):
+    return np.abs(np.diff(compute_heights(terrain), axis=1)).max()
+
+
+def test_hills_correlate_over_metres_where_rough_correlates_over_one_cell():
+    assert compute_correlation_length(build_terrain("rough", 0, 1.0)) <= 0.2
+    hills = compute_correlation_length(build_terrain("hills", 0, 1.0))
+    assert hills >= HILL_WAVELENGTH / 4
+
+
+def test_hills_never_step_the_way_uncorrelated_rocks_do():
+    rough = build_terrain("rough", 0, 1.0)
+    hills = build_terrain("hills", 0, 1.0)
+    assert compute_largest_step(rough) == pytest.approx(rough.peak)
+    assert compute_largest_step(hills) < 0.2 * hills.peak
+
+
+def test_hills_hold_the_same_relief_as_rough_so_only_shape_differs():
+    assert HILL_HEIGHT == pytest.approx(ROUGH_HEIGHT)
+    hills = build_terrain("hills", 0, 1.0)
+    assert np.ptp(compute_heights(hills)) == pytest.approx(HILL_HEIGHT)
+
+
+def test_hills_relief_scales_with_difficulty():
+    hills = build_terrain("hills", 0, 3.0)
+    relief = np.ptp(compute_heights(hills))
+    assert relief == pytest.approx(3 * HILL_HEIGHT)
+
+
+def test_hills_redraw_their_layout_for_a_new_seed():
+    first = build_terrain("hills", 0, 1.0).elevations
+    assert not np.allclose(first, build_terrain("hills", 1, 1.0).elevations)
+
+
+def test_hills_resolve_their_finest_octave_on_the_cell_grid():
+    finest = HILL_WAVELENGTH / 2 ** (HILL_OCTAVES - 1)
+    assert finest >= 2 * HILL_CELL
+
+
+def test_hills_are_flagged_out_of_distribution_at_every_difficulty():
+    for difficulty in [0.1, 0.5, 1.0, 5.0]:
+        assert "OUT OF DISTRIBUTION" in describe_terrain("hills", difficulty)
+
+
+def test_flat_has_no_heightfield_and_is_not_silently_another_terrain():
+    with pytest.raises(ValueError):
+        build_terrain("flat", 0, 1.0)
+
+
+def test_every_name_dispatches_to_the_builder_it_names():
+    expected = [("rough", build_rough(0, 1.0)),
+                ("slope", build_pyramid(1.0)),
+                ("inverted_slope", build_inverted_pyramid(1.0)),
+                ("boxes", build_boxes(0, 1.0)),
+                ("hills", build_hills(0, 1.0))]
+    for name, terrain in expected:
+        assert np.allclose(build_terrain(name, 0, 1.0).elevations,
+                           terrain.elevations)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ gear_wbc = [
     "onnx>=1.16",
     "pygame>=2.6",
 ]
+learning_to_walk = [
+    "mujoco>=3.3",
+    "pygame>=2.6",
+    "pyyaml>=6",
+    "torch>=2.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/oarriaga/paz"


### PR DESCRIPTION
Replays a unitree_rl_lab G1 velocity policy in MuJoCo. The actor is a Keras 3
model on the JAX backend, jitted, loaded straight from the rsl_rl checkpoint
rather than through ONNX. A PlayStation pad steers it.

evaluate.py measures robustness: the five training terrains rebuilt as
heightfields, a correlated fractal one the policy never saw, a torso shove,
and a difficulty dial that scales past the training range.

58 tests pass. Headless demo and sweep both run on CPU; measured results are
in the example README.