### PR TITLE
Complete the RF-DETR training path

### DIFF
--- a/examples/rf_detr/benchmark.py
+++ b/examples/rf_detr/benchmark.py
@@ -1,0 +1,56 @@
+"""Times an RF-DETR forward pass, one row per variant.
+
+Reports the median of --num_runs compiled calls at each variant's own
+training resolution, so the numbers are per image at different input sizes.
+"""
+import argparse
+import os
+import time
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import jax
+
+import paz
+
+VARIANTS = {
+    "nano": paz.models.RFDETRNano,
+    "small": paz.models.RFDETRSmall,
+    "medium": paz.models.RFDETRMedium,
+    "base": paz.models.RFDETRBase,
+    "large": paz.models.RFDETRLarge,
+}
+
+
+def measure_forward(model, num_runs):
+    """Median seconds per call, after one call to compile the graph."""
+    image = np.zeros((1, *model.input_shape[1:]), "float32")
+    model.predict(image, verbose=0)
+    durations = []
+    for _ in range(num_runs):
+        start = time.perf_counter()
+        model.predict(image, verbose=0)
+        durations.append(time.perf_counter() - start)
+    return float(np.median(durations))
+
+
+def count_parameters(model):
+    return sum(int(np.prod(weight.shape)) for weight in model.weights)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--variants", default=list(VARIANTS), nargs="+",
+                        choices=list(VARIANTS))
+    parser.add_argument("--num_runs", default=10, type=int)
+    args = parser.parse_args()
+
+    print("device", jax.default_backend())
+    print(f"{'variant':<10}{'input':>8}{'parameters':>13}{'seconds':>10}")
+    for variant in args.variants:
+        model = VARIANTS[variant]()
+        duration = measure_forward(model, args.num_runs)
+        resolution = model.input_shape[1]
+        parameters = count_parameters(model)
+        print(f"{variant:<10}{resolution:>8}{parameters:>13}{duration:>10.3f}")

--- a/examples/rf_detr/embed_backbone.py
+++ b/examples/rf_detr/embed_backbone.py
@@ -1,0 +1,126 @@
+"""Projects RF-DETR backbone features to two dimensions.
+
+Taps one layer of a detector, pools it into a vector per image and lays
+those out with t-SNE, colored by each image's first VOC class. That shows
+what the backbone already separates, and what a fine-tune changes. Any layer
+name works: ``projector_norm`` is the map that feeds the decoder, while
+``block_5_add2`` sits halfway up the backbone.
+
+Loads the published COCO weights unless --weights names a checkpoint, in
+which case --num_classes has to match it. Needs scikit-learn.
+"""
+import argparse
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+import matplotlib.pyplot as plt
+from keras import Model, ops
+from sklearn.manifold import TSNE
+
+import paz
+from paz.utils import plot
+from generator import IMAGENET_MEAN, IMAGENET_STDV
+
+VARIANTS = {
+    "nano": paz.models.RFDETRNano,
+    "small": paz.models.RFDETRSmall,
+    "medium": paz.models.RFDETRMedium,
+    "base": paz.models.RFDETRBase,
+    "large": paz.models.RFDETRLarge,
+}
+
+
+def build_model(variant, num_classes, weights):
+    model = VARIANTS[variant](num_classes)
+    if weights is None:
+        weights = paz.models.detection.rf_detr.download_weights(model)
+    model.load_weights(weights)
+    return model
+
+
+def build_tap(model, layer_name):
+    """Model returning one pooled feature vector per image."""
+    features = model.get_layer(layer_name).output
+    axes = tuple(range(1, len(features.shape) - 1))
+    return Model(model.input, ops.mean(features, axis=axes))
+
+
+def read_features(tap, image_paths, resolution, batch_size):
+    """Pools every image through the tap, one batch at a time."""
+    features = []
+    for start in range(0, len(image_paths), batch_size):
+        batch = load_batch(image_paths[start:start + batch_size], resolution)
+        features.append(np.asarray(tap.predict(batch, verbose=0)))
+    return np.concatenate(features)
+
+
+def load_batch(image_paths, resolution):
+    """Squeezes each image into the detector input and standardizes it."""
+    mean = np.asarray(IMAGENET_MEAN, "float32")
+    stdv = np.asarray(IMAGENET_STDV, "float32")
+    images = []
+    for image_path in image_paths:
+        image = paz.cast(paz.image.load(image_path), "float32")
+        resized = paz.image.resize(image, (resolution, resolution))
+        images.append(np.asarray(resized) / 255.0)
+    return (np.stack(images) - mean) / stdv
+
+
+def read_labels(ground_truths):
+    """First annotated class of every image, which colors the figure."""
+    labels = []
+    for ground_truth in ground_truths:
+        labels.append(int(np.asarray(ground_truth)[0, 4]))
+    return np.asarray(labels)
+
+
+def project_features(features, seed):
+    """t-SNE keeps perplexity below the sample count, so it is derived."""
+    perplexity = min(30.0, max(5.0, len(features) / 4.0))
+    kwargs = dict(perplexity=perplexity, random_state=seed, init="pca")
+    return TSNE(n_components=2, **kwargs).fit_transform(features)
+
+
+def draw_embedding(points, labels, names, path):
+    figure, axis = plt.subplots(figsize=(6.0, 6.0))
+    colors = plt.get_cmap("tab20")(np.linspace(0.0, 1.0, len(names)))
+    for class_arg, class_name in enumerate(names):
+        chosen = labels == class_arg
+        if chosen.any():
+            args = points[chosen, 0], points[chosen, 1]
+            kwargs = dict(axis=axis, label=class_name, s=14)
+            plot.scatter(*args, color=colors[class_arg], **kwargs)
+    plot.set_labels(axis, x="t-SNE 1", y="t-SNE 2")
+    plot.clean(axis)
+    plot.legend(axis, fontsize=6)
+    figure.tight_layout()
+    figure.savefig(path, dpi=120)
+    plt.close(figure)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--variant", default="nano", choices=list(VARIANTS))
+    parser.add_argument("--layer", default="projector_norm")
+    parser.add_argument("--weights", default=None)
+    parser.add_argument("--num_classes", default=91, type=int)
+    parser.add_argument("--num_images", default=500, type=int)
+    parser.add_argument("--batch_size", default=8, type=int)
+    parser.add_argument("--seed", default=777, type=int)
+    parser.add_argument("--output", default="backbone_features.png")
+    args = parser.parse_args()
+
+    model = build_model(args.variant, args.num_classes, args.weights)
+    tap = build_tap(model, args.layer)
+    images, ground_truths = paz.datasets.voc.load("VOC2007", "test")
+    images = images[:args.num_images]
+    ground_truths = ground_truths[:args.num_images]
+    resolution = model.input_shape[1]
+    features = read_features(tap, images, resolution, args.batch_size)
+    print("pooled", features.shape, "from", args.layer)
+    points = project_features(features, args.seed)
+    names = paz.datasets.voc.get_class_names()
+    draw_embedding(points, read_labels(ground_truths), names, args.output)
+    print("saved", args.output)

--- a/examples/rf_detr/evaluate.py
+++ b/examples/rf_detr/evaluate.py
@@ -1,0 +1,105 @@
+"""Scores a fine-tuned RF-DETR on VOC2007 and draws what it found.
+
+Reports mean average precision at IOU 0.5, at 0.75, and averaged over the
+ten COCO thresholds, which punishes loose boxes the 0.5 number lets through.
+One pass over the images feeds all three. --num_drawn writes that many
+images with the ground truth beside the detections.
+"""
+import argparse
+import os
+
+os.environ.setdefault("KERAS_BACKEND", "jax")
+
+import numpy as np
+
+import paz
+
+VARIANTS = {
+    "nano": paz.models.TrainableRFDETRNano,
+    "small": paz.models.TrainableRFDETRSmall,
+    "medium": paz.models.TrainableRFDETRMedium,
+    "base": paz.models.TrainableRFDETRBase,
+    "large": paz.models.TrainableRFDETRLarge,
+}
+
+
+def build_detector(variant, num_classes, num_groups, weights, score_thresh):
+    """Rebuilds the graph that trained, so a grouped checkpoint also loads.
+
+    Keras keys a weights file by layer class and position, so the model that
+    reads a checkpoint has to be built the same way as the one that wrote it.
+    """
+    model = VARIANTS[variant](num_classes, num_groups)
+    model.load_weights(weights)
+    detector = paz.models.detection.rf_detr.build_detector(model)
+    return paz.applications.detectors.RFDETR(detector, score_thresh, None)
+
+
+def draw_comparison(image, ground_truth, detections, names, colors):
+    """Ground truth on the left, detections on the right."""
+    truth = np.asarray(ground_truth, "float32")
+    scores = np.ones(len(truth), "float32")
+    boxes = truth[:, :4].astype("int32")
+    args = boxes, truth[:, 4].astype("int32"), scores
+    expected = paz.draw.boxes2D(image, *args, names, colors)
+    predicted = paz.draw.boxes2D(image, *detections, names, colors)
+    return np.concatenate([expected, predicted], axis=1)
+
+
+def write_comparisons(detector, paths, ground_truths, names, root, thresh):
+    """One image per path: ground truth beside the confident detections."""
+    colors = paz.draw.lincolor(len(names))
+    for index, path in enumerate(paths):
+        image = paz.image.load(path)
+        detections = keep_confident(detector(image), thresh)
+        args = image, ground_truths[index], detections, names, colors
+        drawn = draw_comparison(*args)
+        paz.image.write(os.path.join(root, f"detections_{index}.png"), drawn)
+
+
+def keep_confident(detections, thresh):
+    """Average precision wants every box, a drawing only the sure ones."""
+    boxes, labels, scores = detections
+    chosen = np.asarray(scores) >= thresh
+    return boxes[chosen], labels[chosen], scores[chosen]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--weights", required=True)
+    parser.add_argument("--variant", default="nano", choices=list(VARIANTS))
+    parser.add_argument("--dataset", default="VOC2007")
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--num_groups", default=1, type=int)
+    parser.add_argument("--score_thresh", default=0.05, type=float)
+    parser.add_argument("--num_images", default=None, type=int)
+    parser.add_argument("--num_drawn", default=0, type=int)
+    parser.add_argument("--draw_thresh", default=0.5, type=float)
+    parser.add_argument("--root", default="evaluation")
+    args = parser.parse_args()
+    os.makedirs(args.root, exist_ok=True)
+
+    names = paz.datasets.voc.get_class_names()
+    detector_args = (args.variant, len(names), args.num_groups,
+                     args.weights)
+    detector = build_detector(*detector_args, args.score_thresh)
+    images, ground_truths = paz.datasets.voc.load(args.dataset, args.split)
+    difficulties = paz.datasets.voc.load_difficulties(args.dataset, args.split)
+    if args.num_images is not None:
+        images = images[:args.num_images]
+        ground_truths = ground_truths[:args.num_images]
+        difficulties = difficulties[:args.num_images]
+
+    scored = detector, images, ground_truths, len(names)
+    kwargs = dict(difficulties=difficulties, verbose=True)
+    result = paz.evaluation.compute_COCO_mAP(*scored, **kwargs)
+    for class_arg, class_name in enumerate(names):
+        print(f"{class_name:>15}: {result['ap'][class_arg]:.4f}")
+    print(f"{'mAP@0.5':>15}: {result['mAP_50']:.4f}")
+    print(f"{'mAP@0.75':>15}: {result['mAP_75']:.4f}")
+    print(f"{'mAP@[.5:.95]':>15}: {result['mAP']:.4f}")
+    if args.num_drawn > 0:
+        drawn = args.num_drawn
+        drawn_args = detector, images[:drawn], ground_truths[:drawn], names
+        write_comparisons(*drawn_args, args.root, args.draw_thresh)
+        print("wrote", drawn, "comparisons to", args.root)

--- a/examples/rf_detr/fine_tune.py
+++ b/examples/rf_detr/fine_tune.py
@@ -1,13 +1,24 @@
 """Fine-tunes a COCO RF-DETR on VOC2007.
 
-The COCO weights load into every layer except the two class heads, whose width
-depends on the class count, so they start fresh and the rest of the detector
-keeps what it learned. Pass --freeze_backbone to train only the projector,
-decoder and heads, which is cheaper and usually enough on a small dataset.
+The COCO weights load into every layer except the two class heads, whose
+width depends on the class count, so they start fresh and the rest of the
+detector keeps what it learned. Pass --freeze_backbone to train only the
+projector, decoder and heads, or --lora_rank to adapt the backbone through
+low rank adapters instead.
 
-Fine-tuning uses a single query group. Upstream trains with thirteen and drops
-all but the first at inference; the extra groups speed up convergence but are
-not needed to fine-tune, and this detector only builds the first one.
+Every run writes a CSV log and a metrics figure. --tensorboard adds the
+Keras TensorBoard callback, which needs tensorboard installed.
+
+Training follows the reference recipe: every decoder layer and the first
+stage are scored, the backbone trains slower the deeper the block, and
+AdamW clips its gradients, optionally accumulates them over several batches,
+keeps an exponential moving average of the weights and decays the rate on a
+cosine after a warmup.
+
+Fine-tuning uses a single query group. Upstream trains with thirteen and
+drops all but the first at inference. --num_groups builds more, but the
+published weights only carry the first, so the others start fresh and
+roughly double the loss the run opens at.
 """
 import argparse
 import os
@@ -21,22 +32,122 @@ from generator import Generator, preprocess_batch
 
 BACKBONE_PREFIXES = ("patch_embed", "cls_token", "pos_embed", "block_",
                      "norm")
+# DINOv2-small depth. Keras prunes the blocks past the last tapped one, so
+# the built model does not carry all twelve.
+NUM_BACKBONE_BLOCKS = 12
+# Reference fine-tune rates, relative to the base learning rate.
+ENCODER_RATE, LAYER_DECAY, COMPONENT_DECAY = 1.5, 0.8, 0.7
+NO_DECAY = ("bias", "gamma", "beta", "pos_embed", "cls_token")
 VARIANTS = {
-    "nano": paz.models.RFDETRNano,
-    "small": paz.models.RFDETRSmall,
-    "medium": paz.models.RFDETRMedium,
-    "base": paz.models.RFDETRBase,
-    "large": paz.models.RFDETRLarge,
+    "nano": paz.models.TrainableRFDETRNano,
+    "small": paz.models.TrainableRFDETRSmall,
+    "medium": paz.models.TrainableRFDETRMedium,
+    "base": paz.models.TrainableRFDETRBase,
+    "large": paz.models.TrainableRFDETRLarge,
 }
 
 
-def build_model(variant, num_classes):
-    """Loads COCO weights into every layer whose shape still matches."""
-    model = VARIANTS[variant](num_classes=num_classes)
-    weights = paz.models.detection.rf_detr.download_weights(model)
-    model.load_weights(weights, skip_mismatch=True)
-    paz.models.detection.rf_detr.reset_class_heads(model)
-    return paz.models.detection.rf_detr.join_outputs(model)
+def build_model(variant, num_classes, num_groups):
+    """Loads COCO weights into every layer whose shape still matches.
+
+    Keras keys a weights file by layer class and position rather than by
+    name, so the layers an extra query group adds would shift everything
+    after them and misplace most of the file. The weights therefore load
+    into a single-group detector and are copied by name from there, which
+    leaves the added groups on their fresh initialization.
+    """
+    source = VARIANTS[variant](num_classes, 1)
+    weights = paz.models.detection.rf_detr.download_weights(source)
+    source.load_weights(weights, skip_mismatch=True)
+    paz.models.detection.rf_detr.reset_class_heads(source)
+    if num_groups == 1:
+        model = source
+    else:
+        model = VARIANTS[variant](num_classes, num_groups)
+        copy_weights(source, model)
+        # The added groups own first-stage heads the copy never reaches.
+        paz.models.detection.rf_detr.reset_class_heads(model)
+    return model
+
+
+def copy_weights(source, model):
+    """Copies every weighted layer the two models name alike."""
+    for layer in source.layers:
+        if layer.weights:
+            model.get_layer(layer.name).set_weights(layer.get_weights())
+
+
+def freeze_backbone(model):
+    """Trains the projector, decoder and heads only."""
+    for layer in model.layers:
+        if layer.name.startswith(BACKBONE_PREFIXES):
+            layer.trainable = False
+
+
+def adapt_backbone(model, rank):
+    """Trains the backbone through LoRA adapters on its dense layers."""
+    for layer in model.layers:
+        if layer.name.startswith(BACKBONE_PREFIXES):
+            adapt_layer(layer, rank)
+
+
+def adapt_layer(layer, rank):
+    """Dense layers gain adapters; everything else freezes."""
+    if hasattr(layer, "enable_lora"):
+        layer.enable_lora(rank)
+    else:
+        layer.trainable = False
+
+
+def build_learning_rate_scales(model):
+    """Rate factor per variable, as the reference recipe sets them."""
+    scales = {}
+    for variable in model.trainable_variables:
+        scales[variable.path] = compute_scale(variable.path)
+    return scales
+
+
+def compute_scale(path):
+    """Earlier blocks train slower, and the decoder slower than the heads."""
+    if path.startswith(BACKBONE_PREFIXES):
+        depth = NUM_BACKBONE_BLOCKS + 1 - read_block_index(path)
+        scale = ENCODER_RATE * LAYER_DECAY**depth * COMPONENT_DECAY**2
+    elif path.startswith("decoder"):
+        scale = COMPONENT_DECAY
+    else:
+        scale = 1.0
+    return scale
+
+
+def read_block_index(path):
+    """Zero for the patch embedding and ``i + 1`` for block ``i``."""
+    if path.startswith("block_"):
+        index = int(path.split("_")[1]) + 1
+    elif path.startswith(("patch_embed", "cls_token", "pos_embed")):
+        index = 0
+    else:
+        index = NUM_BACKBONE_BLOCKS + 1
+    return index
+
+
+def build_schedule(learning_rate, warmup_steps, decay_steps):
+    """Linear warmup, then a cosine decay to a tenth of the rate."""
+    kwargs = dict(warmup_target=learning_rate, warmup_steps=warmup_steps)
+    args = learning_rate / 100.0, decay_steps
+    return keras.optimizers.schedules.CosineDecay(*args, alpha=0.1, **kwargs)
+
+
+def build_optimizer(model, schedule, weight_decay, clipnorm, accumulation,
+                    ema_momentum):
+    """AdamW with per-variable rates, clipping, accumulation and an EMA."""
+    steps = accumulation if accumulation > 1 else None
+    kwargs = dict(weight_decay=weight_decay, global_clipnorm=clipnorm,
+                  gradient_accumulation_steps=steps, use_ema=True,
+                  ema_momentum=ema_momentum)
+    scales = build_learning_rate_scales(model)
+    optimizer = paz.optimizers.LayerwiseAdamW(scales, schedule, **kwargs)
+    optimizer.exclude_from_weight_decay(var_names=NO_DECAY)
+    return optimizer
 
 
 def build_generators(key, resolution, batch_size, max_boxes, workers):
@@ -50,11 +161,15 @@ def build_generators(key, resolution, batch_size, max_boxes, workers):
     return Generator(*train_args), Generator(*test_args)
 
 
-def freeze_backbone(model):
-    """Trains the projector, decoder and heads only."""
-    for layer in model.layers:
-        if layer.name.startswith(BACKBONE_PREFIXES):
-            layer.trainable = False
+def build_evaluation(model, num_classes, score_thresh, period, num_images):
+    """Scores VOC mAP on a slice of the test split every few epochs."""
+    detector = paz.models.detection.rf_detr.build_detector(model)
+    detect = paz.applications.detectors.RFDETR(detector, score_thresh, None)
+    images, ground_truths = paz.datasets.voc.load("VOC2007", "test")
+    difficulties = paz.datasets.voc.load_difficulties("VOC2007", "test")
+    args = detect, images[:num_images], ground_truths[:num_images]
+    kwargs = dict(difficulties=difficulties[:num_images])
+    return paz.callbacks.EvaluateMAP(*args, num_classes, period, **kwargs)
 
 
 if __name__ == "__main__":
@@ -62,9 +177,21 @@ if __name__ == "__main__":
     parser.add_argument("--variant", default="nano", choices=list(VARIANTS))
     parser.add_argument("--batch_size", default=4, type=int)
     parser.add_argument("--learning_rate", default=1e-4, type=float)
+    parser.add_argument("--weight_decay", default=1e-4, type=float)
+    parser.add_argument("--clipnorm", default=0.1, type=float)
+    parser.add_argument("--accumulation_steps", default=1, type=int)
+    parser.add_argument("--ema_momentum", default=0.993, type=float)
     parser.add_argument("--epochs", default=30, type=int)
+    parser.add_argument("--warmup_epochs", default=1, type=int)
+    parser.add_argument("--patience", default=10, type=int)
     parser.add_argument("--max_num_boxes", default=25, type=int)
+    parser.add_argument("--num_groups", default=1, type=int)
     parser.add_argument("--freeze_backbone", action="store_true")
+    parser.add_argument("--lora_rank", default=0, type=int)
+    parser.add_argument("--tensorboard", action="store_true")
+    parser.add_argument("--evaluation_period", default=0, type=int)
+    parser.add_argument("--evaluation_images", default=500, type=int)
+    parser.add_argument("--score_thresh", default=0.05, type=float)
     parser.add_argument("--steps_per_epoch", default=None, type=int)
     parser.add_argument("--validation_steps", default=None, type=int)
     parser.add_argument("--root", default="experiments")
@@ -73,10 +200,22 @@ if __name__ == "__main__":
     root, key = paz.logger.setup(args)
 
     names = paz.datasets.voc.get_class_names()
-    model = build_model(args.variant, len(names))
+    model = build_model(args.variant, len(names), args.num_groups)
     if args.freeze_backbone:
         freeze_backbone(model)
+    if args.lora_rank > 0:
+        adapt_backbone(model, args.lora_rank)
     resolution = model.input_shape[1]
+
+    generator_args = (key, resolution, args.batch_size, args.max_num_boxes, 1)
+    train_generator, test_generator = build_generators(*generator_args)
+    steps_per_epoch = args.steps_per_epoch or len(train_generator)
+    warmup_steps = steps_per_epoch * args.warmup_epochs
+    decay_steps = max(steps_per_epoch * args.epochs - warmup_steps, 1)
+    schedule = build_schedule(args.learning_rate, warmup_steps, decay_steps)
+    optimizer_args = (schedule, args.weight_decay, args.clipnorm,
+                      args.accumulation_steps, args.ema_momentum)
+    optimizer = build_optimizer(model, *optimizer_args)
 
     metrics = [
         paz.losses.detr.classification,
@@ -84,25 +223,33 @@ if __name__ == "__main__":
         paz.losses.detr.generalized_IOU,
     ]
     checkpoint = os.path.join(root, f"rf_detr_{args.variant}_voc.weights.h5")
-    callbacks = [
-        keras.callbacks.ModelCheckpoint(checkpoint, verbose=1,
-                                        save_weights_only=True),
-        keras.callbacks.CSVLogger(os.path.join(root, "optimization.log")),
-    ]
+    kwargs = dict(save_weights_only=True, save_best_only=True, verbose=1)
+    save = keras.callbacks.ModelCheckpoint(checkpoint, **kwargs)
+    log = keras.callbacks.CSVLogger(os.path.join(root, "optimization.log"))
+    kwargs = dict(min_delta=1e-3, restore_best_weights=True, verbose=1)
+    stop = keras.callbacks.EarlyStopping(patience=args.patience, **kwargs)
+    plot = paz.callbacks.PlotMetrics(os.path.join(root, "metrics.png"))
+    callbacks = [save]
+    if args.evaluation_period > 0:
+        evaluation_args = (model, len(names), args.score_thresh,
+                           args.evaluation_period, args.evaluation_images)
+        # Ahead of the log and the figure, which read the epoch it fills in.
+        callbacks.append(build_evaluation(*evaluation_args))
+    callbacks = callbacks + [log, stop, plot]
+    if args.tensorboard:
+        board = os.path.join(root, "tensorboard")
+        callbacks.append(keras.callbacks.TensorBoard(board))
 
-    optimizer = keras.optimizers.AdamW(args.learning_rate, weight_decay=1e-4)
     # The Hungarian assignment is a jax.pure_callback, so it traces inside the
     # compiled train step; eager execution of this graph is far slower.
-    model.compile(optimizer, paz.losses.detr.call, metrics=metrics,
-                  jit_compile=True)
-
-    generator_args = (key, resolution, args.batch_size, args.max_num_boxes, 1)
-    train_generator, test_generator = build_generators(*generator_args)
-    history = model.fit(
-        train_generator,
-        epochs=args.epochs,
-        steps_per_epoch=args.steps_per_epoch,
-        validation_data=test_generator,
-        validation_steps=args.validation_steps,
-        callbacks=callbacks,
-    )
+    losses = paz.losses.detr.call
+    model.compile(optimizer, losses, metrics=metrics, jit_compile=True)
+    kwargs = dict(epochs=args.epochs, callbacks=callbacks,
+                  steps_per_epoch=args.steps_per_epoch,
+                  validation_data=test_generator,
+                  validation_steps=args.validation_steps)
+    model.fit(train_generator, **kwargs)
+    # Keras averages the weights once training ends, but early stopping then
+    # restores the best epoch's raw ones, so average them again here.
+    optimizer.finalize_variable_values(model.trainable_variables)
+    model.save_weights(checkpoint.replace(".weights", "_ema.weights"))

--- a/examples/rf_detr/generator.py
+++ b/examples/rf_detr/generator.py
@@ -5,9 +5,10 @@ torchvision ImageNet statistics the weights were trained with. Targets are
 normalized ``(cx, cy, w, h)`` plus a class index, padded to a fixed count with
 -1 so the loss keeps static shapes.
 
-Augmentation is a horizontal flip only. The colour helpers in ``paz.image``
-expect 0-255 images and the scale-jitter ones move boxes out of normalized
-coordinates, so neither composes with this pipeline as written.
+Augmentation is ``paz.detection.augment_detection``: a photometric jitter,
+a zoom out, an IOU-mode sample crop and a horizontal flip. It keeps the
+image size and the box count fixed, so the whole batch runs as one
+``jit(vmap(...))``.
 """
 import math
 
@@ -89,7 +90,8 @@ def transform_batch(keys, images, detections, augment):
 
     def transform(key, image, detection):
         if augment:
-            image, detection = paz.detection.random_flip(key, image, detection)
+            args = key, image, detection, 255.0 * mean
+            image, detection = paz.detection.augment_detection(*args)
         image = paz.image.standardize(image / 255.0, mean, stdv)
         return image, to_center_form(detection)
 

--- a/paz/applications/detectors.py
+++ b/paz/applications/detectors.py
@@ -254,7 +254,10 @@ def DetectRFDETRCOCO(build_model, score_thresh, draw):
 
 
 def RFDETR(model, score_thresh, draw, num_select=300):
-    forward = jax.jit(lambda x: model(x))
+    # Keras compiles and caches this, and rereads its weights every call.
+    # A jitted ``model(x)`` would instead freeze them at trace time, so a
+    # detector wrapping a model that is still training would never move.
+    forward = model.predict_on_batch
     select = jax.jit(paz.lock(select_detections, num_select))
     # Trained with the torchvision ImageNet statistics, which are rounded
     # differently from paz.image.rgb_IMAGENET_MEAN.

--- a/paz/backend/evaluation.py
+++ b/paz/backend/evaluation.py
@@ -1,9 +1,16 @@
+from collections import namedtuple
+
 import jax
 import jax.numpy as jp
 import numpy as np
 
 import paz
 import paz.utils.progressbar as progressbar
+
+COCO_IOU_THRESHOLDS = (0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90,
+                       0.95)
+Sample = namedtuple("Sample", ["boxes", "labels", "scores", "true_boxes",
+                               "true_labels", "difficult"])
 
 
 def compute_mAP(
@@ -21,31 +28,91 @@ def compute_mAP(
     if difficulties is None:
         difficulties = empty_difficulties(ground_truths)
     positives = count_positives(ground_truths, difficulties, num_classes)
-    matches = match_dataset(detector, images, ground_truths, difficulties,
-                            max_detections, max_objects, iou_thresh, verbose)
+    args = detector, images, ground_truths, difficulties
+    samples = collect_samples(*args, max_detections, max_objects, verbose)
+    widened = [widen_corners(sample) for sample in samples]
+    matches = match_samples(widened, iou_thresh)
     return reduce_average_precisions(*matches, positives, num_classes,
                                      use_07_metric)
 
 
-def match_dataset(detector, images, ground_truths, difficulties,
-                  max_detections, max_objects, iou_thresh, verbose):
-    match = jax.jit(paz.lock(match_predictions, iou_thresh))
-    scores, classes, true_positives, ignored = [], [], [], []
+def compute_COCO_mAP(
+    detector,
+    images,
+    ground_truths,
+    num_classes,
+    difficulties=None,
+    max_detections=200,
+    max_objects=64,
+    verbose=False,
+):
+    """Averages precision over the ten COCO IOU thresholds, 0.50 to 0.95.
+
+    Reports that average as ``mAP``, beside the ``mAP_50`` and ``mAP_75``
+    thresholds. The detector runs once and its predictions are rematched at
+    every threshold. Two things differ from ``pycocotools``: precision is
+    interpolated over all recall points rather than a 101 point grid, and
+    boxes are scored as given instead of widened by the pixel the VOC metric
+    adds.
+    """
+    if difficulties is None:
+        difficulties = empty_difficulties(ground_truths)
+    positives = count_positives(ground_truths, difficulties, num_classes)
+    args = detector, images, ground_truths, difficulties
+    samples = collect_samples(*args, max_detections, max_objects, verbose)
+    results = []
+    for iou_thresh in COCO_IOU_THRESHOLDS:
+        matches = match_samples(samples, iou_thresh)
+        args = matches + (positives, num_classes, False)
+        results.append(reduce_average_precisions(*args))
+    return summarize_COCO_results(results)
+
+
+def summarize_COCO_results(results):
+    """Per class and mean AP over the thresholds, plus AP50 and AP75."""
+    average_precisions = np.nanmean([result["ap"] for result in results], 0)
+    loose = results[COCO_IOU_THRESHOLDS.index(0.50)]
+    tight = results[COCO_IOU_THRESHOLDS.index(0.75)]
+    return {"ap": average_precisions,
+            "mAP": float(np.nanmean(average_precisions)),
+            "mAP_50": loose["mAP"],
+            "mAP_75": tight["mAP"]}
+
+
+def collect_samples(detector, images, ground_truths, difficulties,
+                    max_detections, max_objects, verbose):
+    """Runs the detector once per image, padded to fixed shapes."""
+    samples = []
     start = progressbar.start()
     for index, image_path in enumerate(images):
         image = paz.image.load(image_path)
-        boxes, labels, score = pad_predictions(*detector(image), max_detections)
+        predictions = pad_predictions(*detector(image), max_detections)
         truth = pad_ground_truth(ground_truths[index], difficulties[index],
                                  max_objects)
-        is_true, is_ignored = match(boxes, labels, score, *truth)
-        scores.append(score)
-        classes.append(labels)
-        true_positives.append(is_true)
-        ignored.append(is_ignored)
+        samples.append(Sample(*predictions, *truth))
         if verbose:
             progressbar.print_bar(index + 1, len(images), start, "evaluating")
     if verbose:
         print()
+    return samples
+
+
+def widen_corners(sample):
+    """VOC scores IOU on integer boxes, so it widens every far corner."""
+    boxes = expand_corners(sample.boxes)
+    true_boxes = expand_corners(sample.true_boxes)
+    return sample._replace(boxes=boxes, true_boxes=true_boxes)
+
+
+def match_samples(samples, iou_thresh):
+    match = jax.jit(paz.lock(match_predictions, iou_thresh))
+    scores, classes, true_positives, ignored = [], [], [], []
+    for sample in samples:
+        is_true, is_ignored = match(*sample)
+        scores.append(sample.scores)
+        classes.append(sample.labels)
+        true_positives.append(is_true)
+        ignored.append(is_ignored)
     columns = (scores, classes, true_positives, ignored)
     return tuple(jp.concatenate(column) for column in columns)
 
@@ -102,8 +169,7 @@ def average_precision_07(recall, precision):
 
 def match_predictions(pred_boxes, pred_classes, pred_scores,
                       true_boxes, true_classes, true_difficult, iou_thresh):
-    ious = paz.boxes.compute_IOUs(
-        expand_corners(pred_boxes), expand_corners(true_boxes))
+    ious = paz.boxes.compute_IOUs(pred_boxes, true_boxes)
     same_class = pred_classes[:, None] == true_classes[None, :]
     ious = jp.where(same_class, ious, 0.0)
     best_true = jp.argmax(ious, axis=1)
@@ -133,7 +199,6 @@ def assign_matches(best_true, is_match, true_difficult, order, num_true):
 
 
 def expand_corners(boxes):
-    # VOC scores IoU on integer boxes, so widen the far corner by one pixel.
     return boxes + jp.array([0.0, 0.0, 1.0, 1.0])
 
 

--- a/paz/backend/evaluation_test.py
+++ b/paz/backend/evaluation_test.py
@@ -136,3 +136,44 @@ def test_object_diameter_of_unit_cube():
 def test_is_correct_ADD_threshold():
     assert paz.evaluation.is_correct_ADD(0.09, 1.0, 0.1)
     assert not paz.evaluation.is_correct_ADD(0.11, 1.0, 0.1)
+
+
+def build_dataset(tmp_path, ground_truths):
+    image = np.zeros((16, 16, 3), "uint8")
+    paths = []
+    for index in range(len(ground_truths)):
+        path = os.path.join(str(tmp_path), f"{index}.png")
+        cv2.imwrite(path, image)
+        paths.append(path)
+    return paths
+
+
+def build_predictions(ground_truths, offset=0.0):
+    predictions = []
+    for ground_truth in ground_truths:
+        boxes = ground_truth[:, :4] + offset
+        classes = ground_truth[:, 4].astype("int32")
+        predictions.append((boxes, classes, np.ones(len(boxes))))
+    return predictions
+
+
+def test_compute_COCO_mAP_reaches_one_on_perfect_detector(tmp_path):
+    ground_truths = [np.array([[0.0, 0.0, 10.0, 10.0, 0]]),
+                     np.array([[1.0, 1.0, 9.0, 9.0, 1]])]
+    paths = build_dataset(tmp_path, ground_truths)
+    detector = build_detector(build_predictions(ground_truths))
+    args = detector, paths, ground_truths, 2
+    result = paz.evaluation.compute_COCO_mAP(*args)
+    assert np.isclose(result["mAP"], 1.0)
+
+
+def test_compute_COCO_mAP_punishes_loose_boxes(tmp_path):
+    """A box that only overlaps loosely still passes at 0.5 but not above."""
+    ground_truths = [np.array([[0.0, 0.0, 10.0, 10.0, 0]])]
+    paths = build_dataset(tmp_path, ground_truths)
+    predictions = build_predictions(ground_truths, offset=1.0)
+    result = paz.evaluation.compute_COCO_mAP(build_detector(predictions),
+                                             paths, ground_truths, 1)
+    assert np.isclose(result["mAP_50"], 1.0)
+    assert np.isclose(result["mAP_75"], 0.0)
+    assert 0.0 < result["mAP"] < 1.0

--- a/paz/callbacks/__init__.py
+++ b/paz/callbacks/__init__.py
@@ -1,3 +1,4 @@
 from .epoch_scheduler import EpochScheduler
 from .evaluate_map import EvaluateMAP
+from .plot_metrics import PlotMetrics
 from .evaluate_pose import EvaluatePose

--- a/paz/callbacks/plot_metrics.py
+++ b/paz/callbacks/plot_metrics.py
@@ -1,0 +1,53 @@
+import keras
+import matplotlib.pyplot as plt
+
+from paz.utils import plot
+
+
+class PlotMetrics(keras.callbacks.Callback):
+    """Draws every logged metric against the epoch, one panel each.
+
+    The figure is rewritten at the end of every epoch, so an interrupted run
+    still leaves one behind next to its CSV log.
+    """
+
+    def __init__(self, path):
+        super().__init__()
+        self.path = path
+        self.history = {}
+
+    def on_epoch_end(self, epoch, logs=None):
+        for name, value in (logs or {}).items():
+            entry = (epoch + 1, float(value))
+            self.history.setdefault(name, []).append(entry)
+        draw_metrics(self.history, self.path)
+
+
+def draw_metrics(history, path):
+    """Writes one panel per training metric, beside its validation twin."""
+    names = [name for name in history if not name.startswith("val_")]
+    kwargs = dict(figsize=(4.0 * len(names), 3.0), squeeze=False)
+    figure, axes = plt.subplots(1, len(names), **kwargs)
+    for axis, name in zip(axes[0], names):
+        draw_metric(axis, name, history)
+    figure.tight_layout()
+    figure.savefig(path, dpi=120)
+    plt.close(figure)
+
+
+def draw_metric(axis, name, history):
+    palette = plot.DEFAULT_PALETTE
+    draw_series(axis, history[name], name, palette.primary)
+    validation = history.get(f"val_{name}")
+    if validation is not None:
+        draw_series(axis, validation, f"val_{name}", palette.secondary)
+    plot.set_labels(axis, x="epoch", y=name)
+    plot.clean(axis)
+    plot.legend(axis, fontsize=8)
+
+
+def draw_series(axis, entries, label, color):
+    """A metric logged every few epochs is drawn at the epochs it has."""
+    epochs = [epoch for epoch, _ in entries]
+    values = [value for _, value in entries]
+    plot.line(epochs, values, axis=axis, color=color, label=label)

--- a/paz/callbacks/plot_metrics_test.py
+++ b/paz/callbacks/plot_metrics_test.py
@@ -1,0 +1,25 @@
+import os
+
+import numpy as np
+import keras
+
+import paz
+
+
+def build_regression_data():
+    inputs = np.random.RandomState(0).randn(8, 3).astype("float32")
+    return inputs, inputs.sum(axis=1, keepdims=True)
+
+
+def test_writes_a_figure_every_epoch(tmp_path):
+    x, y = build_regression_data()
+    inputs = keras.Input((3,))
+    model = keras.Model(inputs, keras.layers.Dense(1)(inputs))
+    model.compile("adam", "mse")
+    path = os.path.join(str(tmp_path), "metrics.png")
+    callback = paz.callbacks.PlotMetrics(path)
+    kwargs = dict(epochs=2, verbose=0, validation_data=(x, y))
+    model.fit(x, y, callbacks=[callback], **kwargs)
+    assert os.path.exists(path)
+    assert len(callback.history["loss"]) == 2
+    assert len(callback.history["val_loss"]) == 2

--- a/paz/losses/detr.py
+++ b/paz/losses/detr.py
@@ -9,9 +9,14 @@ so no gradient flows into it.
 
 ``y_true`` is ``(batch, max_boxes, 5)``: normalized ``(cx, cy, w, h)`` and a
 class index, padded with -1. ``y_pred`` is
-``(batch, num_queries, 4 + num_classes)``: normalized ``(cx, cy, w, h)``
-followed by class logits, which is what ``rf_detr.models.join_outputs``
-produces.
+``(batch, stages, groups, num_queries, 4 + num_classes)``: normalized
+``(cx, cy, w, h)`` followed by class logits, for every supervised stage and
+query group, which is what the trainable ``rf_detr`` detectors produce.
+
+Stages are summed and query groups averaged. That is how the reference
+weights its auxiliary and first-stage terms, which carry the same
+coefficients as the final stage, and how it normalizes group-DETR by the box
+count times the group count.
 """
 import numpy as np
 import jax
@@ -29,7 +34,13 @@ UNMATCHABLE_COST = 1e6
 
 @register_keras_serializable("detr_loss", "call")
 def call(y_true, y_pred):
-    """Sums the classification, regression and generalized-IOU terms."""
+    """Sums every stage, averaging the query groups inside each stage."""
+    targets, predictions = flatten_stages(y_true, y_pred)
+    return y_pred.shape[1] * compute_total(targets, predictions)
+
+
+def compute_total(y_true, y_pred):
+    """Classification, regression and generalized-IOU terms of one stage."""
     boxes, logits, targets, labels, valid = unpack(y_true, y_pred)
     queries = match(boxes, logits, targets, labels, valid)
     args = boxes, targets, valid, queries
@@ -42,7 +53,8 @@ def call(y_true, y_pred):
 @register_keras_serializable("detr_loss", "classification")
 def classification(y_true, y_pred):
     """IOU-aware binary cross entropy over every query and class."""
-    boxes, logits, targets, labels, valid = unpack(y_true, y_pred)
+    unpacked = unpack(y_true, read_last_stage(y_pred))
+    boxes, logits, targets, labels, valid = unpacked
     queries = match(boxes, logits, targets, labels, valid)
     args = boxes, logits, targets, labels, valid, queries
     return compute_classification(*args)
@@ -51,7 +63,8 @@ def classification(y_true, y_pred):
 @register_keras_serializable("detr_loss", "regression")
 def regression(y_true, y_pred):
     """Mean absolute error between matched boxes, in center form."""
-    boxes, logits, targets, labels, valid = unpack(y_true, y_pred)
+    unpacked = unpack(y_true, read_last_stage(y_pred))
+    boxes, logits, targets, labels, valid = unpacked
     queries = match(boxes, logits, targets, labels, valid)
     return compute_regression(boxes, targets, valid, queries)
 
@@ -59,7 +72,8 @@ def regression(y_true, y_pred):
 @register_keras_serializable("detr_loss", "generalized_IOU")
 def generalized_IOU(y_true, y_pred):
     """One minus the generalized IOU of every matched pair."""
-    boxes, logits, targets, labels, valid = unpack(y_true, y_pred)
+    unpacked = unpack(y_true, read_last_stage(y_pred))
+    boxes, logits, targets, labels, valid = unpacked
     queries = match(boxes, logits, targets, labels, valid)
     return compute_IOU_error(boxes, targets, valid, queries)
 
@@ -183,6 +197,22 @@ def build_selections(queries, labels, shape):
     query_hot = jax.nn.one_hot(queries, shape[1])
     class_hot = jax.nn.one_hot(labels, shape[2])
     return query_hot[..., None] * class_hot[:, :, None, :]
+
+
+def flatten_stages(y_true, y_pred):
+    """Folds stages and query groups into the batch axis.
+
+    Every stage and group is matched and scored on its own, so each becomes
+    one more row of the batch.
+    """
+    repeats = y_pred.shape[1] * y_pred.shape[2]
+    predictions = jp.reshape(y_pred, (-1,) + y_pred.shape[3:])
+    return jp.repeat(y_true, repeats, axis=0), predictions
+
+
+def read_last_stage(y_pred):
+    """Final decoder layer of the first group, which is what runs at test."""
+    return y_pred[:, -1, 0]
 
 
 def unpack(y_true, y_pred):

--- a/paz/losses/detr_test.py
+++ b/paz/losses/detr_test.py
@@ -13,6 +13,11 @@ def build_targets(boxes_and_labels):
 
 
 def build_predictions(boxes, labels, confidence=8.0):
+    """One stage and one query group, as a single-group detector reports."""
+    return build_stage(boxes, labels, confidence)[:, None, None]
+
+
+def build_stage(boxes, labels, confidence=8.0):
     logits = np.full((1, NUM_QUERIES, NUM_CLASSES), -confidence, "float32")
     predicted = np.full((1, NUM_QUERIES, 4), 0.5, "float32")
     for query, (box, label) in enumerate(zip(boxes, labels)):
@@ -82,3 +87,36 @@ def test_call_is_jit_compatible():
     eager = float(detr.call(y_true, y_pred))
     jitted = float(jax.jit(detr.call)(y_true, y_pred))
     assert np.allclose(eager, jitted, atol=1e-5)
+
+
+def test_stages_are_summed():
+    y_true = build_targets([[0.5, 0.5, 0.2, 0.2, 1]])
+    stage = build_stage([[0.4, 0.4, 0.3, 0.3]], [1])
+    stages = jp.stack([stage, stage], axis=1)[:, :, None]
+    single = float(detr.call(y_true, stage[:, None, None]))
+    assert np.isclose(float(detr.call(y_true, stages)), 2.0 * single)
+
+
+def test_query_groups_are_averaged():
+    y_true = build_targets([[0.5, 0.5, 0.2, 0.2, 1]])
+    stage = build_stage([[0.4, 0.4, 0.3, 0.3]], [1])
+    groups = jp.stack([stage, stage], axis=1)[:, None]
+    single = float(detr.call(y_true, stage[:, None, None]))
+    assert np.isclose(float(detr.call(y_true, groups)), single)
+
+
+def test_a_worse_group_raises_the_loss():
+    y_true = build_targets([[0.5, 0.5, 0.2, 0.2, 1]])
+    right = build_stage([[0.5, 0.5, 0.2, 0.2]], [1])
+    wrong = build_stage([[0.1, 0.1, 0.2, 0.2]], [0])
+    groups = jp.stack([right, wrong], axis=1)[:, None]
+    single = float(detr.call(y_true, right[:, None, None]))
+    assert float(detr.call(y_true, groups)) > single
+
+
+def test_metrics_read_the_last_stage_only():
+    y_true = build_targets([[0.5, 0.5, 0.2, 0.2, 1]])
+    right = build_stage([[0.5, 0.5, 0.2, 0.2]], [1])
+    wrong = build_stage([[0.1, 0.1, 0.2, 0.2]], [0])
+    stages = jp.stack([wrong, right], axis=1)[:, :, None]
+    assert float(detr.regression(y_true, stages)) == 0.0

--- a/paz/models/__init__.py
+++ b/paz/models/__init__.py
@@ -13,6 +13,11 @@ from .detection import RFDETRSmall
 from .detection import RFDETRMedium
 from .detection import RFDETRBase
 from .detection import RFDETRLarge
+from .detection import TrainableRFDETRNano
+from .detection import TrainableRFDETRSmall
+from .detection import TrainableRFDETRMedium
+from .detection import TrainableRFDETRBase
+from .detection import TrainableRFDETRLarge
 from .detection import HaarCascadeEyeDetector
 from .detection import HaarCascadeFrontalFaceDetector
 from .classification.xception import MiniXception

--- a/paz/models/detection/__init__.py
+++ b/paz/models/detection/__init__.py
@@ -13,6 +13,11 @@ from .rf_detr import RFDETRSmall
 from .rf_detr import RFDETRMedium
 from .rf_detr import RFDETRBase
 from .rf_detr import RFDETRLarge
+from .rf_detr import TrainableRFDETRNano
+from .rf_detr import TrainableRFDETRSmall
+from .rf_detr import TrainableRFDETRMedium
+from .rf_detr import TrainableRFDETRBase
+from .rf_detr import TrainableRFDETRLarge
 from .haar_cascade import HaarCascadeDetector
 from .haar_cascade import HaarCascadeEyeDetector
 from .haar_cascade import HaarCascadeFrontalFaceDetector

--- a/paz/models/detection/rf_detr/__init__.py
+++ b/paz/models/detection/rf_detr/__init__.py
@@ -4,6 +4,11 @@ from paz.models.detection.rf_detr.models import RFDETRSmall
 from paz.models.detection.rf_detr.models import RFDETRMedium
 from paz.models.detection.rf_detr.models import RFDETRBase
 from paz.models.detection.rf_detr.models import RFDETRLarge
-from paz.models.detection.rf_detr.models import join_outputs
+from paz.models.detection.rf_detr.models import TrainableRFDETRNano
+from paz.models.detection.rf_detr.models import TrainableRFDETRSmall
+from paz.models.detection.rf_detr.models import TrainableRFDETRMedium
+from paz.models.detection.rf_detr.models import TrainableRFDETRBase
+from paz.models.detection.rf_detr.models import TrainableRFDETRLarge
+from paz.models.detection.rf_detr.models import build_detector
 from paz.models.detection.rf_detr.models import reset_class_heads
 from paz.models.detection.rf_detr.pretrained import download_weights

--- a/paz/models/detection/rf_detr/decoder.py
+++ b/paz/models/detection/rf_detr/decoder.py
@@ -6,9 +6,15 @@ decoder layers refine with deformable cross-attention. Boxes stay in
 normalized ``(cx, cy, w, h)`` and are never squashed through a sigmoid:
 each stage predicts a delta relative to its reference box.
 
-This is the inference graph. Training-time group-DETR duplicates the query
-tables and the first-stage heads; only the first group is used at inference,
-so only the first group is built here.
+``build_stages`` returns one ``(logits, boxes)`` pair per supervised stage:
+the first stage, then every decoder layer. Inference reads the last pair;
+training scores all of them, which is what the reference calls its auxiliary
+and encoder losses.
+
+Group-DETR duplicates the query tables and the first-stage heads
+``num_groups`` times and keeps self-attention inside a group. Group zero
+keeps the ungrouped layer names, so a single-group detector's weights can be
+copied into it by name and only the added groups start fresh.
 """
 import numpy as np
 from keras import ops
@@ -21,30 +27,36 @@ from paz.models.transformers.embeddings.sine import embed_boxes
 from paz.models.transformers.embeddings.token import LearnableTokens
 
 
-def build(features, num_layers, num_self_heads, num_cross_heads, num_points,
-          feedforward_size, num_classes, num_queries):
+def build_stages(features, num_layers, num_self_heads, num_cross_heads,
+                 num_points, feedforward_size, num_classes, num_queries,
+                 num_groups):
     grids = read_grids(features)
     memory = flatten_levels(features)
     hidden_size = memory.shape[-1]
-    selected = select_proposals(memory, grids, num_classes, num_queries)
-    deltas = build_table(memory, num_queries, 4, "refpoint_embed")
-    boxes = refine(deltas, selected)
-    target = build_table(memory, num_queries, hidden_size, "query_feat")
+    args = memory, grids, num_classes, num_queries, num_groups
+    proposals = select_proposals(*args)
+    args = memory, num_queries, 4, num_groups, "refpoint_embed"
+    # The reference is detached: the first stage learns from its own loss.
+    boxes = refine(build_tables(*args), ops.stop_gradient(proposals[1]))
+    args = memory, num_queries, hidden_size, num_groups, "query_feat"
+    target = build_tables(*args)
     query_pos = embed_reference(boxes, hidden_size)
+    heads = build_prediction_heads(hidden_size, num_classes)
     sizes = num_self_heads, num_cross_heads, num_points, feedforward_size
+    stages = [proposals]
     for layer in range(num_layers):
         args = memory, boxes, query_pos, grids
-        target = apply_layer(target, *args, *sizes, f"decoder_{layer}")
-    tokens = normalize(target, "decoder_norm")
-    logits = Dense(num_classes, name="class_embed")(tokens)
-    return logits, refine(apply_box_head(tokens, "bbox_embed"), boxes)
+        name = f"decoder_{layer}"
+        target = apply_layer(target, *args, *sizes, num_groups, name)
+        stages.append(predict_stage(heads, target, boxes))
+    return stages
 
 
-def select_proposals(memory, grids, num_classes, num_queries):
-    """Scores one anchor per cell and keeps the best ``num_queries``.
+def select_proposals(memory, grids, num_classes, num_queries, num_groups):
+    """First-stage logits and boxes of every group's best anchors.
 
-    The feature maps must therefore hold at least ``num_queries`` cells, which
-    is checked here so an undersized detector fails while it is being built
+    The feature maps must hold at least ``num_queries`` cells, which is
+    checked here so an undersized detector fails while it is being built
     rather than on its first forward pass.
     """
     num_cells = sum(height * width for height, width in grids)
@@ -52,13 +64,38 @@ def select_proposals(memory, grids, num_classes, num_queries):
         message = f"Need at least {num_queries} feature cells, got {num_cells}"
         raise ValueError(message)
     anchors, valid = build_anchor_boxes(grids)
-    tokens = Dense(memory.shape[-1], name="enc_output")(memory * valid)
-    tokens = normalize(tokens, "enc_output_norm")
-    logits = Dense(num_classes, name="enc_class_embed")(tokens)
-    deltas = apply_box_head(tokens, "enc_bbox_embed")
-    boxes = refine(deltas, anchors * valid)
+    groups = []
+    for group in range(num_groups):
+        args = memory, anchors, valid, num_classes, num_queries, group
+        groups.append(select_group_proposals(*args))
+    return tuple(ops.concatenate(field, axis=1) for field in zip(*groups))
+
+
+def select_group_proposals(memory, anchors, valid, num_classes, num_queries,
+                           group):
+    hidden_size = memory.shape[-1]
+    project = Dense(hidden_size, name=name_group("enc_output", group))
+    norm_name = name_group("enc_output_norm", group)
+    tokens = normalize(project(memory * valid), norm_name)
+    classify = Dense(num_classes, name=name_group("enc_class_embed", group))
+    logits = classify(tokens)
+    head = build_box_head(hidden_size, name_group("enc_bbox_embed", group))
+    boxes = refine(apply_box_head(head, tokens), anchors * valid)
     ranked = ops.top_k(ops.max(logits, axis=-1), num_queries)[1]
-    return ops.take_along_axis(boxes, ranked[..., None], axis=1)
+    return take_queries(logits, ranked), take_queries(boxes, ranked)
+
+
+def name_group(name, group):
+    """Group zero keeps the ungrouped name, matching a single-group model.
+
+    The suffix spells out ``group`` because the box head names its own three
+    layers ``_0`` to ``_2``, which a bare index would collide with.
+    """
+    return name if group == 0 else f"{name}_group_{group}"
+
+
+def take_queries(values, ranked):
+    return ops.take_along_axis(values, ranked[..., None], axis=1)
 
 
 def build_anchor_boxes(grids):
@@ -82,8 +119,10 @@ def build_cell_indices(height, width):
 
 
 def apply_layer(target, memory, boxes, query_pos, grids, num_self_heads,
-                num_cross_heads, num_points, feedforward_size, name):
-    attended = apply_self_attention(target, query_pos, num_self_heads, name)
+                num_cross_heads, num_points, feedforward_size, num_groups,
+                name):
+    args = target, query_pos, num_self_heads, num_groups, name
+    attended = apply_self_attention(*args)
     target = normalize(target + attended, f"{name}_norm1")
     args = memory, boxes, grids, num_cross_heads, num_points
     attended = deformable.attend(target + query_pos, *args, f"{name}_cross")
@@ -94,11 +133,53 @@ def apply_layer(target, memory, boxes, query_pos, grids, num_self_heads,
     return normalize(target + forwarded, f"{name}_norm3")
 
 
-def apply_self_attention(target, query_pos, num_heads, name):
+def apply_self_attention(target, query_pos, num_heads, num_groups, name):
+    """Attends inside one query group at a time, as group-DETR requires."""
     head_dim = target.shape[-1] // num_heads
-    query = target + query_pos
+    num_queries = target.shape[1]
+    query = split_groups(target + query_pos, num_groups)
+    value = split_groups(target, num_groups)
     key = project_biased_key(query, num_heads, head_dim, name)
-    return attend_key(query, target, key, None, head_dim, 0.0, name)
+    attended = attend_key(query, value, key, None, head_dim, 0.0, name)
+    return merge_groups(attended, num_queries)
+
+
+def split_groups(tokens, num_groups):
+    """Folds the query groups into the batch, leaving one group per row."""
+    num_queries = tokens.shape[1] // num_groups
+    return ops.reshape(tokens, (-1, num_queries, tokens.shape[2]))
+
+
+def merge_groups(tokens, num_queries):
+    return ops.reshape(tokens, (-1, num_queries, tokens.shape[2]))
+
+
+def build_prediction_heads(hidden_size, num_classes):
+    """Norm, class head and box head, shared by every decoder layer."""
+    normalizer = LayerNormalization(epsilon=1e-5, name="decoder_norm")
+    classifier = Dense(num_classes, name="class_embed")
+    return normalizer, classifier, build_box_head(hidden_size, "bbox_embed")
+
+
+def predict_stage(heads, target, reference):
+    normalizer, classifier, box_head = heads
+    tokens = normalizer(target)
+    boxes = refine(apply_box_head(box_head, tokens), reference)
+    return classifier(tokens), boxes
+
+
+def build_box_head(hidden_size, name):
+    """The three dense layers that turn tokens into a box delta."""
+    kwargs = dict(activation="relu")
+    inner_0 = Dense(hidden_size, name=f"{name}_0", **kwargs)
+    inner_1 = Dense(hidden_size, name=f"{name}_1", **kwargs)
+    return inner_0, inner_1, Dense(4, name=f"{name}_2")
+
+
+def apply_box_head(head, tokens):
+    for layer in head:
+        tokens = layer(tokens)
+    return tokens
 
 
 def embed_reference(boxes, hidden_size):
@@ -107,19 +188,20 @@ def embed_reference(boxes, hidden_size):
     return feedforward.relu(embedded, hidden_size, hidden_size, *names)
 
 
-def apply_box_head(tokens, name):
-    hidden_size = tokens.shape[-1]
-    kwargs = dict(activation="relu")
-    inner = Dense(hidden_size, name=f"{name}_0", **kwargs)(tokens)
-    inner = Dense(hidden_size, name=f"{name}_1", **kwargs)(inner)
-    return Dense(4, name=f"{name}_2")(inner)
-
-
 def refine(deltas, reference):
     """Places ``deltas`` relative to a reference ``(cx, cy, w, h)`` box."""
     centers = deltas[..., :2] * reference[..., 2:] + reference[..., :2]
     sizes = ops.exp(deltas[..., 2:]) * reference[..., 2:]
     return ops.concatenate([centers, sizes], axis=-1)
+
+
+def build_tables(reference, count, hidden_size, num_groups, name):
+    """One learnable table per query group, joined along the queries."""
+    tables = []
+    for group in range(num_groups):
+        args = reference, count, hidden_size, name_group(name, group)
+        tables.append(build_table(*args))
+    return ops.concatenate(tables, axis=1)
 
 
 def build_table(reference, count, hidden_size, name):

--- a/paz/models/detection/rf_detr/models.py
+++ b/paz/models/detection/rf_detr/models.py
@@ -11,8 +11,10 @@ them 1-based over the hidden states, where index 0 is the patch embedding, so
 these are those numbers minus one; blocks past the last tapped one also attend
 globally.
 
-Models return ``(logits, boxes)``: per-query class logits and normalized
-``(cx, cy, w, h)`` boxes.
+Detectors return ``(logits, boxes)``: per-query class logits and normalized
+``(cx, cy, w, h)`` boxes. The trainable detectors instead return every
+supervised stage stacked as ``(batch, stages, groups, queries, 4 + classes)``,
+which is what ``paz.losses.detr`` scores.
 """
 import math
 
@@ -24,10 +26,35 @@ from paz.models.detection.rf_detr import decoder, projector
 
 NUM_QUERIES = 300
 PROJECTOR_BLOCKS = 3
+NANO = (384, 384, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 2
+SMALL = (512, 512, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 3
+MEDIUM = (576, 576, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 4
+BASE = (560, 560, 3), 14, 4, (2, 5, 8, 11), (1, 4, 7, 10), 3
+LARGE = (704, 704, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 4
 
 
 def build_rf_detr(image_shape, patch_size, num_windows, global_layers,
                   out_layers, num_decoder_layers, num_classes, name):
+    args = (image_shape, patch_size, num_windows, global_layers, out_layers,
+            num_decoder_layers, num_classes, 1)
+    backbone, stages = build_stages(*args)
+    return Model(backbone.input, stages[-1], name=name)
+
+
+def build_trainable_rf_detr(image_shape, patch_size, num_windows,
+                            global_layers, out_layers, num_decoder_layers,
+                            num_classes, num_groups, name):
+    """Detector that reports every stage and query group to the loss."""
+    args = (image_shape, patch_size, num_windows, global_layers, out_layers,
+            num_decoder_layers, num_classes, num_groups)
+    backbone, stages = build_stages(*args)
+    outputs = stack_stages(stages, num_groups)
+    return Model(backbone.input, outputs, name=name)
+
+
+def build_stages(image_shape, patch_size, num_windows, global_layers,
+                 out_layers, num_decoder_layers, num_classes, num_groups):
+    """Backbone and one ``(logits, boxes)`` pair per supervised stage."""
     args = image_shape, patch_size, num_windows, global_layers, out_layers
     backbone = DINOv2SmallWindowedFeatures(*args)
     hidden_size, feedforward_size = 256, 2048
@@ -35,9 +62,33 @@ def build_rf_detr(image_shape, patch_size, num_windows, global_layers,
     args = hidden_size, PROJECTOR_BLOCKS, "projector"
     features = [projector.build(backbone.outputs, *args)]
     args = num_self_heads, num_cross_heads, num_points, feedforward_size
-    args = args + (num_classes, NUM_QUERIES)
-    outputs = decoder.build(features, num_decoder_layers, *args)
-    return Model(backbone.input, outputs, name=name)
+    args = args + (num_classes, NUM_QUERIES, num_groups)
+    stages = decoder.build_stages(features, num_decoder_layers, *args)
+    return backbone, stages
+
+
+def stack_stages(stages, num_groups):
+    """Packs stages into ``(batch, stages, groups, queries, 4 + classes)``."""
+    joined = [join_stage(*stage, num_groups) for stage in stages]
+    return ops.stack(joined, axis=1)
+
+
+def join_stage(logits, boxes, num_groups):
+    """One stage as boxes then logits, with its query groups split apart."""
+    joined = ops.concatenate([boxes, logits], axis=-1)
+    num_queries = joined.shape[1] // num_groups
+    return ops.reshape(joined, (-1, num_groups, num_queries, joined.shape[2]))
+
+
+def build_detector(model):
+    """Reads a trainable detector's last stage as ``(logits, boxes)``.
+
+    Both models share every weight, so a detector built here reflects the
+    training model as it trains.
+    """
+    stage = model.output[:, -1, 0]
+    outputs = stage[..., 4:], stage[..., :4]
+    return Model(model.input, outputs, name=f"{model.name}_detector")
 
 
 def reset_class_heads(model, prior=0.01):
@@ -49,44 +100,48 @@ def reset_class_heads(model, prior=0.01):
     count needs the same treatment.
     """
     bias = -math.log((1.0 - prior) / prior)
-    for name in ("class_embed", "enc_class_embed"):
-        layer = model.get_layer(name)
-        weights = layer.get_weights()
-        layer.set_weights([weights[0], np.full_like(weights[1], bias)])
-
-
-def join_outputs(model):
-    """Concatenates boxes and logits so one Keras loss sees both.
-
-    ``paz.losses.detr`` needs the boxes and the class logits together to match
-    queries against targets, but the detectors return them separately for
-    inference. This wraps a built detector for training.
-    """
-    logits, boxes = model.outputs
-    joined = ops.concatenate([boxes, logits], axis=-1)
-    return Model(model.input, joined, name=f"{model.name}_joined")
+    for layer in model.layers:
+        if layer.name.startswith(("class_embed", "enc_class_embed")):
+            weights = layer.get_weights()
+            layer.set_weights([weights[0], np.full_like(weights[1], bias)])
 
 
 def RFDETRNano(num_classes=91, name="rf_detr_nano"):
-    args = (384, 384, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 2
-    return build_rf_detr(*args, num_classes, name)
+    return build_rf_detr(*NANO, num_classes, name)
 
 
 def RFDETRSmall(num_classes=91, name="rf_detr_small"):
-    args = (512, 512, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 3
-    return build_rf_detr(*args, num_classes, name)
+    return build_rf_detr(*SMALL, num_classes, name)
 
 
 def RFDETRMedium(num_classes=91, name="rf_detr_medium"):
-    args = (576, 576, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 4
-    return build_rf_detr(*args, num_classes, name)
+    return build_rf_detr(*MEDIUM, num_classes, name)
 
 
 def RFDETRBase(num_classes=91, name="rf_detr_base"):
-    args = (560, 560, 3), 14, 4, (2, 5, 8, 11), (1, 4, 7, 10), 3
-    return build_rf_detr(*args, num_classes, name)
+    return build_rf_detr(*BASE, num_classes, name)
 
 
 def RFDETRLarge(num_classes=91, name="rf_detr_large"):
-    args = (704, 704, 3), 16, 2, (3, 6, 9), (2, 5, 8, 11), 4
-    return build_rf_detr(*args, num_classes, name)
+    return build_rf_detr(*LARGE, num_classes, name)
+
+
+def TrainableRFDETRNano(num_classes=91, num_groups=1, name="rf_detr_nano"):
+    return build_trainable_rf_detr(*NANO, num_classes, num_groups, name)
+
+
+def TrainableRFDETRSmall(num_classes=91, num_groups=1, name="rf_detr_small"):
+    return build_trainable_rf_detr(*SMALL, num_classes, num_groups, name)
+
+
+def TrainableRFDETRMedium(num_classes=91, num_groups=1,
+                          name="rf_detr_medium"):
+    return build_trainable_rf_detr(*MEDIUM, num_classes, num_groups, name)
+
+
+def TrainableRFDETRBase(num_classes=91, num_groups=1, name="rf_detr_base"):
+    return build_trainable_rf_detr(*BASE, num_classes, num_groups, name)
+
+
+def TrainableRFDETRLarge(num_classes=91, num_groups=1, name="rf_detr_large"):
+    return build_trainable_rf_detr(*LARGE, num_classes, num_groups, name)

--- a/paz/models/detection/rf_detr/models_test.py
+++ b/paz/models/detection/rf_detr/models_test.py
@@ -1,16 +1,20 @@
+import os
+
 import numpy as np
 import jax
 import keras
 from keras import Model
 
+from paz.models.detection.rf_detr import models
 from paz.models.detection.rf_detr.models import build_rf_detr
+from paz.models.detection.rf_detr.models import build_trainable_rf_detr
 from paz.models.detection.rf_detr.models import NUM_QUERIES
 
 IMAGE_SHAPE = (288, 288, 3)
 NUM_CLASSES = 7
 
 
-def build_detector():
+def build_model():
     """Taps early blocks so Keras prunes the rest and the test stays quick.
 
     The grid holds 18 x 18 = 324 cells, enough for the 300 queries the first
@@ -28,20 +32,20 @@ def make_input(batch=2):
 
 
 def test_returns_logits_and_boxes():
-    logits, boxes = build_detector()(make_input())
+    logits, boxes = build_model()(make_input())
     assert tuple(logits.shape) == (2, NUM_QUERIES, NUM_CLASSES)
     assert tuple(boxes.shape) == (2, NUM_QUERIES, 4)
 
 
 def test_output_is_two_plain_tensors():
-    output = build_detector()(make_input())
+    output = build_model()(make_input())
     assert not isinstance(output, dict)
     assert not hasattr(output, "_fields")
     assert len(output) == 2
 
 
 def test_boxes_have_positive_sizes():
-    boxes = np.array(build_detector()(make_input())[1])
+    boxes = np.array(build_model()(make_input())[1])
     assert np.all(boxes[..., 2:] > 0.0)
     assert np.all(np.isfinite(boxes))
 
@@ -53,7 +57,7 @@ def test_backbone_jit_matches_eager():
     1e-5 can reorder the selected queries and change every later tensor. The
     ranking is stable on trained weights, which parity_test.py checks.
     """
-    model = build_detector()
+    model = build_model()
     features = Model(model.input, model.get_layer("projector_norm").output)
     data = make_input()
     eager = np.array(features(data))
@@ -62,6 +66,100 @@ def test_backbone_jit_matches_eager():
 
 
 def test_untapped_blocks_are_pruned():
-    names = {layer.name for layer in build_detector().layers}
+    names = {layer.name for layer in build_model().layers}
     assert "block_2_norm1" in names
     assert "block_3_norm1" not in names
+
+
+def build_trainable(num_groups):
+    keras.utils.set_random_seed(0)
+    args = IMAGE_SHAPE, 16, 2, (1,), (0, 2), 2
+    args = args + (NUM_CLASSES, num_groups, "rf_detr_test")
+    return build_trainable_rf_detr(*args)
+
+
+def test_stacks_the_first_stage_and_every_decoder_layer():
+    output = build_trainable(1)(make_input())
+    columns = 4 + NUM_CLASSES
+    assert tuple(output.shape) == (2, 3, 1, NUM_QUERIES, columns)
+
+
+def test_query_groups_add_a_group_axis():
+    output = build_trainable(3)(make_input())
+    columns = 4 + NUM_CLASSES
+    assert tuple(output.shape) == (2, 3, 3, NUM_QUERIES, columns)
+
+
+def read_weighted_names(model):
+    """Names of the layers that own weights, which is what a load matches."""
+    return {layer.name for layer in model.layers if layer.weights}
+
+
+def test_group_zero_keeps_the_ungrouped_names():
+    grouped = read_weighted_names(build_trainable(2))
+    assert read_weighted_names(build_trainable(1)).issubset(grouped)
+    assert read_weighted_names(build_model()).issubset(grouped)
+    assert "enc_output_group_1" in grouped
+    assert "query_feat_group_1" in grouped
+
+
+def test_detector_matches_the_last_stage():
+    model = build_trainable(2)
+    data = make_input()
+    stages = np.array(model(data))
+    logits, boxes = models.build_detector(model)(data)
+    assert np.allclose(np.array(logits), stages[:, -1, 0, :, 4:], atol=1e-6)
+    assert np.allclose(np.array(boxes), stages[:, -1, 0, :, :4], atol=1e-6)
+
+
+def test_query_groups_predict_different_boxes():
+    """Each group owns its tables, so they must not collapse into one."""
+    boxes = np.array(build_trainable(2)(make_input()))[:, -1, :, :, :4]
+    assert not np.allclose(boxes[:, 0], boxes[:, 1], atol=1e-4)
+
+
+def test_self_attention_stays_inside_a_group():
+    model = build_trainable(2)
+    data = make_input()
+    before = np.array(model(data))[:, -1, 0]
+    table = model.get_layer("query_feat_group_1")
+    table.set_weights([100.0 * weight for weight in table.get_weights()])
+    after = np.array(model(data))[:, -1, 0]
+    assert np.allclose(before, after, atol=1e-4)
+
+
+def copy_weights(source, model):
+    for layer in source.layers:
+        if layer.weights:
+            model.get_layer(layer.name).set_weights(layer.get_weights())
+
+
+def test_grouped_layer_names_stay_unique():
+    """A bare group index would collide with the box head suffixes."""
+    names = [layer.name for layer in build_trainable(3).layers]
+    assert len(names) == len(set(names))
+
+
+def test_added_groups_leave_group_zero_alone():
+    """Grouping folds groups into the batch, which retiles the matmuls, so
+    the same weights come back within float32 noise rather than exactly."""
+    single, grouped = build_trainable(1), build_trainable(3)
+    copy_weights(single, grouped)
+    data = make_input()
+    expected = np.array(single(data))[:, :, 0]
+    assert np.allclose(np.array(grouped(data))[:, :, 0], expected, atol=1e-3)
+
+
+def test_a_trainable_checkpoint_loads_into_a_detector(tmp_path):
+    """Keras keys a weights file by layer class and position, not by name,
+    so both graphs have to keep their weighted layers in the same order."""
+    trainable = build_trainable(1)
+    path = os.path.join(str(tmp_path), "trainable.weights.h5")
+    trainable.save_weights(path)
+    data = make_input()
+    expected = np.array(trainable(data))[:, -1, 0]
+    model = build_model()
+    model.load_weights(path)
+    logits, boxes = model(data)
+    assert np.allclose(np.array(logits), expected[..., 4:], atol=1e-6)
+    assert np.allclose(np.array(boxes), expected[..., :4], atol=1e-6)

--- a/paz/optimization/optimizers_test.py
+++ b/paz/optimization/optimizers_test.py
@@ -1,4 +1,6 @@
 import jax.numpy as jp
+import keras
+
 import paz
 
 
@@ -36,3 +38,29 @@ def test_LBFGS_runs_callbacks():
         callbacks=[callback],
     )
     assert calls[-1] == history.stop_step
+
+
+def apply_one_step(optimizer, name="w"):
+    """Change one gradient step makes, so scaled rates can be compared."""
+    variable = keras.Variable(jp.ones(3), name=name)
+    optimizer.apply_gradients([(jp.ones(3), variable)])
+    return 1.0 - jp.asarray(variable)
+
+
+def test_LayerwiseAdamW_scales_the_step_of_a_named_variable():
+    plain = keras.optimizers.AdamW(0.1, weight_decay=0.0)
+    scaled = paz.optimizers.LayerwiseAdamW({"w": 0.5}, 0.1, weight_decay=0.0)
+    assert jp.allclose(apply_one_step(scaled), 0.5 * apply_one_step(plain))
+
+
+def test_LayerwiseAdamW_freezes_a_zero_scale():
+    kwargs = dict(weight_decay=0.0)
+    optimizer = paz.optimizers.LayerwiseAdamW({"w": 0.0}, 0.1, **kwargs)
+    assert jp.allclose(apply_one_step(optimizer), 0.0)
+
+
+def test_LayerwiseAdamW_leaves_unlisted_variables_alone():
+    plain = keras.optimizers.AdamW(0.1, weight_decay=0.0)
+    scaled = paz.optimizers.LayerwiseAdamW({"w": 0.5}, 0.1, weight_decay=0.0)
+    step = apply_one_step(scaled, "other")
+    assert jp.allclose(step, apply_one_step(plain, "other"))

--- a/paz/optimizers.py
+++ b/paz/optimizers.py
@@ -1,3 +1,4 @@
+import keras
 import optax
 
 from paz.optimization.linesearch import LineSearch
@@ -14,3 +15,26 @@ def LBFGS(parameters, loss_fn, learning_rate, max_steps, tolerance, memory_size,
     _, parameters, history = minimize(*args)
     history = trim_trace(history)
     return parameters, history
+
+
+class LayerwiseAdamW(keras.optimizers.AdamW):
+    """AdamW with a per-variable learning-rate scale.
+
+    Fine-tuning wants a smaller rate deep inside a pretrained backbone than
+    on a fresh head, and Keras keeps a single rate per optimizer. Scales are
+    keyed by ``variable.path`` and default to one. Weight decay stays global:
+    only the learning rate is scaled.
+    """
+
+    def __init__(self, scales, learning_rate, **kwargs):
+        super().__init__(learning_rate=learning_rate, **kwargs)
+        self.scales = dict(scales)
+
+    def update_step(self, gradient, variable, learning_rate):
+        scale = self.scales.get(variable.path, 1.0)
+        super().update_step(gradient, variable, scale * learning_rate)
+
+    def get_config(self):
+        config = super().get_config()
+        config["scales"] = self.scales
+        return config


### PR DESCRIPTION
Fills in what #428 left out of the reference training recipe, plus the
tooling around it.

**Model and loss.** Every decoder layer and the first stage are supervised:
the decoder returns one `(logits, boxes)` pair per stage and
`paz.losses.detr` sums them, weighting each like the final one. Group-DETR
builds `num_groups` query tables and first-stage heads and keeps
self-attention inside a group. `y_pred` is now
`(batch, stages, groups, queries, 4 + classes)`, so `join_outputs` is gone
and `TrainableRFDETR*` replaces it; `build_detector` reads a trainable
model's last stage as `(logits, boxes)` off the same weights.

**Training.** `fine_tune.py` gets a cosine schedule with a warmup,
per-variable rates (`paz.optimizers.LayerwiseAdamW`, ViT layer decay 0.8 and
component decay 0.7), global clipping, gradient accumulation, an EMA, early
stopping, and LoRA through `Dense.enable_lora`. Augmentation is
`paz.detection.augment_detection` instead of a bare flip; the docstring
claiming paz's helpers do not compose with this pipeline was wrong. Upstream
also trains multi-scale, which a fixed input shape rules out here.

**Evaluation.** `paz.evaluation.compute_COCO_mAP` averages AP over IOU 0.50
to 0.95 on one pass of the detector, `paz.callbacks.PlotMetrics` draws the
history, and `evaluate.py`, `benchmark.py` and `embed_backbone.py` cover mAP
with drawn comparisons, per-variant timings and backbone feature taps.

Two bugs worth calling out. `RFDETR` jitted `model(x)`, which freezes the
weights at trace time, so a detector wrapping a training model never moved;
`predict_on_batch` tracks updates and costs 0.3 ms of 5.6 ms. And Keras keys
a weights file by layer class and position rather than by name, so a grouped
model cannot load the published file directly - the weights load into a
single-group model and are copied across by name.

Left out: segmentation heads (need the Roboflow checkpoints and a rebuilt
reference oracle), XL/2XL, DoRA (no Keras equivalent), and the drop
scheduler, since paz's DINOv2 has no stochastic depth and Keras bakes
dropout rates into the compiled train step.

**Verification** (GPU, RTX A4000). `rf_detr`, `paz/losses`, `paz/callbacks`,
`evaluation_test`, `detection_test`, `dinov2` and `paz/transformers`: 235
passed, 18 skipped. `paz/optimization`'s 16 failures are pre-existing
(`optax.tree_utils.tree_norm` is gone). Nano and base reproduce their logits
and boxes bit for bit from the published weights, and the COCO app still
finds the two cats and two remotes. A 900 step VOC2007 fine-tune of nano
(batch 4, 270 ms/step) reaches 0.862 mAP@0.5, 0.756 mAP@0.75 and 0.680
mAP@[.5:.95] on the first 1000 test images.